### PR TITLE
Rename `IsStringValidUnicode` to `IsStringWellFormedUnicode`

### DIFF
--- a/src/parser/StatementParser.mjs
+++ b/src/parser/StatementParser.mjs
@@ -1,4 +1,4 @@
-import { IsStringValidUnicode, StringValue } from '../static-semantics/all.mjs';
+import { IsStringWellFormedUnicode, StringValue } from '../static-semantics/all.mjs';
 import { Token, isAutomaticSemicolon, isKeywordRaw } from './tokens.mjs';
 import { ExpressionParser } from './ExpressionParser.mjs';
 import { FunctionKind } from './FunctionParser.mjs';
@@ -1200,7 +1200,7 @@ export class StatementParser extends ExpressionParser {
   // ModuleExportName : StringLiteral
   parseModuleExportName() {
     const literal = this.parseStringLiteral();
-    if (!IsStringValidUnicode(StringValue(literal))) {
+    if (!IsStringWellFormedUnicode(StringValue(literal))) {
       this.raiseEarly('ModuleExportNameInvalidUnicode', literal);
     }
     return literal;

--- a/src/static-semantics/IsStringWellFormedUnicode.mjs
+++ b/src/static-semantics/IsStringWellFormedUnicode.mjs
@@ -1,7 +1,7 @@
 import { X } from '../completion.mjs';
 import { CodePointAt } from './all.mjs';
 
-export function IsStringValidUnicode(string) {
+export function IsStringWellFormedUnicode(string) {
   string = string.stringValue();
   // 1. Let _strLen_ be the number of code units in string.
   const strLen = string.length;
@@ -18,5 +18,6 @@ export function IsStringValidUnicode(string) {
     // c. Set k to k + cp.[[CodeUnitCount]].
     k += cp.CodeUnitCount;
   }
+  // 4. Return true.
   return true;
 }

--- a/src/static-semantics/all.mjs
+++ b/src/static-semantics/all.mjs
@@ -41,5 +41,5 @@ export * from './CodePointAt.mjs';
 export * from './CodePointToUTF16CodeUnits.mjs';
 export * from './StringToCodePoints.mjs';
 export * from './CodePointsToString.mjs';
-export * from './IsStringValidUnicode.mjs';
+export * from './IsStringWellFormedUnicode.mjs';
 export * from './IsComputedPropertyKey.mjs';


### PR DESCRIPTION
This Abstract Operation was renamed since being implemented in **engine262**: <https://github.com/tc39/ecma262/pull/2154#discussion_r491790876>.