### PR TITLE
Value: Drop `CreateBuiltinFunction` alias functionality

### DIFF
--- a/bin/engine262.js
+++ b/bin/engine262.js
@@ -25,8 +25,11 @@ const {
 
   Value,
 
+  CreateBuiltinFunction,
   CreateDataProperty,
   OrdinaryObjectCreate,
+  SetFunctionLength,
+  SetFunctionName,
   Type,
 
   Completion,
@@ -123,24 +126,33 @@ realm.scope(() => {
     return inspect(a);
   }).join(' ');
 
-  const log = new Value((args) => {
+  const log = CreateBuiltinFunction((args) => {
     process.stdout.write(`${format(args)}\n`);
     return Value.undefined;
-  });
+  }, []);
+
+  SetFunctionLength(log, new Value(1));
+  SetFunctionName(log, new Value('log'));
 
   CreateDataProperty(console, new Value('log'), log);
 
-  const error = new Value((args) => {
+  const error = CreateBuiltinFunction((args) => {
     process.stderr.write(`${format(args)}\n`);
     return Value.undefined;
-  });
+  }, []);
+
+  SetFunctionLength(error, new Value(1));
+  SetFunctionName(error, new Value('error'));
 
   CreateDataProperty(console, new Value('error'), error);
 
-  const debug = new Value((args) => {
+  const debug = CreateBuiltinFunction((args) => {
     process.stderr.write(`${util.format(...args)}\n`);
     return Value.undefined;
-  });
+  }, []);
+
+  SetFunctionLength(debug, new Value(1));
+  SetFunctionName(debug, new Value('debug'));
 
   CreateDataProperty(console, new Value('debug'), debug);
 });

--- a/src/value.mjs
+++ b/src/value.mjs
@@ -34,8 +34,6 @@ export class Value {
         return new NumberValue(value);
       case 'bigint':
         return new BigIntValue(value);
-      case 'function':
-        return CreateBuiltinFunction(value, []);
       default:
         throw new OutOfRange('new Value', value);
     }


### PR DESCRIPTION
This functionality was only used by `bin/engine262.js` and `bin/test262_realm.js`.