### PR TITLE
chore(deps): Update rollup to v2.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,20 @@
   "bugs": {
     "url": "https://github.com/engine262/engine262/issues"
   },
-  "main": "dist/engine262",
+  "main": "dist/engine262.js",
+  "module": "dist/engine262.mjs",
+  "type": "commonjs",
+  "exports": {
+    ".": [
+      {
+        "require": "./dist/engine262.js",
+        "import": "./dist/engine262.mjs",
+        "default": "./dist/engine262.js"
+      },
+      "./dist/engine262.js"
+    ],
+    "./": "./"
+  },
   "scripts": {
     "build:engine": "rollup -c",
     "lint": "eslint rollup.config.js test/ src/ bin/ inspector/ scripts/ --cache --ext=js,mjs",
@@ -31,10 +44,12 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/@engine262"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.8.7",
     "@babel/plugin-syntax-bigint": "^7.8.3",
+    "@rollup/plugin-babel": "^5.1.0",
+    "@rollup/plugin-commonjs": "^14.0.0",
+    "@rollup/plugin-node-resolve": "^8.4.0",
     "@snek/source-map-support": "^1.0.4",
     "acorn": "^7.1.1",
     "babel-eslint": "^10.1.0",
@@ -44,10 +59,7 @@
     "glob": "^7.1.6",
     "minimatch": "^3.0.4",
     "nyc": "^15.0.0",
-    "rollup": "^1.32.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup": "^2.23.0",
     "test262-stream": "^1.3.0",
     "unicode-13.0.0": "^0.8.0",
     "ws": "^7.2.3"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,14 +2,22 @@
 
 const fs = require('fs');
 const { execSync } = require('child_process');
-const babel = require('rollup-plugin-babel');
-const commonjs = require('rollup-plugin-commonjs');
-const nodeResolve = require('rollup-plugin-node-resolve');
-const { name, version } = require('./package.json');
+const { default: babel } = require('@rollup/plugin-babel');
+const commonjs = require('@rollup/plugin-commonjs');
+const { default: nodeResolve } = require('@rollup/plugin-node-resolve');
+
+// import of JSON files is disallowed in native ES Modules:
+const {
+  name,
+  version,
+  main: outCommonJS,
+  module: outESModule,
+} = JSON.parse(fs.readFileSync('./package.json', { encoding: 'utf8' }));
 
 const hash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
 
-const banner = `/*
+const banner = `\
+/*!
  * engine262 ${version} ${hash}
  *
  * ${fs.readFileSync('./LICENSE', 'utf8').trim().split('\n').join('\n * ')}
@@ -22,6 +30,7 @@ module.exports = () => ({
     commonjs(),
     nodeResolve(),
     babel({
+      babelHelpers: 'bundled',
       exclude: 'node_modules/**',
       plugins: [
         '@babel/plugin-syntax-bigint',
@@ -31,14 +40,14 @@ module.exports = () => ({
   ],
   output: [
     {
-      file: 'dist/engine262.js',
+      file: outCommonJS,
       format: 'umd',
       sourcemap: true,
       name,
       banner,
     },
     {
-      file: 'dist/engine262.mjs',
+      file: outESModule,
       format: 'es',
       sourcemap: true,
       banner,

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }


### PR DESCRIPTION
This updates **Rollup** to v2.

---

I’ve also added the `module`, <code>[type][package-json-type]: "commonjs"</code> and <code>[exports][package-json-exports]</code> fields to `package.json`, so that **ESM** consumers will use the **ESM** bundle, rather than the **UMD** one.

The `type: "commonjs"` field tells Node that `.js` files in this package are to always be treated as **CommonJS** modules, instead of needing [the special `.cjs` extension][node-esm-enabling].

---

I’ve also added `src/package.json` with <code>{ [type][package-json-type]: "module" }</code>, which will make it possible to switch to using the `.js` file extension in the `src` directory, [while keeping the **ES Module** syntax][node-esm-enabling].

[node-esm-enabling]: https://nodejs.org/api/esm.html#esm_enabling
[package-json-type]: https://nodejs.org/api/esm.html#esm_package_json_type_field
[package-json-exports]: https://nodejs.org/api/esm.html#esm_package_entry_points