### PR TITLE
Rewrite `inspect(…)` function to return values closer to Node.js

### DIFF
--- a/bin/engine262.js
+++ b/bin/engine262.js
@@ -182,6 +182,13 @@ if (entry) {
   process.stdout.write(`${packageJson.name} v${packageJson.version}
 Please report bugs to ${packageJson.bugs.url}
 `);
+
+  // TODO: Make it possible to customise this:
+  const replOptions = {
+    colors: true,
+    showProxy: true,
+  };
+
   repl.start({
     prompt: '> ',
     eval: (cmd, context, filename, callback) => {
@@ -196,9 +203,9 @@ Please report bugs to ${packageJson.bugs.url}
     completer: () => [],
     writer: (o) => realm.scope(() => {
       if (o instanceof Value || o instanceof Completion) {
-        return inspect(o);
+        return inspect(o, replOptions);
       }
-      return util.inspect(o);
+      return util.inspect(o, replOptions);
     }),
   });
 }

--- a/src/inspect.mjs
+++ b/src/inspect.mjs
@@ -1,95 +1,489 @@
 import { surroundingAgent } from './engine.mjs';
 import { Type, Value, wellKnownSymbols } from './value.mjs';
 import {
-  Call, IsArray, Get, LengthOfArrayLike,
+  Assert,
+  Call,
   EscapeRegExpPattern,
+  Get,
+  HasOwnProperty,
+  IsAccessorDescriptor,
+  IsArray,
+  IsCallable,
+  IsDataDescriptor,
+  LengthOfArrayLike,
+  isArrayIndex,
+  isECMAScriptFunctionObject,
 } from './abstract-ops/all.mjs';
 import { Q, X } from './completion.mjs';
+import { OutOfRange } from './helpers.mjs';
 
 const bareKeyRe = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
 
-const getObjectTag = (value, wrap) => {
-  let s;
-  try {
-    s = X(Get(value, wellKnownSymbols.toStringTag)).stringValue();
-  } catch {}
-  try {
-    const c = X(Get(value, new Value('constructor')));
-    s = X(Get(c, new Value('name'))).stringValue();
-  } catch {}
-  if (s) {
-    if (wrap) {
-      return `[${s}] `;
+const defaultOptions = {
+  colors: false,
+  showHidden: false,
+  showProxy: false,
+};
+Object.setPrototypeOf(defaultOptions, null);
+Object.seal(defaultOptions);
+
+const styles = {
+  bigint: 'yellow',
+  boolean: 'yellow',
+  date: 'magenta',
+  hidden: 'blackBright',
+  internalSlot: 'blackBright',
+  module: 'underline',
+  name: undefined,
+  null: 'bold',
+  number: 'yellow',
+  regexp: 'red',
+  special: 'cyan',
+  string: 'green',
+  symbol: 'green',
+  undefined: 'blackBright',
+};
+Object.setPrototypeOf(styles, null);
+
+const resetFG = 39;
+const resetBG = 49;
+
+const colors = {
+  reset: [0, 0],
+  bold: [1, 22],
+  dim: [2, 22],
+  italic: [3, 23],
+  underline: [4, 24],
+
+  black: [30, resetFG],
+  red: [31, resetFG],
+  green: [32, resetFG],
+  yellow: [33, resetFG],
+  blue: [34, resetFG],
+  magenta: [35, resetFG],
+  cyan: [36, resetFG],
+  white: [37, resetFG],
+
+  blackBright: [90, resetFG],
+  redBright: [91, resetFG],
+  greenBright: [92, resetFG],
+  yellowBright: [93, resetFG],
+  blueBright: [94, resetFG],
+  magentaBright: [95, resetFG],
+  cyanBright: [96, resetFG],
+  whiteBright: [97, resetFG],
+
+  bgBlack: [40, resetBG],
+  bgRed: [41, resetBG],
+  bgGreen: [42, resetBG],
+  bgYellow: [43, resetBG],
+  bgBlue: [44, resetBG],
+  bgMagenta: [45, resetBG],
+  bgCyan: [46, resetBG],
+  bgWhite: [47, resetBG],
+
+  bgBlackBright: [100, resetBG],
+  bgRedBright: [101, resetBG],
+  bgGreenBright: [102, resetBG],
+  bgYellowBright: [103, resetBG],
+  bgBlueBright: [104, resetBG],
+  bgMagentaBright: [105, resetBG],
+  bgCyanBright: [106, resetBG],
+  bgWhiteBright: [107, resetBG],
+};
+Object.setPrototypeOf(colors, null);
+
+const stylizeWithColor = (text, styleName) => {
+  const style = styles[styleName];
+  if (style !== undefined) {
+    const color = colors[style];
+    if (color !== undefined) {
+      return `\x1b[${color[0]}m${text}\x1b[${color[1]}m`;
     }
-    return s;
   }
-  return '';
+  return text;
 };
 
-const compactObject = (realm, value) => {
+const stylizeNoColor = (text) => text;
+
+const getFunctionType = (func) => {
+  Assert(IsCallable(func) === Value.true);
+
+  if (!isECMAScriptFunctionObject(func)) {
+    return 'Function';
+  }
+
+  switch (func.ECMAScriptCode.type) {
+    case 'AsyncFunctionBody':
+    case 'AsyncConciseBody':
+      return 'AsyncFunction';
+    case 'AsyncGeneratorBody':
+      return 'AsyncGeneratorFunction';
+    case 'GeneratorBody':
+      return 'GeneratorFunction';
+    default:
+      return 'Function';
+  }
+};
+
+const getDefaultConstructorName = (v) => {
+  Assert(Type(v) === 'Object');
+
+  if ('Call' in v) {
+    return getFunctionType(v);
+  }
+
+  if ('TypedArrayName' in v) {
+    return v.TypedArrayName.stringValue();
+  }
+
+  if (IsArray(v)) {
+    return 'Array';
+  }
+
+  if ('PromiseState' in v) {
+    return 'Promise';
+  }
+
+  if ('ErrorData' in v) {
+    return 'Error';
+  }
+
+  if ('RegExpMatcher' in v) {
+    return 'RegExp';
+  }
+
+  if ('BooleanData' in v) {
+    return 'Boolean';
+  }
+
+  if ('NumberData' in v) {
+    return 'Number';
+  }
+
+  if ('BigIntData' in v) {
+    return 'BigInt';
+  }
+
+  if ('StringData' in v) {
+    return 'String';
+  }
+
+  if ('SymbolData' in v) {
+    return 'Symbol';
+  }
+
+  return 'Object';
+};
+
+const getConstructorName = (value) => {
+  let firstProto;
+  let obj = value;
+  while (Type(obj) === 'Object') {
+    const desc = obj.GetOwnProperty(new Value('constructor'));
+    if (IsDataDescriptor(desc) && IsCallable(desc.Value) === Value.true) {
+      try {
+        return X(Get(desc.Value, new Value('name'))).stringValue();
+      } catch {}
+    }
+
+    obj = obj.GetPrototypeOf();
+    if (!firstProto) {
+      firstProto = obj;
+    }
+  }
+
+  if (firstProto === Value.null) {
+    return null;
+  }
+
+  const fallback = getDefaultConstructorName(value);
+
+  return `${fallback} <Complex prototype>`;
+};
+
+const getPrefix = (constructor, tag, fallback, size = '') => {
+  let prefix;
+  if (constructor === null) {
+    prefix = `[${fallback}${size}: null prototype] `;
+  } else {
+    prefix = `${constructor}${size} `;
+  }
+
+  if (tag !== '' && tag !== constructor) {
+    prefix += `[${tag}] `;
+  }
+
+  return prefix;
+};
+
+const getFunctionBase = (value, constructor, tag) => {
+  Assert(IsCallable(value) === Value.true);
+
+  if (value.IsClassConstructor === Value.true) {
+    let name;
+    try {
+      name = X(value.GetOwnProperty(new Value('name'))) !== Value.undefined
+        && X(Get(value, new Value('name'))).stringValue();
+    } catch {}
+
+    let base = `class ${name || '(anonymous)'}`;
+    if (constructor !== 'Function' && constructor !== null) {
+      base += ` [${constructor}]`;
+    }
+    if (tag !== '' && tag !== constructor) {
+      base += ` [${tag}]`;
+    }
+
+    if (constructor === null) {
+      base += ' extends [null prototype]';
+    } else {
+      let superObj;
+      try {
+        superObj = X(value.GetPrototypeOf());
+      } catch {}
+      if (superObj.nativeFunction !== surroundingAgent.intrinsic('%Function.prototype%').nativeFunction) {
+        let superName;
+        try {
+          superObj = X(value.GetPrototypeOf());
+          superName = X(Get(superObj, new Value('name'))).stringValue();
+        } catch {}
+        base += ` extends ${superName || '(anonymous)'}`;
+      }
+    }
+
+    return `[${base}]`;
+  }
+
+  const type = getFunctionType(value);
+  let base = `[${type}`;
+  if (constructor === null) {
+    base += ' (null prototype)';
+  }
+
+  try {
+    const name = X(Get(value, new Value('name'))).stringValue();
+    if (name) {
+      base += `: ${name}`;
+    } else {
+      base += ' (anonymous)';
+    }
+  } catch {
+    base += ': <unknown>';
+  }
+  base += ']';
+
+  if (constructor !== type && constructor !== null) {
+    base += ` ${constructor}`;
+  }
+
+  if (tag !== '' && tag !== constructor) {
+    base += ` [${tag}]`;
+  }
+
+  return base;
+};
+
+// Based on `EnumerableOwnPropertyNames`, but returns Symbol properties as well:
+const getKeys = (O, includeNonEnumerable = false) => {
+  Assert(Type(O) === 'Object');
+
+  const ownKeys = X(O.OwnPropertyKeys());
+  if (includeNonEnumerable) {
+    return ownKeys;
+  }
+
+  const properties = [];
+  for (const key of ownKeys) {
+    const desc = Q(O.GetOwnProperty(key));
+    if (desc !== Value.undefined && desc.Enumerable === Value.true) {
+      properties.push(key);
+    }
+  }
+
+  return properties;
+};
+
+const getBoxedBase = (type, value, ctx, innerInspect, constructor, tag) => {
+  let base = `[${type}`;
+  if (type !== constructor) {
+    if (constructor !== null) {
+      base += ` (${constructor})`;
+    } else {
+      base += ' (null prototype)';
+    }
+  }
+
+  const os = ctx.stylize;
+  ctx.stylize = stylizeNoColor;
+  base += `: ${innerInspect(value)}]`;
+  ctx.stylize = os;
+
+  if (tag !== '' && tag !== constructor) {
+    base += ` [${tag}]`;
+  }
+
+  return ctx.stylize(base, type.toLowerCase());
+};
+
+const formatPropertyDescriptor = (desc, ctx, i) => {
+  Assert(Type(desc) === 'Descriptor');
+  if (IsDataDescriptor(desc)) {
+    return i(desc.Value);
+  } else {
+    Assert(IsAccessorDescriptor(desc));
+    let label;
+    if (desc.Get !== Value.undefined) {
+      label = desc.Set === Value.undefined ? 'Getter' : 'Getter/Setter';
+    } else {
+      label = 'Setter';
+    }
+    return (ctx.stylize(`[${label}]`, 'special'));
+  }
+};
+
+/* eslint-disable no-control-regex */
+const strEscapeSequencesReplacer = /[\x00-\x1f\x27\x5c\x7f-\x9f]/g;
+const strEscapeSequencesReplacerIgnoreQuotes = /[\x00-\x1f\x5c\x7f-\x9f]/g;
+/* eslint-enable no-control-regex */
+
+// Escaped control characters (plus the single quote and the backslash):
+const strEscapeArray = [
+  /* x00 - x07: */ '\\x00', '\\x01', '\\x02', '\\x03', '\\x04', '\\x05', '\\x06', '\\x07',
+  /* x08 - x0F: */ '\\b', '\\t', '\\n', '\\x0B', '\\f', '\\r', '\\x0E', '\\x0F',
+  /* x10 - x17: */ '\\x10', '\\x11', '\\x12', '\\x13', '\\x14', '\\x15', '\\x16', '\\x17',
+  /* x18 - x1F: */ '\\x18', '\\x19', '\\x1A', '\\x1B', '\\x1C', '\\x1D', '\\x1E', '\\x1F',
+  /* x20 - x2F: */ '', '', '', '', '', '', '', "\\'", '', '', '', '', '', '', '', '',
+  /* x30 - x3F: */ '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
+  /* x40 - x4F: */ '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
+  /* x50 - x5F: */ '', '', '', '', '', '', '', '', '', '', '', '', '\\\\', '', '', '',
+  /* x60 - x6F: */ '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
+  /* x70 - x7F: */ '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '\\x7F',
+  /* x80 - x87: */ '\\x80', '\\x81', '\\x82', '\\x83', '\\x84', '\\x85', '\\x86', '\\x87',
+  /* x88 - x8F: */ '\\x88', '\\x89', '\\x8A', '\\x8B', '\\x8C', '\\x8D', '\\x8E', '\\x8F',
+  /* x90 - x97: */ '\\x90', '\\x91', '\\x92', '\\x93', '\\x94', '\\x95', '\\x96', '\\x97',
+  /* x98 - x9F: */ '\\x98', '\\x99', '\\x9A', '\\x9B', '\\x9C', '\\x9D', '\\x9E', '\\x9F',
+];
+
+const escapeFn = (str) => strEscapeArray[str.charCodeAt(0)];
+
+// Roughly based on the JSON stringify escaping.
+const strEscape = (str) => {
+  let replacer = strEscapeSequencesReplacer;
+  let quote = 0x27;
+
+  if (str.includes("'")) {
+    if (!str.includes('"')) {
+      // If the string contains single quotes and not double quotes,
+      // then we wrap it in double quotes:
+      quote = -1;
+    } else if (!str.includes('`') && !str.includes('${')) {
+      // Otherwise, try to see if we can safely wrap it as a template literal
+      quote = -2;
+    }
+
+    if (quote !== 0x27) {
+      replacer = strEscapeSequencesReplacerIgnoreQuotes;
+    }
+  }
+
+  str = str.replace(replacer, escapeFn);
+  switch (quote) {
+    case -1:
+      return `"${str}"`;
+
+    case -2:
+      return `\`${str}\``;
+
+    case 0x27:
+      return `'${str}'`;
+
+    default:
+      throw new OutOfRange(`strEscape: Invalid quote code point: ${quote}`, quote);
+  }
+};
+
+const compactObject = (value, constructor, tag) => {
   try {
     const toString = X(Get(value, new Value('toString')));
-    const objectToString = realm.Intrinsics['%Object.prototype.toString%'];
+    const objectToString = surroundingAgent.intrinsic('%Object.prototype.toString%');
     if (toString.nativeFunction === objectToString.nativeFunction) {
       return X(Call(toString, value)).stringValue();
     } else {
-      const tag = getObjectTag(value, false) || 'Unknown';
-      const ctor = X(Get(value, new Value('constructor')));
-      if (Type(ctor) === 'Object') {
-        const ctorName = X(Get(ctor, new Value('name'))).stringValue();
-        if (ctorName !== '') {
-          return `#<${ctorName}>`;
-        }
-        return `[object ${tag}]`;
-      }
-      return `[object ${tag}]`;
+      return `[object ${tag || constructor || 'Unknown'}]`;
     }
-  } catch (e) {
+  } catch {
     return '[object Unknown]';
   }
 };
 
 const INSPECTORS = {
   Completion: (v, ctx, i) => i(v.Value),
-  Null: () => 'null',
-  Undefined: () => 'undefined',
-  Boolean: (v) => v.boolean.toString(),
-  Number: (v) => {
+  Null: (v, ctx) => ctx.stylize('null', 'null'),
+  Undefined: (v, ctx) => ctx.stylize('undefined', 'undefined'),
+  Boolean: (v, ctx) => ctx.stylize(v.booleanValue().toString(), 'boolean'),
+  Number: (v, ctx) => {
     const n = v.numberValue();
     if (n === 0 && Object.is(n, -0)) {
-      return '-0';
+      return ctx.stylize('-0', 'number');
     }
-    return n.toString();
+    return ctx.stylize(n.toString(), 'number');
   },
-  BigInt: (v) => `${v.bigintValue()}n`,
-  String: (v) => {
-    const s = JSON.stringify(v.stringValue()).slice(1, -1);
-    return `'${s}'`;
-  },
-  Symbol: (v) => `Symbol(${v.Description === Value.undefined ? '' : v.Description.stringValue()})`,
+  BigInt: (v, ctx) => ctx.stylize(`${v.bigintValue()}n`, 'bigint'),
+  String: (v, ctx) => ctx.stylize(strEscape(v.stringValue()), 'string'),
+  Symbol: (v, ctx) => ctx.stylize(
+    `Symbol(${v.Description === Value.undefined ? '' : v.Description.stringValue()})`,
+    'symbol',
+  ),
   Object: (v, ctx, i) => {
     if (ctx.inspected.includes(v)) {
-      return '[Circular]';
-    }
-    if ('PromiseState' in v) {
-      ctx.indent += 1;
-      const result = v.PromiseState === 'pending' ? 'undefined' : i(v.PromiseResult);
-      ctx.indent -= 1;
-      return `Promise {
-  [[PromiseState]]: ${v.PromiseState}
-  [[PromiseResult]]: ${result}
-}`;
+      return ctx.stylize('[Circular]', 'special');
     }
 
-    if ('Call' in v) {
-      const name = v.properties.get(new Value('name'));
-      if (name !== undefined && name.Value.stringValue() !== '') {
-        return `[Function: ${name.Value.stringValue()}]`;
+    if (ctx.showProxy && 'ProxyTarget' in v) {
+      if (v.ProxyTarget === Value.null) {
+        return 'Proxy { <revoked> }';
+      } else {
+        return `Proxy {
+  ${ctx.stylize('[[ProxyTarget]]', 'internalSlot')}: ${i(v.ProxyTarget)}
+  ${ctx.stylize('[[ProxyHandler]]', 'internalSlot')}: ${i(v.ProxyHandler)}
+}`;
       }
-      return '[Function]';
     }
+
+    const constructor = getConstructorName(v);
+    let tag = '';
+    try {
+      tag = X(Get(v, wellKnownSymbols.toStringTag)).stringValue();
+    } catch {}
+    if (tag) {
+      // Only print the %Symbol.toStringTag% value in the header
+      // if it's not an own property or is non-enumerable,
+      // otherwise we'd print it twice.
+      try {
+        if (ctx.showHidden) {
+          if (X(HasOwnProperty(v, wellKnownSymbols.toStringTag)) === Value.true) {
+            tag = '';
+          }
+        } else {
+          const desc = X(v.GetOwnProperty(wellKnownSymbols.toStringTag));
+          if (desc !== Value.undefined && desc.Enumerable === Value.true) {
+            tag = '';
+          }
+        }
+      } catch {
+        tag = '';
+      }
+    }
+
+    let base = '';
+    let braces = ['{', '}'];
+    let keys = getKeys(v, ctx.showHidden);
+
+    const slots = [];
 
     if ('ErrorData' in v) {
+      // TODO: Get this from the [[ErrorData]] internal slot:
       let e = Q(Get(v, new Value('stack')));
       if (!e.stringValue) {
         const toString = Q(Get(v, new Value('toString')));
@@ -98,34 +492,89 @@ const INSPECTORS = {
       return e.stringValue();
     }
 
-    if ('RegExpMatcher' in v) {
+    if ('Call' in v) {
+      base = ctx.stylize(getFunctionBase(v, constructor, tag), 'special');
+      if (keys.length === 0) {
+        return base;
+      }
+    } else if ('PromiseState' in v) {
+      ctx.indent += 1;
+      const result = v.PromiseState === 'pending'
+        ? ctx.stylize('undefined', 'undefined')
+        : i(v.PromiseResult);
+      ctx.indent -= 1;
+      base = getPrefix(constructor, tag, 'Promise');
+
+      if (keys.length === 0) {
+        return `${base}{
+  ${ctx.stylize('[[PromiseState]]', 'internalSlot')}: ${ctx.stylize(v.PromiseState, 'special')}
+  ${ctx.stylize('[[PromiseResult]]', 'internalSlot')}: ${result}
+}`;
+      }
+
+      slots.push(
+        ['[[PromiseState]]', ctx.stylize(v.PromiseState, 'special')],
+        ['[[PromiseResult]]', result],
+      );
+    } else if ('RegExpMatcher' in v) {
       const P = EscapeRegExpPattern(v.OriginalSource, v.OriginalFlags).stringValue();
       const F = v.OriginalFlags.stringValue();
-      return `/${P}/${F}`;
-    }
+      base = `/${P}/${F}`;
 
-    if ('DateValue' in v) {
-      const d = new Date(v.DateValue.numberValue());
-      if (Number.isNaN(d.getTime())) {
-        return '[Date Invalid]';
+      const prefix = getPrefix(constructor, tag, 'RegExp');
+      if (prefix !== 'RegExp ') {
+        base = `${prefix}${base}`;
       }
-      return `[Date ${d.toISOString()}]`;
-    }
 
-    if ('BooleanData' in v) {
-      return `[Boolean ${i(v.BooleanData)}]`;
-    }
-    if ('NumberData' in v) {
-      return `[Number ${i(v.NumberData)}]`;
-    }
-    if ('BigIntData' in v) {
-      return `[BigInt ${i(v.BigIntData)}]`;
-    }
-    if ('StringData' in v) {
-      return `[String ${i(v.StringData)}]`;
-    }
-    if ('SymbolData' in v) {
-      return `[Symbol ${i(v.SymbolData)}]`;
+      base = ctx.stylize(base, 'regexp');
+
+      if (keys.length === 0) {
+        return base;
+      }
+    } else if ('DateValue' in v) {
+      const d = new Date(v.DateValue.numberValue());
+      const str = Number.isNaN(d.getTime()) ? 'Invalid' : d.toISOString();
+      const prefix = getPrefix(constructor, tag, 'Date');
+      base = ctx.stylize(`[${prefix.slice(0, -1)}: ${str}]`, 'date');
+
+      if (keys.length === 0) {
+        return base;
+      }
+    } else if ('BooleanData' in v) {
+      base = getBoxedBase('Boolean', v.BooleanData, ctx, i, constructor, tag);
+      if (keys.length === 0) {
+        return base;
+      }
+    } else if ('NumberData' in v) {
+      base = getBoxedBase('Number', v.NumberData, ctx, i, constructor, tag);
+      if (keys.length === 0) {
+        return base;
+      }
+    } else if ('BigIntData' in v) {
+      base = getBoxedBase('BigInt', v.BigIntData, ctx, i, constructor, tag);
+      if (keys.length === 0) {
+        return base;
+      }
+    } else if ('StringData' in v) {
+      base = getBoxedBase('String', v.StringData, ctx, i, constructor, tag);
+      if (keys.length === 0) {
+        return base;
+      }
+    } else if ('SymbolData' in v) {
+      base = getBoxedBase('Symbol', v.SymbolData, ctx, i, constructor, tag);
+      if (keys.length === 0) {
+        return base;
+      }
+    } else if (constructor === 'Object') {
+      if ('ParameterMap' in v) {
+        braces[0] = '[Arguments] {';
+      } else if (tag !== '') {
+        braces[0] = `${getPrefix(constructor, tag, 'Object')}{`;
+      }
+
+      if (keys.length === 0) {
+        return `${braces[0]}}`;
+      }
     }
 
     ctx.indent += 1;
@@ -134,59 +583,92 @@ const INSPECTORS = {
     try {
       const isArray = IsArray(v) === Value.true;
       const isTypedArray = 'TypedArrayName' in v;
+
+      const outArray = [];
       if (isArray || isTypedArray) {
         const length = X(LengthOfArrayLike(v)).numberValue();
+
+        let prefix;
+        if (isArray) {
+          prefix = (constructor !== 'Array' || tag !== '')
+            ? getPrefix(constructor, tag, 'Array', `(${length})`)
+            : '';
+        } else {
+          Assert(isTypedArray === true);
+          prefix = getPrefix(
+            constructor,
+            tag,
+            v.TypedArrayName.stringValue(),
+            `(${length})`,
+          );
+        }
+
+        braces = [`${prefix}[`, ']'];
+        keys = keys.filter((k) => !isArrayIndex(k));
+
         let holes = 0;
-        const out = [];
+        // FIXME: This is very slow for big arrays with holes
         for (let j = 0; j < length; j += 1) {
           const elem = X(v.GetOwnProperty(new Value(j.toString())));
           if (elem === Value.undefined) {
+            Assert(isTypedArray === false);
             holes += 1;
           } else {
             if (holes > 0) {
-              out.push(`<${holes} empty items>`);
+              outArray.push(`<${holes} empty items>`);
               holes = 0;
             }
-            if (elem.Value) {
-              out.push(i(elem.Value));
-            } else {
-              out.push('<accessor>');
-            }
+            outArray.push(formatPropertyDescriptor(elem, ctx, i));
           }
         }
-        return `${isTypedArray ? `${v.TypedArrayName.stringValue()} ` : ''}[${out.join(', ')}]`;
+        if (holes > 0) {
+          outArray.push(`<${holes} empty items>`);
+          holes = 0;
+        }
       }
 
-      const keys = X(v.OwnPropertyKeys());
       const cache = [];
       for (const key of keys) {
         const C = X(v.GetOwnProperty(key));
-        if (C.Enumerable === Value.true) {
-          cache.push([
-            Type(key) === 'String' && bareKeyRe.test(key.stringValue()) ? key.stringValue() : i(key),
-            C.Value ? i(C.Value) : '<accessor>',
-          ]);
-        }
+        const k = Type(key) === 'String' && bareKeyRe.test(key.stringValue())
+          ? ctx.stylize(key.stringValue(), 'name')
+          : i(key);
+        cache.push([
+          C.Enumerable === Value.true
+            ? k
+            : `${ctx.stylize(`[${k}`, 'hidden')}${ctx.stylize(']', 'hidden')}`,
+          formatPropertyDescriptor(C, ctx, i),
+        ]);
       }
 
-      const tag = getObjectTag(v);
-      let out = tag && tag !== 'Object' ? `${tag} {` : '{';
-      if (cache.length > 5) {
-        cache.forEach((c) => {
-          out = `${out}\n${'  '.repeat(ctx.indent)}${c[0]}: ${c[1]},`;
+      let outStr = `${base ? `${base} ` : ''}${braces[0]}`;
+      if (slots.length > 0 || (cache.length + outArray.length) > 5) {
+        slots.forEach((s) => {
+          outStr += `\n${'  '.repeat(ctx.indent)}${ctx.stylize(s[0], 'internalSlot')}: ${s[1]}`;
         });
-        return `${out}\n${'  '.repeat(ctx.indent - 1)}}`;
+        outArray.forEach((c) => {
+          outStr += `\n${'  '.repeat(ctx.indent)}${c},`;
+        });
+        cache.forEach((c) => {
+          outStr += `\n${'  '.repeat(ctx.indent)}${c[0]}: ${c[1]},`;
+        });
+        outStr += `\n${'  '.repeat(ctx.indent - 1)}${braces[1]}`;
       } else {
         const oc = ctx.compact;
         ctx.compact = true;
+        outArray.forEach((c, index) => {
+          outStr = `${outStr}${(index === 0) ? '' : ','} ${c}`;
+        });
         cache.forEach((c, index) => {
-          out = `${out}${index === 0 ? '' : ','} ${c[0]}: ${c[1]}`;
+          outStr = `${outStr}${(index === 0 && outArray.length === 0) ? '' : ','} ${c[0]}: ${c[1]}`;
         });
         ctx.compact = oc;
-        return `${out} }`;
+        outStr += ` ${braces[1]}`;
       }
+
+      return outStr;
     } catch {
-      return compactObject(ctx, v);
+      return compactObject(v, constructor, tag);
     } finally {
       ctx.indent -= 1;
       ctx.inspected.pop();
@@ -194,11 +676,26 @@ const INSPECTORS = {
   },
 };
 
-export function inspect(value) {
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+const getOption = (options, name, convert) => {
+  Assert(typeof name === 'string' && name in defaultOptions);
+  Assert(typeof convert === 'function');
+
+  if (hasOwn(options, name)) {
+    return convert(options[name]);
+  } else {
+    return defaultOptions[name];
+  }
+};
+
+export function inspect(value, options = {}) {
   const context = {
     realm: surroundingAgent.currentRealmRecord,
     indent: 0,
     inspected: [],
+    stylize: getOption(options, 'colors', Boolean) ? stylizeWithColor : stylizeNoColor,
+    showHidden: getOption(options, 'showHidden', Boolean),
+    showProxy: getOption(options, 'showProxy', Boolean),
   };
   const inner = (v) => INSPECTORS[Type(v)](v, context, inner);
   return inner(value);

--- a/src/inspect.mjs
+++ b/src/inspect.mjs
@@ -20,6 +20,8 @@ import { OutOfRange } from './helpers.mjs';
 const bareKeyRe = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
 
 const styles = {
+  __proto__: null,
+
   bigint: 'blueBright',
   boolean: 'yellow',
   date: 'magenta',
@@ -35,12 +37,13 @@ const styles = {
   symbol: 'green',
   undefined: 'blackBright',
 };
-Object.setPrototypeOf(styles, null);
 
 const resetFG = 39;
 const resetBG = 49;
 
 const colors = {
+  __proto__: null,
+
   reset: [0, 0],
   bold: [1, 22],
   dim: [2, 22],
@@ -83,7 +86,6 @@ const colors = {
   bgCyanBright: [106, resetBG],
   bgWhiteBright: [107, resetBG],
 };
-Object.setPrototypeOf(colors, null);
 
 const stylizeWithColor = (text, styleName) => {
   const style = styles[styleName];

--- a/src/inspect.mjs
+++ b/src/inspect.mjs
@@ -19,14 +19,6 @@ import { OutOfRange } from './helpers.mjs';
 
 const bareKeyRe = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
 
-const defaultOptions = {
-  colors: false,
-  showHidden: false,
-  showProxy: false,
-};
-Object.setPrototypeOf(defaultOptions, null);
-Object.seal(defaultOptions);
-
 const styles = {
   bigint: 'blueBright',
   boolean: 'yellow',
@@ -675,26 +667,14 @@ const INSPECTORS = {
   },
 };
 
-const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
-const getOption = (options, name, convert) => {
-  Assert(typeof name === 'string' && name in defaultOptions);
-  Assert(typeof convert === 'function');
-
-  if (hasOwn(options, name)) {
-    return convert(options[name]);
-  } else {
-    return defaultOptions[name];
-  }
-};
-
 export function inspect(value, options = {}) {
   const context = {
     realm: surroundingAgent.currentRealmRecord,
     indent: 0,
     inspected: [],
-    stylize: getOption(options, 'colors', Boolean) ? stylizeWithColor : stylizeNoColor,
-    showHidden: getOption(options, 'showHidden', Boolean),
-    showProxy: getOption(options, 'showProxy', Boolean),
+    stylize: options.colors ? stylizeWithColor : stylizeNoColor,
+    showHidden: !!options.showHidden,
+    showProxy: !!options.showProxy,
   };
   const inner = (v) => INSPECTORS[Type(v)](v, context, inner);
   return inner(value);

--- a/src/messages.mjs
+++ b/src/messages.mjs
@@ -1,10 +1,13 @@
-import { surroundingAgent } from './engine.mjs';
 import { Value } from './value.mjs';
 import { inspect } from './api.mjs';
 
 function i(V) {
   if (V instanceof Value) {
-    return inspect(V, surroundingAgent.currentRealmRecord, true);
+    return inspect(V, {
+      colors: false,
+      showHidden: false,
+      showProxy: false,
+    });
   }
   return `${V}`;
 }


### PR DESCRIPTION
This originally started with me trying to fix the fact that `inspect(realm.Intrinsics["%Reflect%"])` returned `"{}"` instead of `"Object [Reflect] {}"` and that the **REPL** doesn’t emit coloured output, and in the process of fixing that, I ended up rewriting the entire `inspect(…)` function such that it now supports an `options` argument which is compatible with **Node**’s [`util.inspect(…)`][node-util-inspect-options] options argument and returns output much closer to what **Node** outputs with its `util.inspect(…)` function, including always printing `[%Symbol.toStringTag%]` properties, when they don’t match `v.constructor.name`.

[node-util-inspect-options]: https://nodejs.org/api/util.html#util_util_inspect_object_options

---

I’ve also added the ability to inspect **Proxy** objects, but that is only enabled in the **REPL** output, so as to not reveal **Proxy** objects through error messages.

## Future work:
- Partially implement [the **Error Stacks** proposal](https://tc39.es/proposal-error-stacks/), such that stack frames are stored in the `[[ErrorData]]` internal slot and `inspect(…)` uses that to compute the stack data.
- Add the ability to inspect collections and built‑in **Iterators**.