### PR TITLE
CompletePropertyDescriptor: Fix init of `like`

### DIFF
--- a/src/abstract-ops/spec-types.mjs
+++ b/src/abstract-ops/spec-types.mjs
@@ -140,11 +140,11 @@ export function CompletePropertyDescriptor(Desc) {
   Assert(Type(Desc) === 'Descriptor');
   const like = Descriptor({
     Value: Value.undefined,
-    Writable: false,
+    Writable: Value.false,
     Get: Value.undefined,
     Set: Value.undefined,
-    Enumerable: false,
-    Configurable: false,
+    Enumerable: Value.false,
+    Configurable: Value.false,
   });
   if (IsGenericDescriptor(Desc) || IsDataDescriptor(Desc)) {
     if (Desc.Value === undefined) {


### PR DESCRIPTION
This would’ve been caught by **TypeScript**:
```
TS2322: Type 'boolean' is not assignable to type 'BooleanValue'
```