### PR TITLE
MemberExpression `[` Expression `]` should include both brackets

### DIFF
--- a/src/parser/ExpressionParser.mjs
+++ b/src/parser/ExpressionParser.mjs
@@ -547,8 +547,8 @@ export class ExpressionParser extends FunctionParser {
           node.MemberExpression = result;
           node.IdentifierName = null;
           node.Expression = this.parseExpression();
-          result = this.finishNode(node, 'MemberExpression');
           this.expect(Token.RBRACK);
+          result = this.finishNode(node, 'MemberExpression');
           break;
         }
         case Token.PERIOD:


### PR DESCRIPTION
The node was finished before the closing `]`, which I think is not correct.