### PR TITLE
GitHub Actions: Run tests for PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,15 +25,11 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run lint
-      - run: npm run coverage
+
+      # Test coverage is handled by tests.yml
+      - run: npm run test
         env:
           CONTINUOUS_INTEGRATION: 1
-
-      # Upload coverage data
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{github.token}}
 
       # Publish built package
       - run: npm publish --access=public

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Run tests
+
+# Trigger the workflow on push or pull request
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      # Set everything up
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - run: git submodule update --init --recursive
+
+      # Run tests and whatnot
+      - run: npm install
+      - run: npm run build
+      - run: npm run lint
+      - run: npm run coverage
+        env:
+          CONTINUOUS_INTEGRATION: 1
+
+      # Upload coverage data
+      - name: Coveralls
+        if: ${{ success() || failure() }}
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{github.token}}


### PR DESCRIPTION
This makes it so that the tests are also run for PRs.

This workflow also always uploads code coverage, even when the tests failed.