### PR TITLE
Implement “Yield” and “Create(Async)IteratorFromClosure”

### DIFF
--- a/src/abstract-ops/async-generator-objects.mjs
+++ b/src/abstract-ops/async-generator-objects.mjs
@@ -8,17 +8,21 @@ import {
   AbruptCompletion,
 } from '../completion.mjs';
 import { Evaluate } from '../evaluator.mjs';
-import { Value, Type } from '../value.mjs';
+import { Value } from '../value.mjs';
 import { resume, handleInResume } from '../helpers.mjs';
 import {
   Assert,
   Call,
   CreateBuiltinFunction,
   CreateIterResultObject,
+  generatorBrandToErrorMessageType,
   GetGeneratorKind,
   NewPromiseCapability,
+  OrdinaryObjectCreate,
   PerformPromiseThen,
   PromiseResolve,
+  RequireInternalSlot,
+  SameValue,
 } from './all.mjs';
 
 // This file covers abstract operations defined in
@@ -34,54 +38,122 @@ class AsyncGeneratorRequestRecord {
 
 // 25.5.3.2 #sec-asyncgeneratorstart
 export function AsyncGeneratorStart(generator, generatorBody) {
-  // Assert: generator is an AsyncGenerator instance.
+  // 1. Assert: generator is an AsyncGenerator instance.
+  // 2. Assert: generator.[[AsyncGeneratorState]] is undefined.
   Assert(generator.AsyncGeneratorState === Value.undefined);
+  // 3. Let genContext be the running execution context.
   const genContext = surroundingAgent.runningExecutionContext;
+  // 4. Set the Generator component of genContext to generator.
   genContext.Generator = generator;
+  // 5. Set the code evaluation state of genContext such that when evaluation
+  //    is resumed for that execution context the following steps will be performed:
   genContext.codeEvaluationState = (function* resumer() {
-    const result = EnsureCompletion(yield* Evaluate(generatorBody));
-    // Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
+    // a. If generatorBody is a Parse Node, then
+    //     i. Let result be the result of evaluating generatorBody.
+    // b. Else,
+    //     i. Assert: generatorBody is an Abstract Closure.
+    //     ii. Let result be generatorBody().
+    const result = EnsureCompletion(
+      // Note: Engine262 can only perform the "If generatorBody is an Abstract Closure" check:
+      yield* typeof generatorBody === 'function'
+        ? generatorBody()
+        : Evaluate(generatorBody),
+    );
+    // c. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
+    // d. Remove genContext from the execution context stack and restore the execution context
+    //    that is at the top of the execution context stack as the running execution context.
     surroundingAgent.executionContextStack.pop(genContext);
+    // e. Set generator.[[AsyncGeneratorState]] to completed.
     generator.AsyncGeneratorState = 'completed';
     let resultValue;
+    // f. If result is a normal completion, let resultValue be undefined.
     if (result instanceof NormalCompletion) {
       resultValue = Value.undefined;
-    } else {
+    } else { // g. Else,
+      // i. Let resultValue be result.[[Value]].
       resultValue = result.Value;
+      // ii. If result.[[Type]] is not return, then
       if (result.Type !== 'return') {
+        // 1. Return ! AsyncGeneratorReject(generator, resultValue).
         return X(AsyncGeneratorReject(generator, resultValue));
       }
     }
+    // h. Return ! AsyncGeneratorResolve(generator, resultValue, true).
     return X(AsyncGeneratorResolve(generator, resultValue, Value.true));
   }());
+  // 6. Set generator.[[AsyncGeneratorContext]] to genContext.
   generator.AsyncGeneratorContext = genContext;
+  // 7. Set generator.[[AsyncGeneratorState]] to suspendedStart.
   generator.AsyncGeneratorState = 'suspendedStart';
+  // 8. Set generator.[[AsyncGeneratorQueue]] to a new empty List.
   generator.AsyncGeneratorQueue = [];
+  // 9. Return undefined.
   return Value.undefined;
+}
+
+// #sec-asyncgeneratorvalidate
+export function AsyncGeneratorValidate(generator, generatorBrand) {
+  // 1. Perform ? RequireInternalSlot(generator, [[AsyncGeneratorContext]]).
+  Q(RequireInternalSlot(generator, 'AsyncGeneratorContext'));
+  // 2. Perform ? RequireInternalSlot(generator, [[AsyncGeneratorState]]).
+  Q(RequireInternalSlot(generator, 'AsyncGeneratorState'));
+  // 3. Perform ? RequireInternalSlot(generator, [[AsyncGeneratorQueue]]).
+  Q(RequireInternalSlot(generator, 'AsyncGeneratorQueue'));
+  // 4. If generator.[[GeneratorBrand]] is not the same value as generatorBrand, throw a TypeError exception.
+  const brand = generator.GeneratorBrand;
+  if (
+    brand === undefined || generatorBrand === undefined
+      ? brand !== generatorBrand
+      : SameValue(brand, generatorBrand) === Value.false
+  ) {
+    return surroundingAgent.Throw(
+      'TypeError',
+      'NotATypeObject',
+      generatorBrandToErrorMessageType(generatorBrand) || 'AsyncGenerator',
+      generator,
+    );
+  }
 }
 
 // 25.5.3.3 #sec-asyncgeneratorresolve
 function AsyncGeneratorResolve(generator, value, done) {
-  // Assert: generator is an AsyncGenerator instance.
+  // 1. Assert: generator is an AsyncGenerator instance.
+  // 2. Let queue be generator.[[AsyncGeneratorQueue]].
   const queue = generator.AsyncGeneratorQueue;
+  // 3. Assert: queue is not an empty List.
   Assert(queue.length > 0);
+  // 4. Let next be the first element of queue.
+  // 5. Remove the first element from queue.
   const next = queue.shift();
+  // 6. Let promiseCapability be next.[[Capability]].
   const promiseCapability = next.Capability;
+  // 7. Let iteratorResult be ! CreateIterResultObject(value, done).
   const iteratorResult = X(CreateIterResultObject(value, done));
+  // 8. Perform ! Call(promiseCapability.[[Resolve]], undefined, « iteratorResult »).
   X(Call(promiseCapability.Resolve, Value.undefined, [iteratorResult]));
+  // 9. Perform ! AsyncGeneratorResumeNext(generator).
   X(AsyncGeneratorResumeNext(generator));
+  // 10. Return undefined.
   return Value.undefined;
 }
 
 // 25.5.3.4 #sec-asyncgeneratorreject
 function AsyncGeneratorReject(generator, exception) {
-  // Assert: generator is an AsyncGenerator instance.
+  // 1. Assert: generator is an AsyncGenerator instance.
+  // 2. Let queue be generator.[[AsyncGeneratorQueue]].
   const queue = generator.AsyncGeneratorQueue;
+  // 3. Assert: queue is not an empty List.
   Assert(queue.length > 0);
+  // 4. Let next be the first element of queue.
+  // 5. Remove the first element from queue.
   const next = queue.shift();
+  // 6. Let promiseCapability be next.[[Capability]].
   const promiseCapability = next.Capability;
+  // 7. Perform ! Call(promiseCapability.[[Reject]], undefined, « exception »).
   X(Call(promiseCapability.Reject, Value.undefined, [exception]));
+  // 8. Perform ! AsyncGeneratorResumeNext(generator).
   X(AsyncGeneratorResumeNext(generator));
+  // 9. Return undefined.
   return Value.undefined;
 }
 
@@ -101,7 +173,6 @@ function AsyncGeneratorResumeNextReturnProcessorRejectedFunctions([reason = Valu
 
 // 25.5.3.5 #sec-asyncgeneratorresumenext
 function AsyncGeneratorResumeNext(generator) {
-  // Assert: generator is an AsyncGenerator instance.
   let state = generator.AsyncGeneratorState;
   Assert(state !== 'executing');
   if (state === 'awaiting-return') {
@@ -153,21 +224,40 @@ function AsyncGeneratorResumeNext(generator) {
 }
 
 // 25.5.3.6 #sec-asyncgeneratorenqueue
-export function AsyncGeneratorEnqueue(generator, completion) {
+export function AsyncGeneratorEnqueue(generator, completion, generatorBrand) {
   Assert(completion instanceof Completion);
+  // 1. Let promiseCapability be ! NewPromiseCapability(%Promise%).
   const promiseCapability = X(NewPromiseCapability(surroundingAgent.intrinsic('%Promise%')));
-  if (Type(generator) !== 'Object' || !('AsyncGeneratorState' in generator)) {
-    const badGeneratorError = surroundingAgent.Throw('TypeError', 'NotATypeObject', 'AsyncGenerator', generator).Value;
+  // 2. Let check be AsyncGeneratorValidate(generator, generatorBrand).
+  const check = AsyncGeneratorValidate(generator, generatorBrand);
+  // 3. If check is an abrupt completion, then
+  if (check instanceof AbruptCompletion) {
+    // a. Let badGeneratorError be a newly created TypeError object.
+    const badGeneratorError = surroundingAgent.Throw(
+      'TypeError',
+      'NotATypeObject',
+      generatorBrandToErrorMessageType(generatorBrand) || 'AsyncGenerator',
+      generator,
+    ).Value;
+    // b. Perform ! Call(promiseCapability.[[Reject]], undefined, « badGeneratorError »).
     X(Call(promiseCapability.Reject, Value.undefined, [badGeneratorError]));
+    // c. Return promiseCapability.[[Promise]].
     return promiseCapability.Promise;
   }
+  // 4. Let queue be generator.[[AsyncGeneratorQueue]].
   const queue = generator.AsyncGeneratorQueue;
+  // 5. Let request be AsyncGeneratorRequest { [[Completion]]: completion, [[Capability]]: promiseCapability }.
   const request = new AsyncGeneratorRequestRecord(completion, promiseCapability);
+  // 6. Append request to the end of queue.
   queue.push(request);
+  // 7. Let state be generator.[[AsyncGeneratorState]].
   const state = generator.AsyncGeneratorState;
+  // 8. If state is not executing, then
   if (state !== 'executing') {
+    // a. Perform ! AsyncGeneratorResumeNext(generator).
     X(AsyncGeneratorResumeNext(generator));
   }
+  // 9. Return promiseCapability.[[Promise]].
   return promiseCapability.Promise;
 }
 
@@ -188,7 +278,7 @@ export function* AsyncGeneratorYield(value) {
   // 7. Remove genContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
   surroundingAgent.executionContextStack.pop(genContext);
   // 8. Set the code evaluation state of genContext such that when evaluation is resumed with a Completion resumptionValue the following steps will be performed:
-  const resumptionValue = EnsureCompletion(yield handleInResume(AsyncGeneratorResolve, generator, value, Value.false));
+  const resumptionValue = EnsureCompletion(yield handleInResume(AsyncGeneratorResolve, generator, value, Value.false, generator.GeneratorBrand));
 
   // a. If resumptionValue.[[Type]] is not return, return Completion(resumptionValue).
   if (resumptionValue.Type !== 'return') {
@@ -206,6 +296,24 @@ export function* AsyncGeneratorYield(value) {
   return new Completion({ Type: 'return', Value: awaited.Value, Target: undefined });
   // f. NOTE: When one of the above steps returns, it returns to the evaluation of the YieldExpression production that originally called this abstract operation.
 
-  // 9. Return ! AsyncGeneratorResolve(generator, value, false).
+  // 9. Return ! AsyncGeneratorResolve(generator, value, false, generator.[[GeneratorBrand]]).
   // 10. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of genContext.
+}
+
+// #sec-createasynciteratorfromclosure
+export function CreateAsyncIteratorFromClosure(closure, generatorBrand, generatorPrototype) {
+  Assert(typeof closure === 'function');
+  // 1. NOTE: closure can contain uses of the Await shorthand, and uses of the Yield shorthand to yield an IteratorResult object.
+  // 2. Let internalSlotsList be « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] ».
+  const internalSlotsList = ['AsyncGeneratorState', 'AsyncGeneratorContext', 'AsyncGeneratorQueue', 'GeneratorBrand'];
+  // 3. Let generator be ! OrdinaryObjectCreate(generatorPrototype, internalSlotsList).
+  const generator = X(OrdinaryObjectCreate(generatorPrototype, internalSlotsList));
+  // 4. Set generator.[[GeneratorBrand]] to generatorBrand.
+  generator.GeneratorBrand = generatorBrand;
+  // 5. Set generator.[[AsyncGeneratorState]] to undefined.
+  generator.AsyncGeneratorState = Value.undefined;
+  // 6. Perform ? AsyncGeneratorStart(generator, closure, generatorBrand).
+  Q(AsyncGeneratorStart(generator, closure));
+  // 7. Return generator.
+  return generator;
 }

--- a/src/abstract-ops/iterator-operations.mjs
+++ b/src/abstract-ops/iterator-operations.mjs
@@ -10,6 +10,7 @@ import {
   IfAbruptRejectPromise,
   Q, X,
   Await,
+  NormalCompletion,
 } from '../completion.mjs';
 import {
   Assert,
@@ -23,6 +24,8 @@ import {
   OrdinaryObjectCreate,
   PerformPromiseThen,
   ToBoolean,
+  Yield,
+  CreateIteratorFromClosure,
 } from './all.mjs';
 
 // This file covers abstract operations defined in
@@ -188,34 +191,24 @@ export function CreateIterResultObject(value, done) {
 
 // 7.4.9 #sec-createlistiteratorRecord
 export function CreateListIteratorRecord(list) {
-  const iterator = OrdinaryObjectCreate(surroundingAgent.intrinsic('%IteratorPrototype%'), [
-    'IteratedList',
-    'ListNextIndex',
-  ]);
-  iterator.IteratedList = list;
-  iterator.ListNextIndex = 0;
-  const steps = ListIteratorNextSteps;
-  const next = X(CreateBuiltinFunction(steps, []));
+  // 1. Let closure be a new Abstract Closure with no parameters that captures list and performs the following steps when called:
+  const closure = function* closure() {
+    // a. For each element E of list, do
+    for (const E of list) {
+      // i. Perform ? Yield(E).
+      Q(yield* Yield(E));
+    }
+    // b. Return undefined.
+    return NormalCompletion(Value.undefined);
+  };
+  // 2. Let iterator be ! CreateIteratorFromClosure(closure, empty, %IteratorPrototype%).
+  const iterator = X(CreateIteratorFromClosure(closure, undefined, surroundingAgent.intrinsic('%IteratorPrototype%')));
+  // 3. Return Record { [[Iterator]]: iterator, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: false }.
   return {
     Iterator: iterator,
-    NextMethod: next,
+    NextMethod: surroundingAgent.intrinsic('%GeneratorFunction.prototype.prototype.next%'),
     Done: Value.false,
   };
-}
-
-// 7.4.9.1 #sec-listiterator-next
-function ListIteratorNextSteps(args, { thisValue }) {
-  const O = thisValue;
-  Assert(Type(O) === 'Object');
-  Assert('IteratedList' in O);
-  const list = O.IteratedList;
-  const index = O.ListNextIndex;
-  const len = list.length;
-  if (index >= len) {
-    return CreateIterResultObject(Value.undefined, Value.true);
-  }
-  O.ListNextIndex += 1;
-  return CreateIterResultObject(list[index], Value.false);
 }
 
 // 25.1.4.1 #sec-createasyncfromsynciterator

--- a/src/intrinsics/ArrayIteratorPrototype.mjs
+++ b/src/intrinsics/ArrayIteratorPrototype.mjs
@@ -1,90 +1,16 @@
 import {
-  surroundingAgent,
-} from '../engine.mjs';
-import {
-  Type,
-  Value,
-} from '../value.mjs';
-import {
-  Assert,
-  CreateArrayFromList,
-  CreateIterResultObject,
-  Get,
-  IsDetachedBuffer,
-  LengthOfArrayLike,
-  ToString,
-  F,
+  GeneratorResume,
 } from '../abstract-ops/all.mjs';
-import { Q, X } from '../completion.mjs';
+import { Q } from '../completion.mjs';
+import { Value } from '../value.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
-// #sec-%arrayiteratorprototype%-object
+const kArrayIteratorPrototype = new Value('%ArrayIteratorPrototype%');
+
+// #sec-%arrayiteratorprototype%.next
 function ArrayIteratorPrototype_next(args, { thisValue }) {
-  // 1. Let O be the this value.
-  const O = thisValue;
-  // 2. If Type(O) is not Object, throw a TypeError exception.
-  if (Type(O) !== 'Object') {
-    return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Array Iterator', O);
-  }
-  // 3. If O does not have all of the internal slots of an Array Iterator Instance (22.1.5.3), throw a TypeError exception.
-  if (!('IteratedArrayLike' in O)
-      || !('ArrayLikeNextIndex' in O)
-      || !('ArrayLikeIterationKind' in O)) {
-    return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Array Iterator', O);
-  }
-  // 4. Let a be O.[[IteratedArrayLike]].
-  const a = O.IteratedArrayLike;
-  // 5. If a is undefined, return CreateIterResultObject(undefined, true).
-  if (a === Value.undefined) {
-    return CreateIterResultObject(Value.undefined, Value.true);
-  }
-  // 6. Let index be O.[[ArrayLikeNextIndex]].
-  const index = O.ArrayLikeNextIndex;
-  // 7. Let itemKind be O.[[ArrayLikeIterationKind]].
-  const itemKind = O.ArrayLikeIterationKind;
-  let len;
-  // 8. If a has a [[TypedArrayName]] internal slot, then
-  if ('TypedArrayName' in a) {
-    // a. If IsDetachedBuffer(a.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
-    if (IsDetachedBuffer(a.ViewedArrayBuffer) === Value.true) {
-      return surroundingAgent.Throw('TypeError', 'ArrayBufferDetached');
-    }
-    // b. Let len be a.[[ArrayLength]].
-    len = a.ArrayLength;
-  } else { // 9. Else,
-    // a. Let len be ? LengthOfArrayLike(a).
-    len = Q(LengthOfArrayLike(a));
-  }
-  // 10. If index ≥ len, then
-  if (index >= len) {
-    // a. Set O.[[IteratedArrayLike]] to undefined.
-    O.IteratedArrayLike = Value.undefined;
-    // b. Return CreateIterResultObject(undefined, true).
-    return CreateIterResultObject(Value.undefined, Value.true);
-  }
-  // 11. Set O.[[ArrayLikeNextIndex]] to index + 1.
-  O.ArrayLikeNextIndex = index + 1;
-  // 12. If itemKind is key, return CreateIterResultObject(index, false).
-  if (itemKind === 'key') {
-    return CreateIterResultObject(F(index), Value.false);
-  }
-  // 13. Let elementKey be ! ToString(index).
-  const elementKey = X(ToString(F(index)));
-  // 14. Let elementValue be ? Get(a, elementKey).
-  const elementValue = Q(Get(a, elementKey));
-  // 15. If itemKind is value, let result be elementValue.
-  let result;
-  // 15. If itemKind is value, let result be elementValue.
-  if (itemKind === 'value') {
-    result = elementValue;
-  } else { // 16. Else,
-    // a. Assert: itemKind is key+value.
-    Assert(itemKind === 'key+value');
-    // b. Let result be ! CreateArrayFromList(« index, elementValue »).
-    result = X(CreateArrayFromList([F(index), elementValue]));
-  }
-  // 17. Return CreateIterResultObject(result, false).
-  return CreateIterResultObject(result, Value.false);
+  // 1. Return ? GeneratorResume(this value, empty, "%ArrayIteratorPrototype%").
+  return Q(GeneratorResume(thisValue, undefined, kArrayIteratorPrototype));
 }
 
 export function bootstrapArrayIteratorPrototype(realmRec) {
@@ -92,5 +18,5 @@ export function bootstrapArrayIteratorPrototype(realmRec) {
     ['next', ArrayIteratorPrototype_next, 0],
   ], realmRec.Intrinsics['%IteratorPrototype%'], 'Array Iterator');
 
-  realmRec.Intrinsics['%ArrayIterator.prototype%'] = proto;
+  realmRec.Intrinsics['%ArrayIteratorPrototype%'] = proto;
 }

--- a/src/intrinsics/AsyncGeneratorFunctionPrototypePrototype.mjs
+++ b/src/intrinsics/AsyncGeneratorFunctionPrototypePrototype.mjs
@@ -14,8 +14,8 @@ function AsyncGeneratorPrototype_next([value = Value.undefined], { thisValue }) 
   const generator = thisValue;
   // 2. Let completion be NormalCompletion(value).
   const completion = NormalCompletion(value);
-  // 3. Return ! AsyncGeneratorEnqueue(generator, completion).
-  return X(AsyncGeneratorEnqueue(generator, completion));
+  // 3. Return ! AsyncGeneratorEnqueue(generator, completion, empty).
+  return X(AsyncGeneratorEnqueue(generator, completion, undefined));
 }
 
 // #sec-asyncgenerator-prototype-return
@@ -24,8 +24,8 @@ function AsyncGeneratorPrototype_return([value = Value.undefined], { thisValue }
   const generator = thisValue;
   // 2. Let completion be Completion { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
   const completion = new Completion({ Type: 'return', Value: value, Target: undefined });
-  // 3. Return ! AsyncGeneratorEnqueue(generator, completion).
-  return X(AsyncGeneratorEnqueue(generator, completion));
+  // 3. Return ! AsyncGeneratorEnqueue(generator, completion, empty).
+  return X(AsyncGeneratorEnqueue(generator, completion, undefined));
 }
 
 // #sec-asyncgenerator-prototype-throw
@@ -34,8 +34,8 @@ function AsyncGeneratorPrototype_throw([exception = Value.undefined], { thisValu
   const generator = thisValue;
   // 2. Let completion be ThrowCompletion(exception).
   const completion = ThrowCompletion(exception);
-  // 3. Return ! AsyncGeneratorEnqueue(generator, completion).
-  return X(AsyncGeneratorEnqueue(generator, completion));
+  // 3. Return ! AsyncGeneratorEnqueue(generator, completion, empty).
+  return X(AsyncGeneratorEnqueue(generator, completion, undefined));
 }
 
 export function bootstrapAsyncGeneratorFunctionPrototypePrototype(realmRec) {

--- a/src/intrinsics/GeneratorFunctionPrototypePrototype.mjs
+++ b/src/intrinsics/GeneratorFunctionPrototypePrototype.mjs
@@ -46,4 +46,7 @@ export function bootstrapGeneratorFunctionPrototypePrototype(realmRec) {
   ], realmRec.Intrinsics['%IteratorPrototype%'], 'Generator');
 
   realmRec.Intrinsics['%GeneratorFunction.prototype.prototype%'] = generatorPrototype;
+
+  // Used by `CreateListIteratorRecord`:
+  realmRec.Intrinsics['%GeneratorFunction.prototype.prototype.next%'] = generatorPrototype.Get(new Value('next'));
 }

--- a/src/intrinsics/GeneratorFunctionPrototypePrototype.mjs
+++ b/src/intrinsics/GeneratorFunctionPrototypePrototype.mjs
@@ -14,8 +14,8 @@ import { bootstrapPrototype } from './bootstrap.mjs';
 function GeneratorProto_next([value = Value.undefined], { thisValue }) {
   // 1. Let g be the this value.
   const g = thisValue;
-  // 2. Return ? GeneratorResume(g, value).
-  return Q(GeneratorResume(g, value));
+  // 2. Return ? GeneratorResume(g, value, empty).
+  return Q(GeneratorResume(g, value, undefined));
 }
 
 // #sec-generator.prototype.return
@@ -24,8 +24,8 @@ function GeneratorProto_return([value = Value.undefined], { thisValue }) {
   const g = thisValue;
   // 2. Let C be Completion { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
   const C = new Completion({ Type: 'return', Value: value, Target: undefined });
-  // 3. Return ? GeneratorResumeAbrupt(g, C).
-  return Q(GeneratorResumeAbrupt(g, C));
+  // 3. Return ? GeneratorResumeAbrupt(g, C, empty).
+  return Q(GeneratorResumeAbrupt(g, C, undefined));
 }
 
 // #sec-generator.prototype.throw
@@ -34,8 +34,8 @@ function GeneratorProto_throw([exception = Value.undefined], { thisValue }) {
   const g = thisValue;
   // 2. Let C be ThrowCompletion(exception).
   const C = ThrowCompletion(exception);
-  // 3. Return ? GeneratorResumeAbrupt(g, C).
-  return Q(GeneratorResumeAbrupt(g, C));
+  // 3. Return ? GeneratorResumeAbrupt(g, C, empty).
+  return Q(GeneratorResumeAbrupt(g, C, undefined));
 }
 
 export function bootstrapGeneratorFunctionPrototypePrototype(realmRec) {

--- a/src/intrinsics/MapIteratorPrototype.mjs
+++ b/src/intrinsics/MapIteratorPrototype.mjs
@@ -2,72 +2,67 @@ import { surroundingAgent } from '../engine.mjs';
 import {
   Assert,
   CreateArrayFromList,
-  CreateIterResultObject,
+  CreateIteratorFromClosure,
+  GeneratorResume,
+  RequireInternalSlot,
+  Yield,
 } from '../abstract-ops/all.mjs';
-import { Type, Value } from '../value.mjs';
-import { X } from '../completion.mjs';
+import { Q, X } from '../completion.mjs';
+import { Value } from '../value.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
+const kMapIteratorPrototype = new Value('%MapIteratorPrototype%');
+
+// #sec-createmapiterator
+export function CreateMapIterator(map, kind) {
+  Assert(kind === 'key+value' || kind === 'key' || kind === 'value');
+  // 1. Perform ? RequireInternalSlot(map, [[MapData]]).
+  Q(RequireInternalSlot(map, 'MapData'));
+  // 2. Let closure be a new Abstract Closure with no parameters that captures map and kind and performs the following steps when called:
+  const closure = function* closure() {
+    // a. Let entries be the List that is map.[[MapData]].
+    const entries = map.MapData;
+    // b. Let index be 0.
+    let index = 0;
+    // c. Let numEntries be the number of elements of entries.
+    let numEntries = entries.length;
+    // d. Repeat, while index < numEntries,
+    while (index < numEntries) {
+      // i. Let e be the Record { [[Key]], [[Value]] } that is the value of entries[index].
+      const e = entries[index];
+      // ii. Set index to index + 1.
+      index += 1;
+      // iii. If e.[[Key]] is not empty, then
+      if (e.Key !== undefined) {
+        let result;
+        // 1. If kind is key, let result be e.[[Key]].
+        if (kind === 'key') {
+          result = e.Key;
+        } else if (kind === 'value') { // 2. Else if kind is value, let result be e.[[Value]].
+          result = e.Value;
+        } else { // 3. Else,
+          // a. Assert: kind is key+value.
+          Assert(kind === 'key+value');
+          // b. Let result be ! CreateArrayFromList(« e.[[Key]], e.[[Value]] »).
+          result = X(CreateArrayFromList([e.Key, e.Value]));
+        }
+        // 4. Perform ? Yield(result).
+        Q(yield* Yield(result));
+      }
+      // iv. Set numEntries to the number of elements of entries.
+      numEntries = entries.length;
+    }
+    // e. Return undefined.
+    return Value.undefined;
+  };
+  // 3. Return ! CreateIteratorFromClosure(closure, "%MapIteratorPrototype%", %MapIteratorPrototype%).
+  return X(CreateIteratorFromClosure(closure, kMapIteratorPrototype, surroundingAgent.intrinsic('%MapIteratorPrototype%')));
+}
 
 // #sec-%mapiteratorprototype%.next
 function MapIteratorPrototype_next(args, { thisValue }) {
-  // 1. Let O be the this value.
-  const O = thisValue;
-  // 2. If Type(O) is not Object, throw a TypeError exception.
-  if (Type(O) !== 'Object') {
-    return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Map Iterator', O);
-  }
-  // 3. If O does not have all of the internal slots of a Map Iterator Instance (23.1.5.3), throw a TypeError exception.
-  if (!('IteratedMap' in O && 'MapNextIndex' in O && 'MapIterationKind' in O)) {
-    return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Map Iterator', O);
-  }
-  // 4. Let m be O.[[IteratedMap]].
-  const m = O.IteratedMap;
-  // 5. Let index be O.[[MapNextIndex]].
-  let index = O.MapNextIndex;
-  // 6. Let index be O.[[MapNextIndex]].
-  const itemKind = O.MapIterationKind;
-  // 7. If m is undefined, return CreateIterResultObject(undefined, true).
-  if (m === Value.undefined) {
-    return CreateIterResultObject(Value.undefined, Value.true);
-  }
-  // 8. Assert: m has a [[MapData]] internal slot.
-  Assert('MapData' in m);
-  // 9. Let entries be the List that is m.[[MapData]].
-  const entries = m.MapData;
-  // 10. Let numEntries be the number of elements of entries.
-  const numEntries = entries.length;
-  // 11. NOTE: numEntries must be redetermined each time this method is evaluated.
-  // 12. Repeat, while index is less than numEntries,
-  while (index < numEntries) {
-    // a. Let e be the Record { [[Key]], [[Value]] } that is the value of entries[index].
-    const e = entries[index];
-    // b. Set index to index + 1.
-    index += 1;
-    // c. Set O.[[MapNextIndex]] to index.
-    O.MapNextIndex = index;
-    // d. If e.[[Key]] is not empty, then
-    if (e.Key !== undefined) {
-      let result;
-      // i. If itemKind is key, let result be e.[[Key]].
-      if (itemKind === 'key') {
-        result = e.Key;
-      } else if (itemKind === 'value') { // ii. Else if itemKind is value, let result be e.[[Value]].
-        result = e.Value;
-      } else { // iii. Else,
-        // 1. Assert: itemKind is key+value.
-        Assert(itemKind === 'key+value');
-        // 2. Let result be ! CreateArrayFromList(« e.[[Key]], e.[[Value]] »).
-        result = X(CreateArrayFromList([e.Key, e.Value]));
-      }
-      // iv. Return CreateIterResultObject(result, false).
-      return CreateIterResultObject(result, Value.false);
-    }
-  }
-  // 13. Set O.[[IteratedMap]] to undefined.
-  O.IteratedMap = Value.undefined;
-  // 14. Return CreateIterResultObject(undefined, true).
-  return CreateIterResultObject(Value.undefined, Value.true);
+  // 1. Return ? GeneratorResume(this value, empty, "%MapIteratorPrototype%")
+  return Q(GeneratorResume(thisValue, undefined, kMapIteratorPrototype));
 }
 
 export function bootstrapMapIteratorPrototype(realmRec) {

--- a/src/intrinsics/MapPrototype.mjs
+++ b/src/intrinsics/MapPrototype.mjs
@@ -1,11 +1,10 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
   Call,
-  IsCallable,
-  OrdinaryObjectCreate,
-  SameValueZero,
-  RequireInternalSlot,
   F,
+  IsCallable,
+  RequireInternalSlot,
+  SameValueZero,
 } from '../abstract-ops/all.mjs';
 import {
   Type,
@@ -14,20 +13,7 @@ import {
 } from '../value.mjs';
 import { Q, X } from '../completion.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
-
-
-function CreateMapIterator(map, kind) {
-  Q(RequireInternalSlot(map, 'MapData'));
-  const iterator = OrdinaryObjectCreate(surroundingAgent.intrinsic('%MapIteratorPrototype%'), [
-    'IteratedMap',
-    'MapNextIndex',
-    'MapIterationKind',
-  ]);
-  iterator.IteratedMap = map;
-  iterator.MapNextIndex = 0;
-  iterator.MapIterationKind = kind;
-  return iterator;
-}
+import { CreateMapIterator } from './MapIteratorPrototype.mjs';
 
 // #sec-map.prototype.clear
 function MapProto_clear(args, { thisValue }) {

--- a/src/intrinsics/RegExpStringIteratorPrototype.mjs
+++ b/src/intrinsics/RegExpStringIteratorPrototype.mjs
@@ -2,63 +2,49 @@ import { surroundingAgent } from '../engine.mjs';
 import { Type, Value } from '../value.mjs';
 import {
   Assert,
-  OrdinaryObjectCreate,
-  CreateIterResultObject,
+  CreateIteratorFromClosure,
+  GeneratorResume,
   ToString,
   ToLength,
   Get,
   Set,
+  Yield,
   F,
 } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { RegExpExec, AdvanceStringIndex } from './RegExpPrototype.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
+const kRegExpStringIteratorPrototype = new Value('%RegExpStringIteratorPrototype%');
 
 // 21.2.5.8.1 #sec-createregexpstringiterator
 export function CreateRegExpStringIterator(R, S, global, fullUnicode) {
+  // 1. Assert: Type(S) is String.
   Assert(Type(S) === 'String');
+  // 2. Assert: Type(global) is Boolean.
   Assert(Type(global) === 'Boolean');
+  // 3. Assert: Type(fullUnicode) is Boolean.
   Assert(Type(fullUnicode) === 'Boolean');
-  const iterator = OrdinaryObjectCreate(surroundingAgent.intrinsic('%RegExpStringIteratorPrototype%'), [
-    'IteratingRegExp',
-    'IteratedString',
-    'Global',
-    'Unicode',
-    'Done',
-  ]);
-  iterator.IteratingRegExp = R;
-  iterator.IteratedString = S;
-  iterator.Global = global;
-  iterator.Unicode = fullUnicode;
-  iterator.Done = Value.false;
-  return iterator;
-}
-
-// 21.2.7.1.1 #sec-%regexpstringiteratorprototype%.next
-function RegExpStringIteratorPrototype_next(args, { thisValue }) {
-  const O = thisValue;
-  if (Type(O) !== 'Object') {
-    return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp String Iterator', O);
-  }
-  if (!('IteratingRegExp' in O && 'IteratedString' in O && 'Global' in O && 'Unicode' in O && 'Done' in O)) {
-    return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp String Iterator', O);
-  }
-  if (O.Done === Value.true) {
-    return X(CreateIterResultObject(Value.undefined, Value.true));
-  }
-  const R = O.IteratingRegExp;
-  const S = O.IteratedString;
-  const global = O.Global;
-  const fullUnicode = O.Unicode;
-  const match = Q(RegExpExec(R, S));
-  if (match === Value.null) {
-    O.Done = Value.true;
-    return X(CreateIterResultObject(Value.undefined, Value.true));
-  } else {
-    if (global === Value.true) {
-      const matchStrValue = Q(Get(match, new Value('0')));
-      const matchStr = Q(ToString(matchStrValue));
+  // 4. Let closure be a new Abstract Closure with no parameters that captures R, S, global, and fullUnicode and performs the following steps when called:
+  const closure = function* closure() {
+    // a. Repeat,
+    while (true) {
+      // i. Let match be ? RegExpExec(R, S).
+      const match = Q(RegExpExec(R, S));
+      // ii. If match is null, return undefined.
+      if (match === Value.null) {
+        return Value.undefined;
+      }
+      // iii. If global is false, then
+      if (global === Value.false) {
+        // 1. Perform ? Yield(match).
+        Q(yield* Yield(match));
+        // 2. Return undefined.
+        return Value.undefined;
+      }
+      // iv. Let matchStr be ? ToString(? Get(match, "0")).
+      const matchStr = Q(ToString(Q(Get(match, new Value('0')))));
+      // v. If matchStr is the empty String, then
       if (matchStr.stringValue() === '') {
         // i. Let thisIndex be ℝ(? ToLength(? Get(R, "lastIndex"))).
         const thisIndex = Q(ToLength(Q(Get(R, new Value('lastIndex'))))).numberValue();
@@ -67,12 +53,18 @@ function RegExpStringIteratorPrototype_next(args, { thisValue }) {
         // iii. Perform ? Set(R, "lastIndex", 𝔽(nextIndex), true).
         Q(Set(R, new Value('lastIndex'), F(nextIndex), Value.true));
       }
-      return Q(CreateIterResultObject(match, Value.false));
-    } else {
-      O.Done = Value.true;
-      return Q(CreateIterResultObject(match, Value.false));
+      // vi. Perform ? Yield(match).
+      Q(yield* Yield(match));
     }
-  }
+  };
+  // 4. Return ! CreateIteratorFromClosure(closure, "%RegExpStringIteratorPrototype%", %RegExpStringIteratorPrototype%).
+  return X(CreateIteratorFromClosure(closure, kRegExpStringIteratorPrototype, surroundingAgent.intrinsic('%RegExpStringIteratorPrototype%')));
+}
+
+// 21.2.7.1.1 #sec-%regexpstringiteratorprototype%.next
+function RegExpStringIteratorPrototype_next(args, { thisValue }) {
+  // 1. Return ? GeneratorResume(this value, empty, "%RegExpStringIteratorPrototype%").
+  return Q(GeneratorResume(thisValue, undefined, kRegExpStringIteratorPrototype));
 }
 
 export function bootstrapRegExpStringIteratorPrototype(realmRec) {

--- a/src/intrinsics/SetPrototype.mjs
+++ b/src/intrinsics/SetPrototype.mjs
@@ -1,11 +1,10 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
   Call,
-  IsCallable,
-  OrdinaryObjectCreate,
-  SameValueZero,
-  RequireInternalSlot,
   F,
+  IsCallable,
+  RequireInternalSlot,
+  SameValueZero,
 } from '../abstract-ops/all.mjs';
 import {
   Type,
@@ -14,20 +13,7 @@ import {
 } from '../value.mjs';
 import { Q, X } from '../completion.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
-
-// 23.2.5.1 #sec-createsetiterator
-function CreateSetIterator(set, kind) {
-  Q(RequireInternalSlot(set, 'SetData'));
-  const iterator = OrdinaryObjectCreate(surroundingAgent.intrinsic('%SetIteratorPrototype%'), [
-    'IteratedSet',
-    'SetNextIndex',
-    'SetIterationKind',
-  ]);
-  iterator.IteratedSet = set;
-  iterator.SetNextIndex = 0;
-  iterator.SetIterationKind = kind;
-  return iterator;
-}
+import { CreateSetIterator } from './SetIteratorPrototype.mjs';
 
 // #sec-set.prototype.add
 function SetProto_add([value = Value.undefined], { thisValue }) {

--- a/src/intrinsics/StringIteratorPrototype.mjs
+++ b/src/intrinsics/StringIteratorPrototype.mjs
@@ -1,69 +1,16 @@
-import { Type, Value } from '../value.mjs';
 import {
-  Assert,
-  CreateIterResultObject,
-  OrdinaryObjectCreate,
+  GeneratorResume,
 } from '../abstract-ops/all.mjs';
-import { CodePointAt } from '../static-semantics/all.mjs';
-import { X } from '../completion.mjs';
-import { surroundingAgent } from '../engine.mjs';
+import { Q } from '../completion.mjs';
+import { Value } from '../value.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
-
-// #sec-createstringiterator
-export function CreateStringIterator(string) {
-  // 1. Assert: Type(string) is String.
-  Assert(Type(string) === 'String');
-  // 2. Let iterator be OrdinaryObjectCreate(%StringIteratorPrototype%, « [[IteratedString]], [[StringNextIndex]] »).
-  const iterator = OrdinaryObjectCreate(surroundingAgent.intrinsic('%StringIteratorPrototype%'), [
-    'IteratedString',
-    'StringNextIndex',
-  ]);
-  // 3. Set iterator.[[IteratedString]] to string.
-  iterator.IteratedString = string;
-  // 4. Set iterator.[[StringNextIndex]] to 0.
-  iterator.StringNextIndex = 0;
-  // 5. Return iterator.
-  return iterator;
-}
+const kStringIteratorPrototype = new Value('%StringIteratorPrototype%');
 
 // #sec-%stringiteratorprototype%.next
 function StringIteratorPrototype_next(args, { thisValue }) {
-  // 1. Let O be the this value.
-  const O = thisValue;
-  // 2. If Type(O) is not Object, throw a TypeError exception.
-  if (Type(O) !== 'Object') {
-    return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'String Iterator', O);
-  }
-  // 3. If O does not have all of the internal slots of a String Iterator Instance (21.1.5.3), throw a TypeError exception.
-  if (!('IteratedString' in O && 'StringNextIndex' in O)) {
-    return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'String Iterator', O);
-  }
-  // 4. Let s be O.[[IteratedString]].
-  const s = O.IteratedString;
-  // 5. Let s be O.[[IteratedString]].
-  if (s === Value.undefined) {
-    return CreateIterResultObject(Value.undefined, Value.true);
-  }
-  // 6. If s is undefined, return CreateIterResultObject(undefined, true).
-  const position = O.StringNextIndex;
-  // 7. Let len be the length of s.
-  const len = s.stringValue().length;
-  // 8. If position ≥ len, then
-  if (position >= len) {
-    // a. Set O.[[IteratedString]] to undefined.
-    O.IteratedString = Value.undefined;
-    // b. Return CreateIterResultObject(undefined, true).
-    return CreateIterResultObject(Value.undefined, Value.true);
-  }
-  // 9. Let cp be ! CodePointAt(s, position).
-  const cp = X(CodePointAt(s.stringValue(), position));
-  // 10. Let resultString be the String value containing cp.[[CodeUnitCount]] consecutive code units from s beginning with the code unit at index position.
-  const resultString = new Value(s.stringValue().substr(position, cp.CodeUnitCount));
-  // 11. Set O.[[StringNextIndex]] to position + cp.[[CodeUnitCount]].
-  O.StringNextIndex = position + cp.CodeUnitCount;
-  // 12. Return CreateIterResultObject(resultString, false).
-  return CreateIterResultObject(resultString, Value.false);
+  // 1. Return ? GeneratorResume(this value, empty, "%StringIteratorPrototype%").
+  return Q(GeneratorResume(thisValue, undefined, kStringIteratorPrototype));
 }
 
 export function bootstrapStringIteratorPrototype(realmRec) {

--- a/src/runtime-semantics/EvaluateBody.mjs
+++ b/src/runtime-semantics/EvaluateBody.mjs
@@ -78,11 +78,13 @@ function* EvaluateBody_AsyncConciseBody({ ExpressionBody }, functionObject, argu
 export function* EvaluateBody_GeneratorBody(GeneratorBody, functionObject, argumentsList) {
   // 1. Perform ? FunctionDeclarationInstantiation(functionObject, argumentsList).
   Q(yield* FunctionDeclarationInstantiation(functionObject, argumentsList));
-  // 2. Let G be ? OrdinaryCreateFromConstructor(functionObject, "%GeneratorFunction.prototype.prototype%", « [[GeneratorState]], [[GeneratorContext]] »).
-  const G = Q(OrdinaryCreateFromConstructor(functionObject, '%GeneratorFunction.prototype.prototype%', ['GeneratorState', 'GeneratorContext']));
-  // 3. Perform GeneratorStart(G, FunctionBody).
+  // 2. Let G be ? OrdinaryCreateFromConstructor(functionObject, "%GeneratorFunction.prototype.prototype%", « [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] »).
+  const G = Q(OrdinaryCreateFromConstructor(functionObject, '%GeneratorFunction.prototype.prototype%', ['GeneratorState', 'GeneratorContext', 'GeneratorBrand']));
+  // 3. Set G.[[GeneratorBrand]] to empty.
+  G.GeneratorBrand = undefined;
+  // 4. Perform GeneratorStart(G, FunctionBody).
   GeneratorStart(G, GeneratorBody);
-  // 4. Return Completion { [[Type]]: return, [[Value]]: G, [[Target]]: empty }.
+  // 5. Return Completion { [[Type]]: return, [[Value]]: G, [[Target]]: empty }.
   return new Completion({ Type: 'return', Value: G, Target: undefined });
 }
 
@@ -91,15 +93,18 @@ export function* EvaluateBody_GeneratorBody(GeneratorBody, functionObject, argum
 export function* EvaluateBody_AsyncGeneratorBody(FunctionBody, functionObject, argumentsList) {
   // 1. Perform ? FunctionDeclarationInstantiation(functionObject, argumentsList).
   Q(yield* FunctionDeclarationInstantiation(functionObject, argumentsList));
-  // 2. Let generator be ? OrdinaryCreateFromConstructor(functionObject, "%AsyncGeneratorFunction.prototype.prototype%", « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]] »).
+  // 2. Let generator be ? OrdinaryCreateFromConstructor(functionObject, "%AsyncGeneratorFunction.prototype.prototype%", « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] »).
   const generator = Q(OrdinaryCreateFromConstructor(functionObject, '%AsyncGeneratorFunction.prototype.prototype%', [
     'AsyncGeneratorState',
     'AsyncGeneratorContext',
     'AsyncGeneratorQueue',
+    'GeneratorBrand',
   ]));
-  // 3. Perform ! AsyncGeneratorStart(generator, FunctionBody).
+  // 3. Set generator.[[GeneratorBrand]] to empty.
+  generator.GeneratorBrand = undefined;
+  // 4. Perform ! AsyncGeneratorStart(generator, FunctionBody).
   X(AsyncGeneratorStart(generator, FunctionBody));
-  // 4. Return Completion { [[Type]]: return, [[Value]]: generator, [[Target]]: empty }.
+  // 5. Return Completion { [[Type]]: return, [[Value]]: generator, [[Target]]: empty }.
   return new Completion({ Type: 'return', Value: generator, Target: undefined });
 }
 

--- a/src/runtime-semantics/YieldExpression.mjs
+++ b/src/runtime-semantics/YieldExpression.mjs
@@ -3,7 +3,6 @@ import { Type, Value } from '../value.mjs';
 import {
   Assert,
   Call,
-  CreateIterResultObject,
   GeneratorYield,
   GetGeneratorKind,
   GetIterator,
@@ -14,6 +13,7 @@ import {
   IteratorValue,
   AsyncGeneratorYield,
   AsyncIteratorClose,
+  Yield,
 } from '../abstract-ops/all.mjs';
 import {
   Await,
@@ -30,9 +30,9 @@ import { Evaluate } from '../evaluator.mjs';
 //     `yield` AssignmentExpression
 //     `yield` `*` AssignmentExpression
 export function* Evaluate_YieldExpression({ hasStar, AssignmentExpression }) {
-  // 1. Let generatorKind be ! GetGeneratorKind().
-  const generatorKind = X(GetGeneratorKind());
   if (hasStar) {
+    // 1. Let generatorKind be ! GetGeneratorKind().
+    const generatorKind = X(GetGeneratorKind());
     // 2. Let exprRef be the result of evaluating AssignmentExpression.
     const exprRef = yield* Evaluate(AssignmentExpression);
     // 3. Let value be ? GetValue(exprRef).
@@ -158,21 +158,13 @@ export function* Evaluate_YieldExpression({ hasStar, AssignmentExpression }) {
     }
   }
   if (AssignmentExpression) {
-    // 2. Let exprRef be the result of evaluating AssignmentExpression.
+    // 1. Let exprRef be the result of evaluating AssignmentExpression.
     const exprRef = yield* Evaluate(AssignmentExpression);
-    // 3. Let value be ? GetValue(exprRef).
+    // 2. Let value be ? GetValue(exprRef).
     const value = Q(GetValue(exprRef));
-    // 4. If generatorKind is async, then return ? AsyncGeneratorYield(value).
-    if (generatorKind === 'async') {
-      return Q(yield* AsyncGeneratorYield(value));
-    }
-    // 5. Otherwise, return ? GeneratorYield(CreateIterResultObject(value, false)).
-    return Q(yield* GeneratorYield(CreateIterResultObject(value, Value.false)));
+    // 3. Return ? Yield(value).
+    return Q(yield* Yield(value));
   }
-  // 2. If generatorKind is async, then return ? AsyncGeneratorYield(undefined).
-  if (generatorKind === 'async') {
-    return Q(yield* AsyncGeneratorYield(Value.undefined));
-  }
-  // 3. Otherwise, return ? GeneratorYield(CreateIterResultObject(undefined, false)).
-  return Q(yield* GeneratorYield(CreateIterResultObject(Value.undefined, Value.false)));
+  // 1. Return ? Yield(undefined).
+  return Q(yield* Yield(Value.undefined));
 }


### PR DESCRIPTION
**Spec:** <https://github.com/tc39/ecma262/pull/2045>

## To do:
- [x] Convert built‑in iterators to use `CreateIteratorFromClosure` and `CreateAsyncIteratorFromClosure`.

---

review?(@devsnek)