### PR TITLE
Fix usage of the `[[VarNames]]` field of global Environment Records

### DIFF
--- a/src/environment.mjs
+++ b/src/environment.mjs
@@ -583,8 +583,9 @@ export class GlobalEnvironmentRecord extends EnvironmentRecord {
         // i. Let varNames be envRec.[[VarNames]].
         const varNames = envRec.VarNames;
         // ii. If N is an element of varNames, remove that element from the varNames.
-        if (varNames.includes(N)) {
-          varNames.splice(varNames.indexOf(N), 1);
+        const i = varNames.findIndex((v) => v.stringValue() === N.stringValue());
+        if (i >= 0) {
+          varNames.splice(i, 1);
         }
       }
       // c. Return status.
@@ -627,7 +628,7 @@ export class GlobalEnvironmentRecord extends EnvironmentRecord {
     // 2. Let varDeclaredNames be envRec.[[VarNames]].
     const varDeclaredNames = envRec.VarNames;
     // 3. If varDeclaredNames contains N, return true.
-    if (varDeclaredNames.includes(N)) {
+    if (varDeclaredNames.some((v) => v.stringValue() === N.stringValue())) {
       return Value.true;
     }
     // 4. Return false.
@@ -735,7 +736,7 @@ export class GlobalEnvironmentRecord extends EnvironmentRecord {
     // 7. Let varDeclaredNames be envRec.[[VarNames]].
     const varDeclaredNames = envRec.VarNames;
     // 8. If varDeclaredNames does not contain N, then
-    if (!varDeclaredNames.includes(N)) {
+    if (!varDeclaredNames.some((v) => v.stringValue() === N.stringValue())) {
       // a. Append N to varDeclaredNames.
       varDeclaredNames.push(N);
     }
@@ -777,7 +778,7 @@ export class GlobalEnvironmentRecord extends EnvironmentRecord {
     // 10. Let varDeclaredNames be envRec.[[VarNames]].
     const varDeclaredNames = envRec.VarNames;
     // 11. If varDeclaredNames does not contain N, then
-    if (!varDeclaredNames.includes(N)) {
+    if (!varDeclaredNames.some((v) => v.stringValue() === N.stringValue())) {
       // a. Append N to varDeclaredNames.
       varDeclaredNames.push(N);
     }

--- a/test/supplemental.js
+++ b/test/supplemental.js
@@ -263,6 +263,26 @@ Error: owo
     assert.strictEqual(agent1.executionContextStack.pop, agent2.executionContextStack.pop,
       "The 'agent.executionContextStack.pop' method is identical for every execution context stack.");
   },
+  () => {
+    const agent = new Agent();
+    setSurroundingAgent(agent);
+    const realm = new ManagedRealm();
+    realm.evaluateScript(`
+      var foo;
+      eval(\`
+        var foo;
+        var bar;
+        var deleteMe;
+      \`);
+      delete deleteMe;
+    `);
+    const varNames = new Set();
+    for (const name of realm.GlobalEnv.VarNames) {
+      assert(!varNames.has(name.stringValue()), 'Every member of `realm.[[GlobalEnv]].[[VarNames]]` should be unique.');
+      varNames.add(name.stringValue());
+    }
+    assert(!varNames.has('deleteMe'), "`realm.[[GlobalEnv]].[[VarNames]]` shouldn't have 'deleteMe'.");
+  },
 ].forEach((test, i) => {
   total();
   try {


### PR DESCRIPTION
Because the `[[VarNames]]` field is implemented using an `Array` instead of a `ValueSet` (or some other `Value` collection), and because `new Value("foo") !== new Value("foo")`, this causes `VarNames.includes(N)` to always return `false`.

This causes `[[VarNames]]` to have duplicates when sloppy `eval` is used, and doesn’t correctly remove entries when `delete varName` is used and `var varName` was declared inside a sloppy `eval`.