### PR TITLE
Fix `new.target` checks

### DIFF
--- a/src/completion.mjs
+++ b/src/completion.mjs
@@ -11,16 +11,16 @@ import { resume } from './helpers.mjs';
 
 // #sec-completion-record-specification-type
 export function Completion(init) {
-  if (new.target === Completion) {
-    this.Type = init.Type;
-    this.Value = init.Value;
-    this.Target = init.Target;
-  } else {
+  if (new.target === undefined) {
     // 1. Assert: completionRecord is a Completion Record.
     Assert(init instanceof Completion);
     // 2. Return completionRecord as the Completion Record of this abstract operation.
     return init;
   }
+
+  this.Type = init.Type;
+  this.Value = init.Value;
+  this.Target = init.Target;
 }
 
 // NON-SPEC

--- a/src/value.mjs
+++ b/src/value.mjs
@@ -747,16 +747,16 @@ export class SuperReference extends Reference {
 }
 
 export function Descriptor(O) {
-  if (new.target === Descriptor) {
-    this.Value = O.Value;
-    this.Get = O.Get;
-    this.Set = O.Set;
-    this.Writable = O.Writable;
-    this.Enumerable = O.Enumerable;
-    this.Configurable = O.Configurable;
-  } else {
+  if (new.target === undefined) {
     return new Descriptor(O);
   }
+
+  this.Value = O.Value;
+  this.Get = O.Get;
+  this.Set = O.Set;
+  this.Writable = O.Writable;
+  this.Enumerable = O.Enumerable;
+  this.Configurable = O.Configurable;
 }
 
 Descriptor.prototype.everyFieldIsAbsent = function everyFieldIsAbsent() {


### PR DESCRIPTION
Using `new.target === Constructor` causes cases where:
```js
new.target !== undefined && new.target !== Constructor
```
to behave as a normal `[[Call]]`, rather than a `[[Construct]]`.