### PR TITLE
lexer: return scannedValue for any value-less token

### DIFF
--- a/src/parser/Lexer.mjs
+++ b/src/parser/Lexer.mjs
@@ -3,9 +3,9 @@ import isUnicodeIDContinueRegex from '@unicode/unicode-13.0.0/Binary_Property/ID
 import isSpaceSeparatorRegex from '@unicode/unicode-13.0.0/General_Category/Space_Separator/regex.js';
 import { UTF16SurrogatePairToCodePoint } from '../static-semantics/all.mjs';
 import {
-  RawTokens,
   Token,
   TokenNames,
+  TokenValues,
   KeywordLookup,
   isKeywordRaw,
 } from './tokens.mjs';
@@ -150,14 +150,7 @@ export class Lexer {
       column: this.columnForNextToken,
       hadLineTerminatorBefore: this.lineTerminatorBeforeNextToken,
       name: TokenNames[type],
-      value: (
-        type === Token.IDENTIFIER
-        || type === Token.NUMBER
-        || type === Token.BIGINT
-        || type === Token.STRING
-        || type === Token.ESCAPED_KEYWORD
-        || type === Token.PRIVATE_IDENTIFIER
-      ) ? this.scannedValue : RawTokens[type][1],
+      value: TokenValues[type] ?? this.scannedValue,
       escaped: this.escapeIndex !== -1,
     };
   }

--- a/src/parser/tokens.mjs
+++ b/src/parser/tokens.mjs
@@ -147,6 +147,8 @@ export const Token = RawTokens
 
 export const TokenNames = RawTokens.map((r) => r[0]);
 
+export const TokenValues = RawTokens.map((r) => r[1]);
+
 export const TokenPrecedence = RawTokens.map((r) => (r[2] || 0));
 
 const Keywords = RawTokens


### PR DESCRIPTION
Ensure that `Lexer.advance` returns the `scannedValue` of any token without a fixed value, so that one doesn't need to edit that function whenever adding such a token type.
