### PR TITLE
Update and unflag “Arbitrary Module Namespace Identifier Names”

### DIFF
--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -42,11 +42,6 @@ export const FEATURES = Object.freeze([
     url: 'https://github.com/tc39/proposal-cleanup-some',
   },
   {
-    name: 'Arbitrary Module Namespace Names',
-    flag: 'arbitrary-module-namespace-names',
-    url: 'https://github.com/tc39/ecma262/pull/2154',
-  },
-  {
     name: 'At Method',
     flag: 'at-method',
     url: 'https://github.com/tc39/proposal-item-method',

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -6,9 +6,6 @@ import { X, AwaitFulfilledFunctions } from './completion.mjs';
 export const kInternal = Symbol('kInternal');
 
 function convertValueForKey(key) {
-  if (typeof key === 'string') {
-    return Symbol.for(`engine262_helper_key_${key}`);
-  }
   switch (Type(key)) {
     case 'String':
       return key.stringValue();

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -34,7 +34,7 @@ import { Evaluate } from './evaluator.mjs';
 export class ResolvedBindingRecord {
   constructor({ Module, BindingName }) {
     Assert(Module instanceof AbstractModuleRecord);
-    Assert(BindingName === 'namespace' || BindingName === 'default' || Type(BindingName) === 'String');
+    Assert(BindingName === 'namespace' || Type(BindingName) === 'String');
     this.Module = Module;
     this.BindingName = BindingName;
   }
@@ -288,8 +288,8 @@ export class SourceTextModuleRecord extends CyclicModuleRecord {
       if (SameValue(exportName, e.ExportName) === Value.true) {
         // i. Let importedModule be ? HostResolveImportedModule(module, e.[[ModuleRequest]]).
         const importedModule = Q(HostResolveImportedModule(module, e.ModuleRequest));
-        // ii. If e.[[ImportName]] is ~star~, then
-        if (e.ImportName === 'star') {
+        // ii. If e.[[ImportName]] is ~all~, then
+        if (e.ImportName === 'all') {
           // 1. Assert: module does not provide the direct binding for this export
           // 2. Return ResolvedBinding Record { [[Module]]: importedModule, [[BindingName]]: ~namespace~ }.
           return new ResolvedBindingRecord({
@@ -377,8 +377,8 @@ export class SourceTextModuleRecord extends CyclicModuleRecord {
       // a. Let importedModule be ! HostResolveImportedModule(module, in.[[ModuleRequest]]).
       const importedModule = X(HostResolveImportedModule(module, ie.ModuleRequest));
       // b. NOTE: The above call cannot fail because imported module requests are a subset of module.[[RequestedModules]], and these have been resolved earlier in this algorithm.
-      // c. If in.[[ImportName]] is ~star~, then
-      if (ie.ImportName === 'star') {
+      // c. If in.[[ImportName]] is ~namespace-object~, then
+      if (ie.ImportName === 'namespace-object') {
         // i. Let namespace be ? GetModuleNamespace(importedModule).
         const namespace = Q(GetModuleNamespace(importedModule));
         // ii. Perform ! env.CreateImmutableBinding(in.[[LocalName]], true).

--- a/src/parse.mjs
+++ b/src/parse.mjs
@@ -116,8 +116,8 @@ export function ParseModule(sourceText, realm, hostDefined = {}) {
       } else { // ii. Else,
         // 1. Let ie be the element of importEntries whose [[LocalName]] is the same as ee.[[LocalName]].
         const ie = importEntries.find((e) => e.LocalName.stringValue() === ee.LocalName.stringValue());
-        // 2. If ie.[[ImportName]] is ~star~, then
-        if (ie.ImportName === 'star') {
+        // 2. If ie.[[ImportName]] is ~namespace-object~, then
+        if (ie.ImportName === 'namespace-object') {
           // a. NOTE: This is a re-export of an imported module namespace object.
           // b. Append ee to localExportEntries.
           localExportEntries.push(ee);
@@ -132,7 +132,7 @@ export function ParseModule(sourceText, realm, hostDefined = {}) {
           });
         }
       }
-    } else if (ee.ImportName && ee.ImportName === 'star' && ee.ExportName === Value.null) { // b. Else if ee.[[ImportName]] is ~star~ and ee.[[ExportName]] is null, then
+    } else if (ee.ImportName && ee.ImportName === 'all-but-default' && ee.ExportName === Value.null) { // b. Else if ee.[[ImportName]] is ~all-but-default~ and ee.[[ExportName]] is null, then
       // i. Append ee to starExportEntries.
       starExportEntries.push(ee);
     } else { // c. Else,

--- a/src/runtime-semantics/BindingInitialization.mjs
+++ b/src/runtime-semantics/BindingInitialization.mjs
@@ -18,8 +18,8 @@ import {
 
 // #sec-initializeboundname
 export function InitializeBoundName(name, value, environment) {
-  // 1. Assert: Either Type(name) is String or name is ~default~.
-  Assert(name === 'default' || Type(name) === 'String');
+  // 1. Assert: Type(name) is String.
+  Assert(Type(name) === 'String');
   // 2. If environment is not undefined, then
   if (environment !== Value.undefined) {
     // a. Perform environment.InitializeBinding(name, value).

--- a/src/runtime-semantics/ExportDeclaration.mjs
+++ b/src/runtime-semantics/ExportDeclaration.mjs
@@ -55,12 +55,12 @@ export function* Evaluate_ExportDeclaration(ExportDeclaration) {
     const value = Q(yield* BindingClassDeclarationEvaluation(ClassDeclaration));
     // 2. Let className be the sole element of BoundNames of ClassDeclaration.
     const className = BoundNames(ClassDeclaration)[0];
-    // If className is ~default~, then
-    if (className === 'default') {
+    // If className is "*default*", then
+    if (className.stringValue() === '*default*') {
       // a. Let env be the running execution context's LexicalEnvironment.
       const env = surroundingAgent.runningExecutionContext.LexicalEnvironment;
-      // b. Perform ? InitializeBoundName(~default~, value, env).
-      Q(InitializeBoundName('default', value, env));
+      // b. Perform ? InitializeBoundName("*default*", value, env).
+      Q(InitializeBoundName(new Value('*default*'), value, env));
     }
     // 3. Return NormalCompletion(empty).
     return NormalCompletion(undefined);
@@ -79,8 +79,8 @@ export function* Evaluate_ExportDeclaration(ExportDeclaration) {
     }
     // 3. Let env be the running execution context's LexicalEnvironment.
     const env = surroundingAgent.runningExecutionContext.LexicalEnvironment;
-    // 4. Perform ? InitializeBoundName(~default~, value, env).
-    Q(InitializeBoundName('default', value, env));
+    // 4. Perform ? InitializeBoundName("*default*", value, env).
+    Q(InitializeBoundName(new Value('*default*'), value, env));
     // 5. Return NormalCompletion(empty).
     return NormalCompletion(undefined);
   }

--- a/src/static-semantics/BoundNames.mjs
+++ b/src/static-semantics/BoundNames.mjs
@@ -1,4 +1,5 @@
 import { OutOfRange } from '../helpers.mjs';
+import { Value } from '../value.mjs';
 import { StringValue } from './all.mjs';
 
 export function BoundNames(node) {
@@ -41,7 +42,7 @@ export function BoundNames(node) {
       if (node.BindingIdentifier) {
         return BoundNames(node.BindingIdentifier);
       }
-      return ['default'];
+      return [new Value('*default*')];
     case 'ImportSpecifier':
       return BoundNames(node.ImportedBinding);
     case 'ExportDeclaration':
@@ -63,7 +64,7 @@ export function BoundNames(node) {
         return declarationNames;
       }
       if (node.AssignmentExpression) {
-        return ['default'];
+        return [new Value('*default*')];
       }
       throw new OutOfRange('BoundNames', node);
     case 'SingleNameBinding':

--- a/src/static-semantics/ExportEntries.mjs
+++ b/src/static-semantics/ExportEntries.mjs
@@ -100,11 +100,11 @@ export function ExportEntries(node) {
         }
         case node.default && !!node.AssignmentExpression: {
           // `export` `default` AssignmentExpression `;`
-          // 1. Let entry be the ExportEntry Record { [[ModuleRequest]]: null, [[ImportName]]: null, [[LocalName]]: ~default~, [[ExportName]]: "default" }.
+          // 1. Let entry be the ExportEntry Record { [[ModuleRequest]]: null, [[ImportName]]: null, [[LocalName]]: "*default*", [[ExportName]]: "default" }.
           const entry = {
             ModuleRequest: Value.null,
             ImportName: Value.null,
-            LocalName: 'default',
+            LocalName: new Value('*default*'),
             ExportName: new Value('default'),
           };
           // 2. Return a new List containing entry.

--- a/src/static-semantics/ExportEntriesForModule.mjs
+++ b/src/static-semantics/ExportEntriesForModule.mjs
@@ -12,35 +12,23 @@ export function ExportEntriesForModule(node, module) {
   }
   switch (node.type) {
     case 'ExportFromClause':
-      if (node.IdentifierName) {
-        // 1. Let exportName be the StringValue of IdentifierName.
-        const exportName = StringValue(node.IdentifierName);
-        // 2. Let entry be the ExportEntry Record { [[ModuleRequest]]: module, [[ImportName]]: ~star~, [[LocalName]]: null, [[ExportName]]: exportName }.
-        const entry = {
-          ModuleRequest: module,
-          ImportName: 'star',
-          LocalName: Value.null,
-          ExportName: exportName,
-        };
-        // 3. Return a new List containing entry.
-        return [entry];
-      } else if (node.ModuleExportName) {
+      if (node.ModuleExportName) {
         // 1. Let exportName be the StringValue of ModuleExportName.
         const exportName = StringValue(node.ModuleExportName);
-        // 2. Let entry be the ExportEntry Record { [[ModuleRequest]]: module, [[ImportName]]: ~star~, [[LocalName]]: null, [[ExportName]]: exportName }.
+        // 2. Let entry be the ExportEntry Record { [[ModuleRequest]]: module, [[ImportName]]: ~all~, [[LocalName]]: null, [[ExportName]]: exportName }.
         const entry = {
           ModuleRequest: module,
-          ImportName: 'star',
+          ImportName: 'all',
           LocalName: Value.null,
           ExportName: exportName,
         };
         // 3. Return a new List containing entry.
         return [entry];
       } else {
-        // 1. Let entry be the ExportEntry Record { [[ModuleRequest]]: module, [[ImportName]]: ~star~, [[LocalName]]: null, [[ExportName]]: null }.
+        // 1. Let entry be the ExportEntry Record { [[ModuleRequest]]: module, [[ImportName]]: ~all-but-default~, [[LocalName]]: null, [[ExportName]]: null }.
         const entry = {
           ModuleRequest: module,
-          ImportName: 'star',
+          ImportName: 'all-but-default',
           LocalName: Value.null,
           ExportName: Value.null,
         };

--- a/src/static-semantics/ImportEntriesForModule.mjs
+++ b/src/static-semantics/ImportEntriesForModule.mjs
@@ -46,10 +46,10 @@ export function ImportEntriesForModule(node, module) {
     case 'NameSpaceImport': {
       // 1. Let localName be the StringValue of ImportedBinding.
       const localName = StringValue(node.ImportedBinding);
-      // 2. Let entry be the ImportEntry Record { [[ModuleRequest]]: module, [[ImportName]]: ~star~, [[LocalName]]: localName }.
+      // 2. Let entry be the ImportEntry Record { [[ModuleRequest]]: module, [[ImportName]]: ~namespace-object~, [[LocalName]]: localName }.
       const entry = {
         ModuleRequest: module,
-        ImportName: 'star',
+        ImportName: 'namespace-object',
         LocalName: localName,
       };
       // 3. Return a new List containing entry.
@@ -63,20 +63,7 @@ export function ImportEntriesForModule(node, module) {
       return specs;
     }
     case 'ImportSpecifier':
-      if (node.IdentifierName) {
-        // 1. Let importName be the StringValue of IdentifierName.
-        const importName = StringValue(node.IdentifierName);
-        // 2. Let localName be the StringValue of ImportedBinding.
-        const localName = StringValue(node.ImportedBinding);
-        // 3. Let entry be the ImportEntry Record { [[ModuleRequest]]: module, [[ImportName]]: importName, [[LocalName]]: localName }.
-        const entry = {
-          ModuleRequest: module,
-          ImportName: importName,
-          LocalName: localName,
-        };
-        // 4. Return a new List containing entry.
-        return [entry];
-      } else if (node.ModuleExportName) {
+      if (node.ModuleExportName) {
         // 1. Let importName be the StringValue of ModuleExportName.
         const importName = StringValue(node.ModuleExportName);
         // 2. Let localName be the StringValue of ImportedBinding.

--- a/src/static-semantics/IsStringWellFormedUnicode.mjs
+++ b/src/static-semantics/IsStringWellFormedUnicode.mjs
@@ -7,7 +7,7 @@ export function IsStringWellFormedUnicode(string) {
   const strLen = string.length;
   // 2. Let k be 0.
   let k = 0;
-  // 3. Repeat, while k does not equal strLen,
+  // 3. Repeat, while k ≠ strLen,
   while (k !== strLen) {
     // a. Let cp be ! CodePointAt(string, k).
     const cp = X(CodePointAt(string, k));


### PR DESCRIPTION
This updates and unflags the implementation of “**Arbitrary Module Namespace Identifier Names**” to the ~~latest draft~~ merged version of <https://github.com/tc39/ecma262/pull/2154> and includes the changes in <https://github.com/tc39/ecma262/pull/2566>, which superseded <https://github.com/tc39/ecma262/pull/2155>.