### PR TITLE
Use abstract closures for most invocations of `CreateBuiltinFunction`

### DIFF
--- a/src/abstract-ops/arguments-operations.mjs
+++ b/src/abstract-ops/arguments-operations.mjs
@@ -149,58 +149,27 @@ export function CreateUnmappedArgumentsObject(argumentsList) {
   return obj;
 }
 
-function ArgGetterSteps() {
-  // 1. Let f be the active function object.
-  const f = this;
-  // 2. Let name be f.[[Name]].
-  const name = f.Name;
-  // 3. Let env be f.[[Env]].
-  const env = f.Env;
-  // 4. Return env.GetBindingValue(name, false).
-  return env.GetBindingValue(name, Value.false);
-}
-
 // 9.4.4.7.1 #sec-makearggetter
 function MakeArgGetter(name, env) {
-  // 1. Let steps be the steps of an ArgGetter function as specified below.
-  const steps = ArgGetterSteps;
-  // 2. Let length be the number of non-optional parameters of an ArgGetter function as specified below.
-  const length = 0;
-  // 3. Let getter be ! CreateBuiltinFunction(steps, length, "", « [[Name]], [[Env]] »).
-  const getter = X(CreateBuiltinFunction(steps, length, new Value(''), ['Name', 'Env']));
-  // 4. Set getter.[[Name]] to name.
-  getter.Name = name;
-  // 5. Set getter.[[Env]] to env.
-  getter.Env = env;
-  // 6. Return getter.
+  // 1. Let getterClosure be a new Abstract Closure with no parameters that captures name and env and performs the following steps when called:
+  //   a. Return env.GetBindingValue(name, false).
+  const getterClosure = () => env.GetBindingValue(name, false);
+  // 2. Let getter be ! CreateBuiltinFunction(getterClosure, 0, "", « »).
+  const getter = X(CreateBuiltinFunction(getterClosure, 0, new Value(''), ['Name', 'Env']));
+  // 3. NOTE: getter is never directly accessible to ECMAScript code.
+  // 4. Return getter.
   return getter;
-}
-
-function ArgSetterSteps([value]) {
-  Assert(value !== undefined);
-  // 1. Let f be the active function object.
-  const f = this;
-  // 2. Let name be f.[[Name]].
-  const name = f.Name;
-  // 3. Let env be f.[[Env]].
-  const env = f.Env;
-  // 4. Return env.SetMutableBinding(name, value, false).
-  return env.SetMutableBinding(name, value, Value.false);
 }
 
 // 9.4.4.7.2 #sec-makeargsetter
 function MakeArgSetter(name, env) {
-  // 1. Let steps be the steps of an ArgSetter function as specified below.
-  const steps = ArgSetterSteps;
-  // 2. Let length be the number of non-optional parameters of an ArgSetter function as specified below.
-  const length = 1;
-  // 3. Let setter be ! CreateBuiltinFunction(steps, length, "", « [[Name]], [[Env]] »).
-  const setter = X(CreateBuiltinFunction(steps, length, new Value(''), ['Name', 'Env']));
-  // 4. Set setter.[[Name]] to name.
-  setter.Name = name;
-  // 5. Set setter.[[Env]] to env.
-  setter.Env = env;
-  // 6. Return setter.
+  // 1. Let setterClosure be a new Abstract Closure with parameters (value) that captures name and env and performs the following steps when called:
+  //   a. Return env.SetMutableBinding(name, value, false).
+  const setterClosure = ([value = Value.undefined]) => env.SetMutableBinding(name, value, false);
+  // 2. Let setter be ! CreateBuiltinFunction(setterClosure, 1, "", « »).
+  const setter = X(CreateBuiltinFunction(setterClosure, 1, new Value(''), ['Name', 'Env']));
+  // 3. NOTE: setter is never directly accessible to ECMAScript code.
+  // 4. Return setter.
   return setter;
 }
 

--- a/src/completion.mjs
+++ b/src/completion.mjs
@@ -6,7 +6,7 @@ import {
   PromiseResolve,
 } from './abstract-ops/all.mjs';
 import { Value } from './value.mjs';
