### PR TITLE
Preview: add jsdoc-style type comment to some files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+declaration
 test.mjs
 test.js
 .eslintcache

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 test
 src
+declaration/.tsbuildinfo
+declaration/**/*.map
 scripts
 coverage
 rollup.config.js

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "minimatch": "^5.1.0",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.77.0",
+    "typescript": "^4.9.3",
     "ws": "^8.8.1"
   }
 }

--- a/src/abstract-ops/function-operations.mjs
+++ b/src/abstract-ops/function-operations.mjs
@@ -7,6 +7,7 @@ import {
   Type,
   Value,
   PrivateName,
+  ObjectValue,
 } from '../value.mjs';
 import {
   EnsureCompletion,
@@ -498,7 +499,18 @@ function BuiltinFunctionConstruct(argumentsList, newTarget) {
   return result;
 }
 
-// 9.3.3 #sec-createbuiltinfunction
+/**
+ * 9.3.3 #sec-createbuiltinfunction
+ * @param {Function} steps
+ * @param {number} length
+ * @param {StringValue} name
+ * @param {readonly InternalSlots[]} internalSlotsList
+ * @param {Realm=} realm
+ * @param {Value=} prototype
+ * @param {string=} prefix
+ * @param {boolean} isConstructor
+ * @template {string} InternalSlots
+ */
 export function CreateBuiltinFunction(steps, length, name, internalSlotsList, realm, prototype, prefix, isConstructor = Value.false) {
   // 1. Assert: steps is either a set of algorithm steps or other definition of a function's behaviour provided in this specification.
   Assert(typeof steps === 'function');
@@ -513,6 +525,7 @@ export function CreateBuiltinFunction(steps, length, name, internalSlotsList, re
     prototype = realm.Intrinsics['%Function.prototype%'];
   }
   // 5. Let func be a new built-in function object that when called performs the action described by steps. The new function object has internal slots whose names are the elements of internalSlotsList.
+  /** @type {BuiltinFunctionObjectValue<InternalSlots>} */
   const func = X(MakeBasicObject(['Prototype', 'Extensible', 'Realm', 'ScriptOrModule', 'InitialName'].concat(internalSlotsList)));
   func.Call = BuiltinFunctionCall;
   if (isConstructor === Value.true) {
@@ -542,8 +555,19 @@ export function CreateBuiltinFunction(steps, length, name, internalSlotsList, re
   // 13. Return func.
   return func;
 }
+/**
+ * @typedef BuiltinFunctionObjectValue
+ * @type {ObjectValue & {
+ * Prototype: Value,
+ * Extensible: BooleanValue,
+ * Realm: Realm,
+ * ScriptOrModule: Value,
+ * InitialName: Value,
+ * } & { [key: InternalSlots]: unknown }}
+ * @template {string} [InternalSlots=never]
+ */
 
-// 14.9.3 #sec-preparefortailcall
+/** 14.9.3 #sec-preparefortailcall */
 export function PrepareForTailCall() {
   // 1. Let leafContext be the running execution context.
   const leafContext = surroundingAgent.runningExecutionContext;

--- a/src/abstract-ops/notational-conventions.mjs
+++ b/src/abstract-ops/notational-conventions.mjs
@@ -1,8 +1,13 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type } from '../value.mjs';
+import { Value, Type } from '../value.mjs';
 
 class AssertError extends Error {}
 
+/**
+ * @param {boolean} invariant
+ * @param {string=} source
+ * @returns {asserts invariant}
+ */
 export function Assert(invariant, source) {
   /* c8 ignore next */
   if (!invariant) {
@@ -11,6 +16,10 @@ export function Assert(invariant, source) {
 }
 
 // 9.1.15 #sec-requireinternalslot
+/**
+ * @param {Value} O
+ * @param {string} internalSlot
+ */
 export function RequireInternalSlot(O, internalSlot) {
   if (Type(O) !== 'Object') {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', O);

--- a/src/abstract-ops/object-operations.mjs
+++ b/src/abstract-ops/object-operations.mjs
@@ -36,6 +36,11 @@ import {
 // 7.3 #sec-operations-on-objects
 
 // #sec-makebasicobject
+/**
+ * @param {readonly T[]} internalSlotsList
+ * @template {string} T
+ * @returns {ObjectValue & {[key in T]: any}}
+ */
 export function MakeBasicObject(internalSlotsList) {
   // 1.  Assert: internalSlotsList is a List of internal slot names.
   Assert(Array.isArray(internalSlotsList));

--- a/src/abstract-ops/objects.mjs
+++ b/src/abstract-ops/objects.mjs
@@ -56,7 +56,11 @@ export function OrdinarySetPrototypeOf(O, V) {
   return Value.true;
 }
 
-// 9.1.3.1 OrdinaryIsExtensible
+/**
+ * 9.1.3.1 OrdinaryIsExtensible
+ * @param {ObjectValue} O
+ * @returns {boolean}
+ */
 export function OrdinaryIsExtensible(O) {
   return O.Extensible;
 }
@@ -92,7 +96,12 @@ export function OrdinaryGetOwnProperty(O, P) {
   return D;
 }
 
-// 9.1.6.1 OrdinaryDefineOwnProperty
+/**
+ * 9.1.6.1 OrdinaryDefineOwnProperty
+ * @param {ObjectValue} O
+ * @param {import('../api.mjs').PropertyKeyValue} P
+ * @param {Descriptor} Desc
+ */
 export function OrdinaryDefineOwnProperty(O, P, Desc) {
   const current = Q(O.GetOwnProperty(P));
   const extensible = Q(IsExtensible(O));
@@ -400,4 +409,3 @@ export function GetPrototypeFromConstructor(constructor, intrinsicDefaultProto) 
   }
   return proto;
 }
-

--- a/src/abstract-ops/proxy-objects.mjs
+++ b/src/abstract-ops/proxy-objects.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { NullValue, ObjectValue, Type, Value } from '../value.mjs';
 import { Q, X } from '../completion.mjs';
 import { ValueSet } from '../helpers.mjs';
 import {
@@ -532,6 +532,14 @@ function ProxyConstruct(argumentsList, newTarget) {
   return newObj;
 }
 
+/**
+ * @typedef {ObjectValue & {ProxyHandler: ObjectValue | NullValue;ProxyTarget: ObjectValue | NullValue;}} ProxyObject
+ */
+
+/**
+ * @param {Value} O
+ * @returns {O is ProxyObject}
+ */
 export function isProxyExoticObject(O) {
   return 'ProxyHandler' in O;
 }
@@ -547,6 +555,7 @@ export function ProxyCreate(target, handler) {
     return surroundingAgent.Throw('TypeError', 'CannotCreateProxyWith', 'non-object', 'handler');
   }
   // 3. Let P be ! MakeBasicObject(« [[ProxyHandler]], [[ProxyTarget]] »).
+  /** @type {ProxyObject} */
   const P = X(MakeBasicObject(['ProxyHandler', 'ProxyTarget']));
   // 4. Set P's essential internal methods, except for [[Call]] and [[Construct]], to the definitions specified in 9.5.
   P.GetPrototypeOf = ProxyGetPrototypeOf;

--- a/src/abstract-ops/realms.mjs
+++ b/src/abstract-ops/realms.mjs
@@ -137,7 +137,11 @@ function AddRestrictedFunctionProperties(F, realm) {
   })));
 }
 
-// #sec-createintrinsics
+/**
+ * #sec-createintrinsics
+ * @param {Realm} realmRec
+ * @returns {any}
+ */
 export function CreateIntrinsics(realmRec) {
   const intrinsics = Object.create(null);
   realmRec.Intrinsics = intrinsics;

--- a/src/abstract-ops/type-conversion.mjs
+++ b/src/abstract-ops/type-conversion.mjs
@@ -4,6 +4,7 @@ import {
   NumberValue,
   BigIntValue,
   wellKnownSymbols,
+  BooleanValue,
 } from '../value.mjs';
 import {
   surroundingAgent,
@@ -100,6 +101,10 @@ export function OrdinaryToPrimitive(O, hint) {
 }
 
 // 7.1.2 #sec-toboolean
+/**
+ * @param {Value} argument
+ * @returns {BooleanValue}
+ */
 export function ToBoolean(argument) {
   const type = Type(argument);
   switch (type) {

--- a/src/api.mjs
+++ b/src/api.mjs
@@ -145,7 +145,13 @@ export function gc() {
   });
 }
 
+/**
+ * @callback GCMarkCallback
+ * @param {any} value
+ */
+
 // https://tc39.es/ecma262/#sec-jobs
+/** */
 export function runJobQueue() {
   if (surroundingAgent.executionContextStack.some((e) => e.ScriptOrModule !== Value.null)) {
     return;

--- a/src/completion.mjs
+++ b/src/completion.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import { surroundingAgent } from './engine.mjs';
 import {
   Assert,
@@ -8,7 +9,12 @@ import {
 import { Value } from './value.mjs';
 import { kAsyncContext, resume } from './helpers.mjs';
 
-// #sec-completion-record-specification-type
+/**
+ * #sec-completion-record-specification-type
+ * @template [T=unknown]
+ * @param {Pick<Completion<T>, 'Type' | 'Value' | 'Target'>} init
+ * @returns {Completion<T>}
+ */
 export function Completion(init) {
   if (new.target === undefined) {
     // 1. Assert: completionRecord is a Completion Record.
@@ -17,24 +23,43 @@ export function Completion(init) {
     return init;
   }
 
+  /**
+   * @type {'normal' | 'break' | 'continue' | 'return' | 'throw'} The type of completion that occurred.
+   * @readonly
+   */
   this.Type = init.Type;
+  /**
+   * @type {T} The value that was produced.
+   * @readonly
+   */
   this.Value = init.Value;
+  /**
+   * @type {string=} The target label for directed control transfers.
+   * @readonly
+   */
   this.Target = init.Target;
+  return this;
 }
 
-// NON-SPEC
+/**
+ * NON-SPEC
+ * @param {(callback: T) => void} m
+ */
 Completion.prototype.mark = function mark(m) {
   m(this.Value);
 };
 
-// #sec-normalcompletion
+/**
+ * #sec-normalcompletion
+ * @template T
+ * @param {T} argument
+ */
 export function NormalCompletion(argument) {
-  // 1. Return Completion { [[Type]]: normal, [[Value]]: argument, [[Target]]: empty }.
   return new Completion({ Type: 'normal', Value: argument, Target: undefined });
 }
 
 Object.defineProperty(NormalCompletion, Symbol.hasInstance, {
-  value: function hasInstance(v) {
+  value: function hasInstance(/** @type {any} */ v) {
     return v instanceof Completion && v.Type === 'normal';
   },
   writable: true,
@@ -43,18 +68,27 @@ Object.defineProperty(NormalCompletion, Symbol.hasInstance, {
 });
 
 export class AbruptCompletion {
-  static [Symbol.hasInstance](v) {
+  static [Symbol.hasInstance](/** @type {any} */ v) {
     return v instanceof Completion && v.Type !== 'normal';
   }
 }
 
-// #sec-throwcompletion
+/**
+ * #sec-throwcompletion
+ * @template T
+ * @param {T} argument
+ */
 export function ThrowCompletion(argument) {
   // 1. Return Completion { [[Type]]: throw, [[Value]]: argument, [[Target]]: empty }.
   return new Completion({ Type: 'throw', Value: argument, Target: undefined });
 }
 
-// 6.2.3.4 #sec-updateempty
+/**
+ * 6.2.3.4 #sec-updateempty
+ * @param {Completion<T>} completionRecord
+ * @param {T} value
+ * @template T
+ */
 export function UpdateEmpty(completionRecord, value) {
   Assert(completionRecord instanceof Completion);
   // 1. Assert: If completionRecord.[[Type]] is either return or throw, then completionRecord.[[Value]] is not empty.
@@ -67,40 +101,56 @@ export function UpdateEmpty(completionRecord, value) {
   return new Completion({ Type: completionRecord.Type, Value: value, Target: completionRecord.Target });
 }
 
-// #sec-returnifabrupt
+/**
+ * #sec-returnifabrupt
+ * @type {<T>(completion: T) => T extends Completion<infer U> ? U : T}
+ */
 export function ReturnIfAbrupt(_completion) {
   /* c8 skip next */
   throw new TypeError('ReturnIfAbrupt requires build');
 }
 
 // #sec-returnifabrupt-shorthands ? OperationName()
-export const Q = ReturnIfAbrupt;
+export { ReturnIfAbrupt as Q };
+const Q = ReturnIfAbrupt;
 
-// #sec-returnifabrupt-shorthands ! OperationName()
+/**
+ * #sec-returnifabrupt-shorthands ! OperationName()
+ * @type {<T>(completion: T) => T extends Completion<infer U> ? U : T}
+ */
 export function X(_completion) {
   /* c8 skip next */
   throw new TypeError('X() requires build');
 }
 
 // 7.4.7 #sec-ifabruptcloseiterator
+// @ts-expect-error
 export function IfAbruptCloseIterator(_value, _iteratorRecord) {
   /* c8 skip next */
   throw new TypeError('IfAbruptCloseIterator() requires build');
 }
 
 // 25.6.1.1.1 #sec-ifabruptrejectpromise
+// @ts-expect-error
 export function IfAbruptRejectPromise(_value, _capability) {
   /* c8 skip next */
   throw new TypeError('IfAbruptRejectPromise requires build');
 }
 
+/**
+ * @type {<T>(val: T) => T extends Completion<any> ? T : Completion<T>}
+ */
 export function EnsureCompletion(val) {
   if (val instanceof Completion) {
-    return val;
+    return /** @type {any} */ (val);
   }
-  return NormalCompletion(val);
+  return /** @type {any} */ (NormalCompletion(val));
 }
 
+/**
+ * @param {Value} value
+ * @returns {Generator<Value, Completion, Completion>}
+ */
 export function* Await(value) {
   // 1. Let asyncContext be the running execution context.
   const asyncContext = surroundingAgent.runningExecutionContext;
@@ -122,6 +172,7 @@ export function* Await(value) {
   };
   // 4. Let onFulfilled be ! CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
   const onFulfilled = X(CreateBuiltinFunction(fulfilledClosure, 1, new Value(''), []));
+  // @ts-expect-error
   onFulfilled[kAsyncContext] = asyncContext;
   // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the following steps when called:
   const rejectedClosure = ([reason = Value.undefined]) => {
@@ -139,6 +190,7 @@ export function* Await(value) {
   };
   // 6. Let onRejected be ! CreateBuiltinFunction(rejectedClosure, 1, "", « »).
   const onRejected = X(CreateBuiltinFunction(rejectedClosure, 1, new Value(''), []));
+  // @ts-expect-error
   onRejected[kAsyncContext] = asyncContext;
   // 7. Perform ! PerformPromiseThen(promise, onFulfilled, onRejected).
   X(PerformPromiseThen(promise, onFulfilled, onRejected));

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -4,7 +4,7 @@ import {
   EnsureCompletion,
   NormalCompletion,
   ThrowCompletion,
-  Q, X,
+  Q, X, Completion,
 } from './completion.mjs';
 import {
   IsCallable,
@@ -33,6 +33,9 @@ export const FEATURES = Object.freeze([
   },
 ].map(Object.freeze));
 
+/**
+ * @extends {Array<ExecutionContext>}
+ */
 class ExecutionContextStack extends Array {
   // This ensures that only the length taking overload is supported.
   // This is necessary to support `ArraySpeciesCreate`, which invokes
@@ -41,6 +44,10 @@ class ExecutionContextStack extends Array {
     super(+length);
   }
 
+  /**
+   * @override
+   * @param {ExecutionContext} ctx
+   */
   pop(ctx) {
     if (!ctx.poppedForTailCall) {
       const popped = super.pop();
@@ -106,6 +113,13 @@ export class Agent {
   }
 
   // Generate a throw completion using message templates
+  /**
+   * @param {import('./intrinsics/Error.mjs').IntrinsicsErrorName} type
+   * @param {Template} template
+   * @param  {Parameters<(typeof messages)[Template]>} templateArgs
+   * @template {keyof typeof messages} Template
+   * @returns {Completion<Value>}
+   */
   Throw(type, template, ...templateArgs) {
     if (type instanceof Value) {
       return ThrowCompletion(type);
@@ -157,7 +171,11 @@ export class Agent {
   }
 }
 
+/** @type {Agent} */
 export let surroundingAgent;
+/**
+ * @param {Agent} a
+ */
 export function setSurroundingAgent(a) {
   surroundingAgent = a;
 }

--- a/src/intrinsics/Error.mjs
+++ b/src/intrinsics/Error.mjs
@@ -53,3 +53,7 @@ export function bootstrapError(realmRec) {
 
   realmRec.Intrinsics['%Error%'] = error;
 }
+/**
+ * @typedef IntrinsicsErrorName
+ * @type {'RangeError' | 'TypeError' | 'AggregateError' | 'Error' | 'ReferenceError' | 'SyntaxError' | 'URIError'}
+ */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitOverride": true,
+        "noImplicitReturns": true,
+        "useUnknownInCatchVariables": true,
+
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+
+        "declaration": true,
+        // to make declaration map useful, we need to publish src
+        // but it might help when debugging
+        "declarationMap": true,
+        "emitDeclarationOnly": true,
+        "stripInternal": true,
+
+        "allowJs": true,
+        // "checkJs": true,
+
+        "forceConsistentCasingInFileNames": true,
+        "lib": ["ES2022"],
+
+        "incremental": true,
+        "declarationDir": "./declaration/",
+        "tsBuildInfoFile": "./declaration/.tsbuildinfo",
+
+        "skipLibCheck": true
+    },
+    "include": ["./src/"]
+}


### PR DESCRIPTION
this is a preview of #202. using jsdoc-style type comment to use the type checker. as you can see, the type comment is very verbose. Do you want to go with JSDoc or with real TypeScript file?

This won't be the final PR to be merged. I intended to send separate PRs to do some changes before migrating some code (please comment if you don't like any of the changes listed below so I can avoid creating a PR that won't be accepted):

- convert comment `// #sec-something` to `/** https://tc39.es/ecma262/#sec-something */`
- Replace `Type(x) === 'Object'` with `x instanceof ObjectValue`.
      This reflects to the spec convention change from `if Type(x) is *Object*` to `if x is an Object`. and it's also more friendly to the TypeScript checker.