### PR TITLE
helpers: Use constant Value object for ‑0 in Value collections

### DIFF
--- a/src/api.mjs
+++ b/src/api.mjs
@@ -24,6 +24,7 @@ import {
 } from './parse.mjs';
 import { SourceTextModuleRecord } from './modules.mjs';
 
+export { ValueMap, ValueSet } from './helpers.mjs';
 export * from './value.mjs';
 export * from './engine.mjs';
 export * from './completion.mjs';

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -3,6 +3,7 @@ import { Type, Value, Descriptor } from './value.mjs';
 import { ToString, DefinePropertyOrThrow, CreateBuiltinFunction } from './abstract-ops/all.mjs';
 import { X, AwaitFulfilledFunctions } from './completion.mjs';
 
+const kNegativeZero = new Value(-0);
 function convertValueForKey(key) {
   if (typeof key === 'string') {
     return Symbol.for(`engine262_helper_key_${key}`);
@@ -12,7 +13,7 @@ function convertValueForKey(key) {
       return key.stringValue();
     case 'Number':
       if (key.numberValue() === 0 && Object.is(key.numberValue(), -0)) {
-        return key;
+        return kNegativeZero;
       }
       return key.numberValue();
     default:

--- a/test/supplemental.js
+++ b/test/supplemental.js
@@ -7,6 +7,8 @@ const {
   setSurroundingAgent,
   ManagedRealm,
   Value,
+  ValueMap,
+  ValueSet,
   FEATURES,
   Get,
   CreateArrayFromList,
@@ -255,6 +257,16 @@ Error: owo
 }
     `);
     assert.strictEqual(result.Value, Value.undefined);
+  },
+  () => {
+    const valueMap = new ValueMap();
+    valueMap.set(new Value(-0), true);
+    assert.strictEqual(valueMap.get(new Value(-0)), true);
+  },
+  () => {
+    const valueSet = new ValueSet();
+    valueSet.add(new Value(-0));
+    assert.strictEqual(valueSet.has(new Value(-0)), true);
   },
 ].forEach((test) => {
   total();


### PR DESCRIPTION
This ensures that:
```js
new ValueSet([
	new Value(-0),
]).has(new Value(-0));
```
returns `true`, instead of `false` as it does now, because:
```js
new Value(-0) === new Value(-0);
```
is `false`.

---

**Refs:** <https://github.com/engine262/engine262/pull/123>