### PR TITLE
bin: Fix rejected `result` Promise in `oneShotEval`

### DIFF
--- a/bin/engine262.js
+++ b/bin/engine262.js
@@ -31,7 +31,7 @@ const {
 
   Completion,
   AbruptCompletion,
-  Throw,
+  ThrowCompletion,
 } = require('..');
 const { createRealm } = require('./test262_realm');
 
@@ -164,7 +164,7 @@ function oneShotEval(source, filename) {
         }
         if (!(result instanceof AbruptCompletion)) {
           if (result.PromiseState === 'rejected') {
-            result = Throw(result.PromiseResult);
+            result = ThrowCompletion(result.PromiseResult);
           }
         }
       }


### PR DESCRIPTION
The `Throw` function takes at least 2 arguments and constructs a new `Error` object.

---

I caught this by using a custom work‑in‑progress **TypeScript** definition file for **engine262**.