### PR TITLE
Update Test262 feature flag name

### DIFF
--- a/test/test262/features
+++ b/test/test262/features
@@ -31,7 +31,7 @@ hashbang = hashbang
 regexp-match-indices = regexp-match-indices
 
 # https://github.com/tc39/proposal-cleanup-some
-cleanupSome = cleanup-some
+FinalizationRegistry.prototype.cleanupSome = cleanup-some
 
 # https://github.com/tc39/proposal-item-method/
 Array.prototype.at = at-method


### PR DESCRIPTION
The feature flag named `cleanupSome` is planned to be removed in favor
of the flag named `FinalizationRegistry.prototype.cleanupSome`

https://github.com/tc39/test262/pull/2892