-import { resume } from './helpers.mjs';
+import { kAsyncContext, resume } from './helpers.mjs';
 
 // #sec-completion-record-specification-type
 export function Completion(init) {
@@ -68,7 +68,7 @@ export function UpdateEmpty(completionRecord, value) {
 }
 
 // #sec-returnifabrupt
-export function ReturnIfAbrupt() {
+export function ReturnIfAbrupt(_completion) {
   /* c8 skip next */
   throw new TypeError('ReturnIfAbrupt requires build');
 }
@@ -77,13 +77,13 @@ export function ReturnIfAbrupt() {
 export const Q = ReturnIfAbrupt;
 
 // #sec-returnifabrupt-shorthands ! OperationName()
-export function X() {
+export function X(_completion) {
   /* c8 skip next */
   throw new TypeError('X() requires build');
 }
 
 // 25.6.1.1.1 #sec-ifabruptrejectpromise
-export function IfAbruptRejectPromise() {
+export function IfAbruptRejectPromise(_value, _capability) {
   /* c8 skip next */
   throw new TypeError('IfAbruptRejectPromise requires build');
 }
@@ -95,41 +95,52 @@ export function EnsureCompletion(val) {
   return NormalCompletion(val);
 }
 
-export function AwaitFulfilledFunctions([value]) {
-  const F = surroundingAgent.activeFunctionObject;
-  const asyncContext = F.AsyncContext;
-  const prevContext = surroundingAgent.runningExecutionContext;
-  // Suspend prevContext
-  surroundingAgent.executionContextStack.push(asyncContext);
-  resume(asyncContext, NormalCompletion(value));
-  Assert(surroundingAgent.runningExecutionContext === prevContext);
-  return Value.undefined;
-}
-
-function AwaitRejectedFunctions([reason]) {
-  const F = surroundingAgent.activeFunctionObject;
-  const asyncContext = F.AsyncContext;
-  const prevContext = surroundingAgent.runningExecutionContext;
-  // Suspend prevContext
-  surroundingAgent.executionContextStack.push(asyncContext);
-  resume(asyncContext, ThrowCompletion(reason));
-  Assert(surroundingAgent.runningExecutionContext === prevContext);
-  return Value.undefined;
-}
-
 export function* Await(value) {
+  // 1. Let asyncContext be the running execution context.
   const asyncContext = surroundingAgent.runningExecutionContext;
+  // 2. Let promise be ? PromiseResolve(%Promise%, value).
   const promise = Q(PromiseResolve(surroundingAgent.intrinsic('%Promise%'), value));
-  const stepsFulfilled = AwaitFulfilledFunctions;
-  const lengthFulfilled = 1;
-  const onFulfilled = X(CreateBuiltinFunction(stepsFulfilled, lengthFulfilled, new Value(''), ['AsyncContext']));
-  onFulfilled.AsyncContext = asyncContext;
-  const stepsRejected = AwaitRejectedFunctions;
-  const lengthRejected = 1;
-  const onRejected = X(CreateBuiltinFunction(stepsRejected, lengthRejected, new Value(''), ['AsyncContext']));
-  onRejected.AsyncContext = asyncContext;
+  // 3. Let fulfilledClosure be a new Abstract Closure with parameters (value) that captures asyncContext and performs the following steps when called:
+  const fulfilledClosure = ([valueInner = Value.undefined]) => {
+    // a. Let prevContext be the running execution context.
+    const prevContext = surroundingAgent.runningExecutionContext;
+    // b. Suspend prevContext.
+    // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
+    surroundingAgent.executionContextStack.push(asyncContext);
+    // d. Resume the suspended evaluation of asyncContext using NormalCompletion(value) as the result of the operation that suspended it.
+    resume(asyncContext, NormalCompletion(valueInner));
+    // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and prevContext is the currently running execution context.
+    Assert(surroundingAgent.runningExecutionContext === prevContext);
+    // f. Return undefined.
+    return Value.undefined;
+  };
+  // 4. Let onFulfilled be ! CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
+  const onFulfilled = X(CreateBuiltinFunction(fulfilledClosure, 1, new Value(''), []));
+  onFulfilled[kAsyncContext] = asyncContext;
+  // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the following steps when called:
+  const rejectedClosure = ([reason = Value.undefined]) => {
+    // a. Let prevContext be the running execution context.
+    const prevContext = surroundingAgent.runningExecutionContext;
+    // b. Suspend prevContext.
+    // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
+    surroundingAgent.executionContextStack.push(asyncContext);
+    // d. Resume the suspended evaluation of asyncContext using ThrowCompletion(reason) as the result of the operation that suspended it.
+    resume(asyncContext, ThrowCompletion(reason));
+    // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and prevContext is the currently running execution context.
+    Assert(surroundingAgent.runningExecutionContext === prevContext);
+    // f. Return undefined.
+    return Value.undefined;
+  };
+  // 6. Let onRejected be ! CreateBuiltinFunction(rejectedClosure, 1, "", « »).
+  const onRejected = X(CreateBuiltinFunction(rejectedClosure, 1, new Value(''), []));
+  onRejected[kAsyncContext] = asyncContext;
+  // 7. Perform ! PerformPromiseThen(promise, onFulfilled, onRejected).
   X(PerformPromiseThen(promise, onFulfilled, onRejected));
+  // 8. Remove asyncContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
   surroundingAgent.executionContextStack.pop(asyncContext);
+  // 9. Set the code evaluation state of asyncContext such that when evaluation is resumed with a Completion completion, the following steps of the algorithm that invoked Await will be performed, with completion available.
   const completion = yield Value.undefined;
+  // 10. Return.
   return completion;
+  // 11. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of asyncContext.
 }

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -1,7 +1,7 @@
 import { surroundingAgent } from './engine.mjs';
 import { Type, Value, Descriptor } from './value.mjs';
 import { ToString, DefinePropertyOrThrow, CreateBuiltinFunction } from './abstract-ops/all.mjs';
-import { X, AwaitFulfilledFunctions } from './completion.mjs';
+import { X } from './completion.mjs';
 
 export const kInternal = Symbol('kInternal');
 
@@ -302,6 +302,8 @@ export class CallSite {
   }
 }
 
+export const kAsyncContext = Symbol('kAsyncContext');
+
 function captureAsyncStack(stack) {
   let promise = stack[0].context.promiseCapability.Promise;
   for (let i = 0; i < 10; i += 1) {
@@ -309,8 +311,8 @@ function captureAsyncStack(stack) {
       return;
     }
     const [reaction] = promise.PromiseFulfillReactions;
-    if (reaction.Handler && reaction.Handler.Callback.nativeFunction === AwaitFulfilledFunctions) {
-      const asyncContext = reaction.Handler.Callback.AsyncContext;
+    if (reaction.Handler && reaction.Handler.Callback[kAsyncContext]) {
+      const asyncContext = reaction.Handler.Callback[kAsyncContext];
       stack.push(asyncContext.callSite.clone());
       if ('PromiseState' in asyncContext.promiseCapability.Promise) {
         promise = asyncContext.promiseCapability.Promise;

--- a/src/intrinsics/Object.mjs
+++ b/src/intrinsics/Object.mjs
@@ -186,37 +186,26 @@ function Object_freeze([O = Value.undefined]) {
   return O;
 }
 
-// #sec-create-data-property-on-object-functions
-function CreateDataPropertyOnObjectFunctions([key, value], { thisValue }) {
-  // 1. Let O be the this value.
-  const O = thisValue;
-  // 2. Assert: Type(O) is Object.
-  Assert(Type(O) === 'Object');
-  // 3. Assert: O is an extensible ordinary object.
-  Assert(O.Extensible === Value.true);
-  // 4. Let propertyKey be ? ToPropertyKey(key).
-  const propertyKey = Q(ToPropertyKey(key));
-  // 5. Perform ! CreateDataPropertyOrThrow(O, propertyKey, value).
-  X(CreateDataPropertyOrThrow(O, propertyKey, value));
-  // 6. Return undefined.
-  return Value.undefined;
-}
-
 // #sec-object.fromentries
 function Object_fromEntries([iterable = Value.undefined]) {
   // 1. Perform ? RequireObjectCoercible(iterable).
   Q(RequireObjectCoercible(iterable));
-  // 2. Let obj be OrdinaryObjectCreate(%Object.prototype%).
-  const obj = OrdinaryObjectCreate(surroundingAgent.intrinsic('%Object.prototype%'));
+  // 2. Let obj be ! OrdinaryObjectCreate(%Object.prototype%).
+  const obj = X(OrdinaryObjectCreate(surroundingAgent.intrinsic('%Object.prototype%')));
   // 3. Assert: obj is an extensible ordinary object with no own properties.
   Assert(obj.Extensible === Value.true && obj.properties.size === 0);
-  // 4. Let stepsDefine be the algorithm steps defined in CreateDataPropertyOnObject Functions.
-  const stepsDefine = CreateDataPropertyOnObjectFunctions;
-  // 5. Let lengthDefine be the number of non-optional parameters of the function definition in CreateDataPropertyOnObject Functions.
-  const lengthDefine = 2;
-  // 6. Let adder be ! CreateBuiltinFunction(stepsDefine, lengthDefine, "", « »).
-  const adder = X(CreateBuiltinFunction(stepsDefine, lengthDefine, new Value(''), []));
-  // 7. Return ? AddEntriesFromIterable(obj, iterable, adder).
+  // 4. Let closure be a new Abstract Closure with parameters (key, value) that captures obj and performs the following steps when called:
+  const closure = ([key = Value.undefined, value = Value.undefined]) => {
+    // a. Let propertyKey be ? ToPropertyKey(key).
+    const propertyKey = Q(ToPropertyKey(key));
+    // b. Perform ! CreateDataPropertyOrThrow(obj, propertyKey, value).
+    X(CreateDataPropertyOrThrow(obj, propertyKey, value));
+    // c. Return undefined.
+    return Value.undefined;
+  };
+  // 5. Let adder be ! CreateBuiltinFunction(closure, 2, "", « »).
+  const adder = X(CreateBuiltinFunction(closure, 2, new Value(''), []));
+  // 6. Return ? AddEntriesFromIterable(obj, iterable, adder).
   return Q(AddEntriesFromIterable(obj, iterable, adder));
 }
 

--- a/test/supplemental.js
+++ b/test/supplemental.js
@@ -263,12 +263,12 @@ Error: owo
     assert.strictEqual(agent1.executionContextStack.pop, agent2.executionContextStack.pop,
       "The 'agent.executionContextStack.pop' method is identical for every execution context stack.");
   },
-].forEach((test) => {
+].forEach((test, i) => {
   total();
   try {
     test();
     pass();
   } catch (e) {
-    fail('', e.stack || e);
+    fail(`Test ${i + 1}`, e.stack || e);
   }
 });


### PR DESCRIPTION
Note that the static `Promise` constructor methods have been left alone as they’re still specified using the older format:
- <https://tc39.es/ecma262/#sec-properties-of-the-promise-constructor>
- <https://github.com/tc39/ecma262/pull/2439>

I also left `Proxy.revocable` (<https://github.com/tc39/ecma262/commit/08d2018>) for a future PR as it runs into too many violations of [**ESLint**’s `no‑shadow` rule](https://eslint.org/docs/rules/no-shadow).

---

Addresses the following entries listed in <https://github.com/engine262/engine262/issues/164>:
- <https://github.com/tc39/ecma262/commit/6d3c629> Editorial: use abstract closures in MakeArg{Getter,Setter} ([tc39/ecma262#2439](https://github.com/tc39/ecma262/pull/2439))
- <https://github.com/tc39/ecma262/commit/5872981> Editorial: use abstract closures in AsyncGeneratorResumeNext ([tc39/ecma262#2439](https://github.com/tc39/ecma262/pull/2439))
- <https://github.com/tc39/ecma262/commit/a5645b0> Editorial: use abstract closure in Promise.prototype.finally ([tc39/ecma262#2439](https://github.com/tc39/ecma262/pull/2439))
- <https://github.com/tc39/ecma262/commit/9254e1a> Editorial: use abstract closure in NewPromiseCapability ([tc39/ecma262#2439](https://github.com/tc39/ecma262/pull/2439))
- <https://github.com/tc39/ecma262/commit/b268083> Editorial: use abstract closure in AsyncFromSyncIteratorContinuation ([tc39/ecma262#2439](https://github.com/tc39/ecma262/pull/2439))
- <https://github.com/tc39/ecma262/commit/148089b> Editorial: use abstract closure for default constructor ([tc39/ecma262#2439](https://github.com/tc39/ecma262/pull/2439))
- <https://github.com/tc39/ecma262/commit/2ae1ebb> Editorial: use abstract closures in Await ([tc39/ecma262#2439](https://github.com/tc39/ecma262/pull/2439))
- <https://github.com/tc39/ecma262/commit/fbdf389> Editorial: Add support for Abstract Closures to `CreateBuiltinFunction` ([tc39/ecma262#2109](https://github.com/tc39/ecma262/pull/2109))