### PR TITLE
CreateBuiltinFunction: Add internal slots in common order

### DIFF
--- a/src/abstract-ops/function-operations.mjs
+++ b/src/abstract-ops/function-operations.mjs
@@ -413,7 +413,7 @@ export function CreateBuiltinFunction(steps, internalSlotsList, realm, prototype
     prototype = realm.Intrinsics['%Function.prototype%'];
   }
   // 5. Let func be a new built-in function object that when called performs the action described by steps. The new function object has internal slots whose names are the elements of internalSlotsList.
-  const func = X(MakeBasicObject(internalSlotsList.concat('InitialName')));
+  const func = X(MakeBasicObject(['Prototype', 'Extensible', 'Realm', 'ScriptOrModule', 'InitialName'].concat(internalSlotsList)));
   func.Call = BuiltinFunctionCall;
   if (isConstructor === Value.true) {
     func.Construct = BuiltinFunctionConstruct;
@@ -425,7 +425,7 @@ export function CreateBuiltinFunction(steps, internalSlotsList, realm, prototype
   func.Prototype = prototype;
   // 8. Set func.[[Extensible]] to true.
   func.Extensible = Value.true;
-  // 9. Set func.[[Extensible]] to true.
+  // 9. Set func.[[ScriptOrModule]] to null.
   func.ScriptOrModule = Value.null;
   // 10. Set func.[[InitialName]] to null.
   func.InitialName = Value.null;


### PR DESCRIPTION
This ensures that the internal slots are added [in an optimizable order](https://mathiasbynens.be/notes/shapes-ics#optimizing-property-access) for all built‑in functions by ensuring that the `Prototype` and `Extensible` slots share the **V8** _Shape_ with ordinary objects.