### PR TITLE
Parser: Add missing `BIGINT` token

### DIFF
--- a/src/parser/tokens.mjs
+++ b/src/parser/tokens.mjs
@@ -117,6 +117,7 @@ export const RawTokens = [
   ['FALSE', 'false'],
   ['NUMBER', null],
   ['STRING', null],
+  ['BIGINT', null],
 
   // BEGIN Callable
   ['SUPER', 'super'],
@@ -141,7 +142,7 @@ export const Token = RawTokens
   .reduce((obj, [name], i) => {
     obj[name] = i;
     return obj;
-  }, {});
+  }, Object.create(null));
 
 export const TokenNames = RawTokens.map((r) => r[0]);
 


### PR DESCRIPTION
This didn’t cause any test failures, because it was the only `undefined` token, so it still got a unique value.