### PR TITLE
Use `loose` class properties where possible

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,11 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2020,
     requireConfigFile: false,
+    babelOptions: {
+      plugins: [
+        '@babel/plugin-syntax-class-properties',
+      ],
+    },
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "devDependencies": {
     "@babel/core": "^7.11.6",
     "@babel/eslint-parser": "^7.11.5",
+    "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",
+    "@babel/plugin-syntax-class-properties": "^7.12.1",
     "@engine262/eslint-plugin": "file:./test/eslint-plugin-engine262",
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-commonjs": "^14.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,6 +28,9 @@ module.exports = () => ({
       exclude: 'node_modules/**',
       plugins: [
         '@babel/plugin-proposal-optional-chaining',
+        ['@babel/plugin-proposal-class-properties', {
+          loose: true,
+        }],
         './scripts/transform.js',
       ],
     }),

--- a/src/abstract-ops/promise-operations.mjs
+++ b/src/abstract-ops/promise-operations.mjs
@@ -34,11 +34,9 @@ import {
 
 // 25.6.1.1 #sec-promisecapability-records
 export class PromiseCapabilityRecord {
-  constructor() {
-    this.Promise = Value.undefined;
-    this.Resolve = Value.undefined;
-    this.Reject = Value.undefined;
-  }
+  Promise = Value.undefined;
+  Resolve = Value.undefined;
+  Reject = Value.undefined;
 }
 
 // 25.6.1.2 #sec-promisereaction-records

--- a/src/abstract-ops/realms.mjs
+++ b/src/abstract-ops/realms.mjs
@@ -87,15 +87,13 @@ import {
 
 // 8.2 #sec-code-realms
 export class Realm {
-  constructor() {
-    this.Intrinsics = undefined;
-    this.GlobalObject = undefined;
-    this.GlobalEnv = undefined;
-    this.TemplateMap = undefined;
-    this.HostDefined = undefined;
+  Intrinsics = undefined;
+  GlobalObject = undefined;
+  GlobalEnv = undefined;
+  TemplateMap = undefined;
+  HostDefined = undefined;
 
-    this.randomState = undefined;
-  }
+  randomState = undefined;
 
   mark(m) {
     m(this.GlobalObject);

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -174,19 +174,18 @@ export function setSurroundingAgent(a) {
 
 // #sec-execution-contexts
 export class ExecutionContext {
-  constructor() {
-    this.codeEvaluationState = undefined;
-    this.Function = undefined;
-    this.Realm = undefined;
-    this.ScriptOrModule = undefined;
-    this.VariableEnvironment = undefined;
-    this.LexicalEnvironment = undefined;
+  codeEvaluationState = undefined;
+  Function = undefined;
+  Realm = undefined;
+  ScriptOrModule = undefined;
+  VariableEnvironment = undefined;
+  LexicalEnvironment = undefined;
 
-    // NON-SPEC
-    this.callSite = new CallSite(this);
-    this.promiseCapability = undefined;
-    this.poppedForTailCall = false;
-  }
+  // NON-SPEC
+  HostDefined = undefined;
+  callSite = new CallSite(this);
+  promiseCapability = undefined;
+  poppedForTailCall = false;
 
   copy() {
     const e = new ExecutionContext();

--- a/src/environment.mjs
+++ b/src/environment.mjs
@@ -25,9 +25,7 @@ import { ValueMap } from './helpers.mjs';
 
 // #sec-environment-records
 export class EnvironmentRecord {
-  constructor() {
-    this.OuterEnv = undefined;
-  }
+  OuterEnv = undefined;
 
   // NON-SPEC
   mark(m) {
@@ -37,10 +35,7 @@ export class EnvironmentRecord {
 
 // #sec-declarative-environment-records
 export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
-  constructor() {
-    super();
-    this.bindings = new ValueMap();
-  }
+  bindings = new ValueMap()
 
   // #sec-declarative-environment-records-hasbinding-n
   HasBinding(N) {
@@ -361,13 +356,10 @@ export class ObjectEnvironmentRecord extends EnvironmentRecord {
 
 // #sec-function-environment-records
 export class FunctionEnvironmentRecord extends DeclarativeEnvironmentRecord {
-  constructor() {
-    super();
-    this.ThisValue = undefined;
-    this.ThisBindingStatus = undefined;
-    this.FunctionObject = undefined;
-    this.NewTarget = undefined;
-  }
+  ThisValue = undefined;
+  ThisBindingStatus = undefined;
+  FunctionObject = undefined;
+  NewTarget = undefined;
 
   // #sec-bindthisvalue
   BindThisValue(V) {
@@ -453,13 +445,10 @@ export class FunctionEnvironmentRecord extends DeclarativeEnvironmentRecord {
 
 // #sec-global-environment-records
 export class GlobalEnvironmentRecord extends EnvironmentRecord {
-  constructor() {
-    super();
-    this.ObjectRecord = undefined;
-    this.GlobalThisValue = undefined;
-    this.DeclarativeRecord = undefined;
-    this.VarNames = undefined;
-  }
+  ObjectRecord = undefined;
+  GlobalThisValue = undefined;
+  DeclarativeRecord = undefined;
+  VarNames = undefined;
 
   // #sec-global-environment-records-hasbinding-n
   HasBinding(N) {

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -20,9 +20,7 @@ function convertValueForKey(key) {
 }
 
 export class ValueMap {
-  constructor() {
-    this.map = new Map();
-  }
+  map = new Map();
 
   get size() {
     return this.map.size;
@@ -80,8 +78,9 @@ export class ValueMap {
 }
 
 export class ValueSet {
+  set = new Set();
+
   constructor(init) {
-    this.set = new Set();
     if (init !== undefined && init !== null) {
       for (const item of init) {
         this.add(item);

--- a/src/parser/Lexer.mjs
+++ b/src/parser/Lexer.mjs
@@ -121,20 +121,18 @@ const SingleCharTokens = {
 };
 
 export class Lexer {
-  constructor() {
-    this.currentToken = undefined;
-    this.peekToken = undefined;
-    this.peekAheadToken = undefined;
+  currentToken = undefined;
+  peekToken = undefined;
+  peekAheadToken = undefined;
 
-    this.position = 0;
-    this.line = 1;
-    this.columnOffset = 0;
-    this.scannedValue = undefined;
-    this.lineTerminatorBeforeNextToken = false;
-    this.positionForNextToken = 0;
-    this.lineForNextToken = 0;
-    this.columnForNextToken = 0;
-  }
+  position = 0;
+  line = 1;
+  columnOffset = 0;
+  scannedValue = undefined;
+  lineTerminatorBeforeNextToken = false;
+  positionForNextToken = 0;
+  lineForNextToken = 0;
+  columnForNextToken = 0;
 
   advance() {
     this.lineTerminatorBeforeNextToken = false;

--- a/src/value.mjs
+++ b/src/value.mjs
@@ -40,6 +40,11 @@ export class Value {
         throw new OutOfRange('new Value', value);
     }
   }
+
+  static undefined = undefined;
+  static null = undefined;
+  static true = undefined;
+  static false = undefined;
 }
 
 export class PrimitiveValue extends Value {}
@@ -347,9 +352,9 @@ export class NumberValue extends PrimitiveValue {
     // TODO: implement properly
     return new Value(`${xVal}`);
   }
-}
 
-NumberValue.unit = new NumberValue(1);
+  static unit = new NumberValue(1);
+}
 
 // #sec-numberbitwiseop
 function NumberBitwiseOp(op, x, y) {
@@ -529,9 +534,9 @@ export class BigIntValue extends PrimitiveValue {
     // 2. Return the String value consisting of the code units of the digits of the decimal representation of x.
     return new Value(`${x.bigintValue()}`);
   }
-}
 
-BigIntValue.unit = new BigIntValue(1n);
+  static unit = new BigIntValue(1n);
+}
 
 /*
 // #sec-binaryand
@@ -653,10 +658,11 @@ function BigIntBitwiseOp(op, x, y) {
 
 // #sec-object-type
 export class ObjectValue extends Value {
+  properties = new ValueMap();
+
   constructor(internalSlotsList) {
     super();
 
-    this.properties = new ValueMap();
     this.internalSlotsList = internalSlotsList;
   }
 


### PR DESCRIPTION
This makes it so that the classes use the class property syntax instead of assigning the properties inside the class constructor in the source code where the emit doesn’t change.

---

Using native class properties will require bumping the minimum supported **Node.js** version to **12.0.0**.