### PR TITLE
Use `Array` subclass for `agent.executionContextStack`

### DIFF
--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -53,6 +53,22 @@ export const FEATURES = Object.freeze([
   },
 ].map(Object.freeze));
 
+class ExecutionContextStack extends Array {
+  // This ensures that only the length taking overload is supported.
+  // This is necessary to support `ArraySpeciesCreate`, which invokes
+  // the constructor with argument `length`:
+  constructor(length = 0) {
+    super(+length);
+  }
+
+  pop(ctx) {
+    if (!ctx.poppedForTailCall) {
+      const popped = super.pop();
+      Assert(popped === ctx);
+    }
+  }
+}
+
 let agentSignifier = 0;
 // #sec-agents
 export class Agent {
@@ -71,14 +87,7 @@ export class Agent {
     };
 
     // #execution-context-stack
-    this.executionContextStack = [];
-    const stackPop = this.executionContextStack.pop;
-    this.executionContextStack.pop = function pop(ctx) {
-      if (!ctx.poppedForTailCall) {
-        const popped = stackPop.call(this);
-        Assert(popped === ctx);
-      }
-    };
+    this.executionContextStack = new ExecutionContextStack();
 
     // NON-SPEC
     this.jobQueue = [];

--- a/test/supplemental.js
+++ b/test/supplemental.js
@@ -256,6 +256,13 @@ Error: owo
     `);
     assert.strictEqual(result.Value, Value.undefined);
   },
+  () => {
+    const agent1 = new Agent();
+    const agent2 = new Agent();
+
+    assert.strictEqual(agent1.executionContextStack.pop, agent2.executionContextStack.pop,
+      "The 'agent.executionContextStack.pop' method is identical for every execution context stack.");
+  },
 ].forEach((test) => {
   total();
   try {


### PR DESCRIPTION
This has the primary benefit that the `Agent` constructor doesn’t create a new closure for `executionContextStack.pop` for every `Agent` instance.