### PR TITLE
helpers: Fix return value of Value collection setter methods

### DIFF
--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -31,7 +31,8 @@ export class ValueMap {
   }
 
   set(key, value) {
-    return this.map.set(convertValueForKey(key), value);
+    this.map.set(convertValueForKey(key), value);
+    return this;
   }
 
   has(key) {
@@ -91,7 +92,8 @@ export class ValueSet {
   }
 
   add(item) {
-    return this.set.add(convertValueForKey(item));
+    this.set.add(convertValueForKey(item));
+    return this;
   }
 
   has(item) {


### PR DESCRIPTION
This fixes a bug that was introduced in <https://github.com/engine262/engine262/commit/427ed405b4ad625719268ae747eb25e95b53cd8d>, which caused the return value of `ValueMap.prototype.set` and `ValueSet.prototype.add` to no longer be the `this` value, but would instead be the backing colection.