### PR TITLE
Recognize ZWJ and ZWNJ as valid identifier parts

### DIFF
--- a/src/parser/Lexer.mjs
+++ b/src/parser/Lexer.mjs
@@ -779,12 +779,12 @@ export class Lexer {
         }
         this.position += 1;
         const raw = String.fromCodePoint(this.scanCodePoint());
-        if (!buffer.length) {
-          if (!(isIdentifierStart(raw) || raw === '$' || raw === '_')) {
+        if (buffer.length) {
+          if (!(isIdentifierContinue(raw) || raw === '$' || raw === '_' || raw === '\u200C' || raw === '\u200D')) {
             this.unexpected(escapeIndex);
           }
         } else {
-          if (!(isIdentifierContinue(raw) || raw === '$' || raw === '_' || raw === '\u200C' || raw === '\u200D')) {
+          if (!(isIdentifierStart(raw) || raw === '$' || raw === '_')) {
             this.unexpected(escapeIndex);
           }
         }

--- a/src/parser/Lexer.mjs
+++ b/src/parser/Lexer.mjs
@@ -779,8 +779,14 @@ export class Lexer {
         }
         this.position += 1;
         const raw = String.fromCodePoint(this.scanCodePoint());
-        if (!(SingleCharTokens[raw] === Token.IDENTIFIER || isIdentifierContinue(raw))) {
-          this.unexpected(escapeIndex);
+        if (!buffer.length) {
+          if (!(isIdentifierStart(raw) || raw === '$' || raw === '_')) {
+            this.unexpected(escapeIndex);
+          }
+        } else {
+          if (!(isIdentifierContinue(raw) || raw === '$' || raw === '_' || raw === '\u200C' || raw === '\u200D')) {
+            this.unexpected(escapeIndex);
+          }
         }
         buffer += raw;
       } else if (SingleCharTokens[c] === Token.IDENTIFIER || isIdentifierContinue(c)) {


### PR DESCRIPTION
Recognize zero width joiner (U+200D) and zero width non-joiner (U+200C) as valid identifier parts (https://tc39.es/ecma262/#sec-names-and-keywords). I have a pull request to test262 containing relevant tests (https://github.com/tc39/test262/pull/2723).

There were a couple other things that came up that should be fixed now. Previously, when the identifier start was a Unicode escape, it was only being checked that it was a valid identifier part. Also, a Unicode escaped backslash was being allowed in identifiers.