### PR TITLE
ESLint: use private scoped package for `eslint‑plugin‑engine262`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,23 +1,9 @@
 'use strict';
 
-const Module = require('module');
-
-const ModuleFindPath = Module._findPath;
-const hacks = [
-  'eslint-plugin-engine262',
-];
-Module._findPath = (request, paths, isMain) => {
-  const r = ModuleFindPath(request, paths, isMain);
-  if (!r && hacks.includes(request)) {
-    return require.resolve(`./test/${request}`);
-  }
-  return r;
-};
-
 module.exports = {
   root: true,
   extends: 'airbnb-base',
-  plugins: ['engine262'],
+  plugins: ['@engine262'],
   parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaVersion: 2020,
@@ -37,12 +23,12 @@ module.exports = {
     SharedArrayBuffer: false,
   },
   rules: {
+    '@engine262/no-use-in-def': 'error',
+    '@engine262/valid-feature': 'error',
+    '@engine262/valid-throw': 'error',
     'arrow-parens': ['error', 'always'],
     'brace-style': ['error', '1tbs', { allowSingleLine: false }],
     'curly': ['error', 'all'],
-    'engine262/no-use-in-def': 'error',
-    'engine262/valid-feature': 'error',
-    'engine262/valid-throw': 'error',
     'import/order': ['error', { 'newlines-between': 'never' }],
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
     'no-multiple-empty-lines': ['error', { maxBOF: 0, max: 2 }],

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/@engine262"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.11.6",
     "@babel/eslint-parser": "^7.11.5",
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",
+    "@engine262/eslint-plugin": "file:./test/eslint-plugin-engine262",
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/test/eslint-plugin-engine262/package.json
+++ b/test/eslint-plugin-engine262/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@engine262/eslint-plugin",
+  "version": "0.0.0",
+  "private": true
+}

--- a/test/eslint-plugin-engine262/valid-throw.js
+++ b/test/eslint-plugin-engine262/valid-throw.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+// eslint-disable-next-line import/no-extraneous-dependencies
 const acorn = require('acorn');
 
 function isThrowCall(node) {


### PR DESCRIPTION
This has the added benefit of not having to monkey‑patch **Node**’s internals.