### PR TITLE
fix: isIntegerIndex should check the argument wether is an integer

### DIFF
--- a/src/abstract-ops/data-types-and-values.mjs
+++ b/src/abstract-ops/data-types-and-values.mjs
@@ -14,6 +14,9 @@ export function isIntegerIndex(V) {
   if (numeric === Value.undefined) {
     return false;
   }
+  if (!Number.isInteger(numeric.numberValue())) {
+    return false;
+  }
   if (Object.is(numeric.numberValue(), +0)) {
     return true;
   }


### PR DESCRIPTION
According to the spec the `integer index` should be an integer ([spec](https://tc39.es/ecma262/#integer-index)), but the original code didn't check it.