### PR TITLE
fix `new Symbol("x")` error message

### DIFF
--- a/src/intrinsics/Symbol.mjs
+++ b/src/intrinsics/Symbol.mjs
@@ -21,7 +21,7 @@ export const GlobalSymbolRegistry = [];
 function SymbolConstructor([description = Value.undefined], { NewTarget }) {
   // 1. If NewTarget is not undefined, throw a TypeError exception.
   if (NewTarget !== Value.undefined) {
-    return surroundingAgent.Throw('TypeError', 'ConstructorNonCallable', this);
+    return surroundingAgent.Throw('TypeError', 'NotAConstructor', this);
   }
   // 2. If description is undefined, let descString be undefined.
   let descString;


### PR DESCRIPTION
Changed from:
```
> new Symbol('asdf')
TypeError: [Function: Symbol] cannot be invoked without new
    at new Symbol (native)
    at (engine262):1:12
```

to:
```
> new Symbol('adsf')
TypeError: [Function: Symbol] is not a constructor
    at new Symbol (native)
    at (engine262):1:12
```
