### PR TITLE
Implement Object.hasOwn

### DIFF
--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -56,6 +56,11 @@ export const FEATURES = Object.freeze([
     flag: 'error-cause',
     url: 'github.com/tc39/proposal-error-cause',
   },
+  {
+    name: 'Accessible Object.prototype.hasOwnProperty',
+    flag: 'accessible-object-hasownproperty',
+    url: 'https://github.com/tc39/proposal-accessible-object-hasownproperty',
+  },
 ].map(Object.freeze));
 
 class ExecutionContextStack extends Array {

--- a/src/intrinsics/Object.mjs
+++ b/src/intrinsics/Object.mjs
@@ -294,7 +294,7 @@ function Object_getPrototypeOf([O = Value.undefined]) {
 
 // #sec-object.hasown
 function Object_hasOwn([O = Value.undefined, P = Value.undefined]) {
-  // 1. 1. Let obj be ? ToObject(O).
+  // 1. Let obj be ? ToObject(O).
   const obj = Q(ToObject(O));
   // 2. Let O be ? ToObject(this value).
   const key = Q(ToPropertyKey(P));

--- a/src/intrinsics/Object.mjs
+++ b/src/intrinsics/Object.mjs
@@ -298,7 +298,7 @@ function Object_hasOwn([O = Value.undefined, P = Value.undefined]) {
   const obj = Q(ToObject(O));
   // 2. Let O be ? ToObject(this value).
   const key = Q(ToPropertyKey(P));
-  // 3. 3. Return ? HasOwnProperty(obj, key).
+  // 3. Return ? HasOwnProperty(obj, key).
   return HasOwnProperty(obj, key);
 }
 

--- a/src/intrinsics/Object.mjs
+++ b/src/intrinsics/Object.mjs
@@ -426,7 +426,9 @@ export function bootstrapObject(realmRec) {
     ['getOwnPropertyNames', Object_getOwnPropertyNames, 1],
     ['getOwnPropertySymbols', Object_getOwnPropertySymbols, 1],
     ['getPrototypeOf', Object_getPrototypeOf, 1],
-    ['hasOwn', Object_hasOwn, 2],
+    surroundingAgent.feature('accessible-object-hasownproperty')
+      ? ['hasOwn', Object_hasOwn, 2]
+      : undefined,
     ['is', Object_is, 2],
     ['isExtensible', Object_isExtensible, 1],
     ['isFrozen', Object_isFrozen, 1],

--- a/src/intrinsics/Object.mjs
+++ b/src/intrinsics/Object.mjs
@@ -14,6 +14,7 @@ import {
   EnumerableOwnPropertyNames,
   FromPropertyDescriptor,
   Get,
+  HasOwnProperty,
   IsExtensible,
   OrdinaryObjectCreate,
   OrdinaryCreateFromConstructor,
@@ -291,6 +292,16 @@ function Object_getPrototypeOf([O = Value.undefined]) {
   return Q(obj.GetPrototypeOf());
 }
 
+// #sec-object.hasown
+function Object_hasOwn([O = Value.undefined, P = Value.undefined]) {
+  // 1. 1. Let obj be ? ToObject(O).
+  const obj = Q(ToObject(O));
+  // 2. Let O be ? ToObject(this value).
+  const key = Q(ToPropertyKey(P));
+  // 3. 3. Return ? HasOwnProperty(obj, key).
+  return HasOwnProperty(obj, key);
+}
+
 // #sec-object.is
 function Object_is([value1 = Value.undefined, value2 = Value.undefined]) {
   // 1. Return SameValue(value1, value2).
@@ -415,6 +426,7 @@ export function bootstrapObject(realmRec) {
     ['getOwnPropertyNames', Object_getOwnPropertyNames, 1],
     ['getOwnPropertySymbols', Object_getOwnPropertySymbols, 1],
     ['getPrototypeOf', Object_getPrototypeOf, 1],
+    ['hasOwn', Object_hasOwn, 2],
     ['is', Object_is, 2],
     ['isExtensible', Object_isExtensible, 1],
     ['isFrozen', Object_isFrozen, 1],

--- a/src/intrinsics/Object.mjs
+++ b/src/intrinsics/Object.mjs
@@ -292,7 +292,7 @@ function Object_getPrototypeOf([O = Value.undefined]) {
   return Q(obj.GetPrototypeOf());
 }
 
-// #sec-object.hasown
+// https://tc39.es/proposal-accessible-object-hasownproperty/#sec-object.hasown
 function Object_hasOwn([O = Value.undefined, P = Value.undefined]) {
   // 1. Let obj be ? ToObject(O).
   const obj = Q(ToObject(O));

--- a/test/test262/features
+++ b/test/test262/features
@@ -19,8 +19,6 @@
 -class-static-fields-private
 -class-static-methods-private
 
--Object.hasOwn
-
 -json-modules
 -import-assertions
 

--- a/test/test262/features
+++ b/test/test262/features
@@ -45,4 +45,4 @@ arbitrary-module-namespace-names = arbitrary-module-namespace-names
 error-cause = error-cause
 
 # https://github.com/tc39/proposal-accessible-object-hasownproperty
-Object.hasOwn
+Object.hasOwn = accessible-object-hasownproperty

--- a/test/test262/features
+++ b/test/test262/features
@@ -45,3 +45,6 @@ arbitrary-module-namespace-names = arbitrary-module-namespace-names
 
 # https://github.com/tc39/proposal-error-cause
 error-cause = error-cause
+
+# https://github.com/tc39/proposal-accessible-object-hasownproperty
+Object.hasOwn


### PR DESCRIPTION
This proposal just reached stage 3: https://github.com/tc39/proposal-accessible-object-hasownproperty

Spec: https://tc39.es/proposal-accessible-object-hasownproperty/

> ### Object.hasOwn ( _O_, _P_ )
> 
> When the hasOwn method is called, the following steps are taken:
> 
> 1. Let _obj_ be ? ToObject(_O_).
> 1. Let _key_ be ? ToPropertyKey(_P_). 
> 1. Return ? HasOwnProperty(_obj_, _key_).