### PR TITLE
refactor: use val instanceof TValue

### DIFF
--- a/src/abstract-ops/array-objects.mjs
+++ b/src/abstract-ops/array-objects.mjs
@@ -1,7 +1,8 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
   Descriptor,
-  Type,
+  ObjectValue,
+  JSStringValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -40,7 +41,7 @@ function ArrayDefineOwnProperty(P, Desc) {
   const A = this;
 
   Assert(IsPropertyKey(P));
-  if (Type(P) === 'String' && P.stringValue() === 'length') {
+  if (P instanceof JSStringValue && P.stringValue() === 'length') {
     return Q(ArraySetLength(A, Desc));
   } else if (isArrayIndex(P)) {
     const oldLenDesc = OrdinaryGetOwnProperty(A, new Value('length'));
@@ -115,7 +116,7 @@ export function ArraySpeciesCreate(originalArray, length) {
       }
     }
   }
-  if (Type(C) === 'Object') {
+  if (C instanceof ObjectValue) {
     C = Q(Get(C, wellKnownSymbols.species));
     if (C === Value.null) {
       C = Value.undefined;
@@ -190,7 +191,7 @@ export function ArraySetLength(A, Desc) {
 
 // 22.1.3.1.1 #sec-isconcatspreadable
 export function IsConcatSpreadable(O) {
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return Value.false;
   }
   const spreadable = Q(Get(O, wellKnownSymbols.isConcatSpreadable));
@@ -248,7 +249,7 @@ export function SortCompare(x, y, comparefn) {
 // 22.1.5.1 #sec-createarrayiterator
 export function CreateArrayIterator(array, kind) {
   // 1. Assert: Type(array) is Object.
-  Assert(Type(array) === 'Object');
+  Assert(array instanceof ObjectValue);
   // 2. Assert: kind is key+value, key, or value.
   Assert(kind === 'key+value' || kind === 'key' || kind === 'value');
   // 3. Let closure be a new Abstract Closure with no parameters that captures kind and array and performs the following steps when called:

--- a/src/abstract-ops/arraybuffer-objects.mjs
+++ b/src/abstract-ops/arraybuffer-objects.mjs
@@ -1,5 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import {
+  NumberValue, BigIntValue, BooleanValue, ObjectValue, Value,
+} from '../value.mjs';
 import { Q, X, NormalCompletion } from '../completion.mjs';
 import {
   Assert, OrdinaryCreateFromConstructor,
@@ -31,7 +33,7 @@ export function AllocateArrayBuffer(constructor, byteLength) {
 // #sec-isdetachedbuffer
 export function IsDetachedBuffer(arrayBuffer) {
   // 1. Assert: Type(arrayBuffer) is Object and it has an [[ArrayBufferData]] internal slot.
-  Assert(Type(arrayBuffer) === 'Object' && 'ArrayBufferData' in arrayBuffer);
+  Assert(arrayBuffer instanceof ObjectValue && 'ArrayBufferData' in arrayBuffer);
   // 2. If arrayBuffer.[[ArrayBufferData]] is null, return true.
   if (arrayBuffer.ArrayBufferData === Value.null) {
     return Value.true;
@@ -43,7 +45,7 @@ export function IsDetachedBuffer(arrayBuffer) {
 // #sec-detacharraybuffer
 export function DetachArrayBuffer(arrayBuffer, key) {
   // 1. Assert: Type(arrayBuffer) is Object and it has [[ArrayBufferData]], [[ArrayBufferByteLength]], and [[ArrayBufferDetachKey]] internal slots.
-  Assert(Type(arrayBuffer) === 'Object'
+  Assert(arrayBuffer instanceof ObjectValue
          && 'ArrayBufferData' in arrayBuffer
          && 'ArrayBufferByteLength' in arrayBuffer
          && 'ArrayBufferDetachKey' in arrayBuffer);
@@ -72,7 +74,7 @@ export function IsSharedArrayBuffer(_obj) {
 
 export function CloneArrayBuffer(srcBuffer, srcByteOffset, srcLength, cloneConstructor) {
   // 1. Assert: Type(srcBuffer) is Object and it has an [[ArrayBufferData]] internal slot.
-  Assert(Type(srcBuffer) === 'Object' && 'ArrayBufferData' in srcBuffer);
+  Assert(srcBuffer instanceof ObjectValue && 'ArrayBufferData' in srcBuffer);
   // 2. Assert: IsConstructor(cloneConstructor) is true.
   Assert(IsConstructor(cloneConstructor) === Value.true);
   // 3. Let targetBuffer be ? AllocateArrayBuffer(cloneConstructor, srcLength).
@@ -148,7 +150,7 @@ const float64NaNBE = Object.freeze([127, 248, 0, 0, 0, 0, 0, 0]);
 
 // #sec-numerictorawbytes
 export function NumericToRawBytes(type, value, isLittleEndian) {
-  Assert(Type(isLittleEndian) === 'Boolean');
+  Assert(isLittleEndian instanceof BooleanValue);
   isLittleEndian = isLittleEndian === Value.true;
   let rawBytes;
   // One day, we will write our own IEEE 754 and two's complement encoder…
@@ -189,9 +191,9 @@ export function SetValueInBuffer(arrayBuffer, byteIndex, type, value, isTypedArr
   Assert(isNonNegativeInteger(byteIndex));
   // 4. Assert: Type(value) is BigInt if ! IsBigIntElementType(type) is true; otherwise, Type(value) is Number.
   if (X(IsBigIntElementType(type)) === Value.true) {
-    Assert(Type(value) === 'BigInt');
+    Assert(value instanceof BigIntValue);
   } else {
-    Assert(Type(value) === 'Number');
+    Assert(value instanceof NumberValue);
   }
   // 5. Let block be arrayBuffer.[[ArrayBufferData]].
   const block = arrayBuffer.ArrayBufferData;

--- a/src/abstract-ops/data-types-and-values.mjs
+++ b/src/abstract-ops/data-types-and-values.mjs
@@ -1,4 +1,4 @@
-import { Type, Value } from '../value.mjs';
+import { JSStringValue, Value } from '../value.mjs';
 import { X } from '../completion.mjs';
 import { CanonicalNumericIndexString } from './all.mjs';
 
@@ -7,7 +7,7 @@ import { CanonicalNumericIndexString } from './all.mjs';
 
 // 6.1.7 #integer-index
 export function isIntegerIndex(V) {
-  if (Type(V) !== 'String') {
+  if (!(V instanceof JSStringValue)) {
     return false;
   }
   const numeric = X(CanonicalNumericIndexString(V));
@@ -22,7 +22,7 @@ export function isIntegerIndex(V) {
 
 // 6.1.7 #array-index
 export function isArrayIndex(V) {
-  if (Type(V) !== 'String') {
+  if (!(V instanceof JSStringValue)) {
     return false;
   }
   const numeric = X(CanonicalNumericIndexString(V));

--- a/src/abstract-ops/error-objects.mjs
+++ b/src/abstract-ops/error-objects.mjs
@@ -1,11 +1,11 @@
-import { Type, Value, Descriptor } from '../value.mjs';
+import { ObjectValue, Value, Descriptor } from '../value.mjs';
 import { Q, X, NormalCompletion } from '../completion.mjs';
 import { HasProperty, Get, DefinePropertyOrThrow } from './all.mjs';
 
 // #sec-errorobjects-install-error-cause
 export function InstallErrorCause(O, options) {
   // 1. If Type(options) is Object and ? HasProperty(options, "cause") is true, then
-  if (Type(options) === 'Object') {
+  if (options instanceof ObjectValue) {
     // nested if statement due to macro expansion
     if (Q(HasProperty(options, new Value('cause'))) === Value.true) {
       // a. Let cause be ? Get(options, "cause").

--- a/src/abstract-ops/function-operations.mjs
+++ b/src/abstract-ops/function-operations.mjs
@@ -4,7 +4,9 @@ import {
 } from '../engine.mjs';
 import {
   Descriptor,
-  Type,
+  SymbolValue,
+  ObjectValue,
+  UndefinedValue,
   Value,
   PrivateName,
 } from '../value.mjs';
@@ -63,7 +65,7 @@ export function isFunctionObject(O) {
 // #sec-prepareforordinarycall
 export function PrepareForOrdinaryCall(F, newTarget) {
   // 1. Assert: Type(newTarget) is Undefined or Object.
-  Assert(Type(newTarget) === 'Undefined' || Type(newTarget) === 'Object');
+  Assert(newTarget instanceof UndefinedValue || newTarget instanceof ObjectValue);
   // 2. Let callerContext be the running execution context.
   // const callerContext = surroundingAgent.runningExecutionContext;
   // 3. Let calleeContext be a new ECMAScript code execution context.
@@ -224,7 +226,7 @@ function FunctionConstructSlot(argumentsList, newTarget) {
   // 1. Assert: F is an ECMAScript function object.
   Assert(isECMAScriptFunctionObject(F));
   // 2. Assert: Type(newTarget) is Object.
-  Assert(Type(newTarget) === 'Object');
+  Assert(newTarget instanceof ObjectValue);
   // 3. Let callerContext be the running execution context.
   // 4. Let kind be F.[[ConstructorKind]].
   const kind = F.ConstructorKind;
@@ -262,7 +264,7 @@ function FunctionConstructSlot(argumentsList, newTarget) {
   // 12. If result.[[Type]] is return, then
   if (result.Type === 'return') {
     // a. If Type(result.[[Value]]) is Object, return NormalCompletion(result.[[Value]]).
-    if (Type(result.Value) === 'Object') {
+    if (result.Value instanceof ObjectValue) {
       return NormalCompletion(result.Value);
     }
     // b. If kind is base, return NormalCompletion(thisArgument).
@@ -283,7 +285,7 @@ function FunctionConstructSlot(argumentsList, newTarget) {
 // #sec-functionallocate
 export function OrdinaryFunctionCreate(functionPrototype, sourceText, ParameterList, Body, thisMode, Scope, PrivateScope) {
   // 1. Assert: Type(functionPrototype) is Object.
-  Assert(Type(functionPrototype) === 'Object');
+  Assert(functionPrototype instanceof ObjectValue);
   // 2. Let internalSlotsList be the internal slots listed in Table 33.
   const internalSlotsList = [
     'Environment',
@@ -390,7 +392,7 @@ export function MakeClassConstructor(F) {
 // 9.2.12 #sec-makemethod
 export function MakeMethod(F, homeObject) {
   Assert(isECMAScriptFunctionObject(F));
-  Assert(Type(homeObject) === 'Object');
+  Assert(homeObject instanceof ObjectValue);
   F.HomeObject = homeObject;
   return NormalCompletion(Value.undefined);
 }
@@ -400,7 +402,7 @@ export function SetFunctionName(F, name, prefix) {
   // 1. Assert: F is an extensible object that does not have a "name" own property.
   Assert(IsExtensible(F) === Value.true && HasOwnProperty(F, new Value('name')) === Value.false);
   // 2. If Type(name) is Symbol, then
-  if (Type(name) === 'Symbol') {
+  if (name instanceof SymbolValue) {
     // a. Let description be name's [[Description]] value.
     const description = name.Description;
     // b. If description is undefined, set name to the empty String.

--- a/src/abstract-ops/global-object.mjs
+++ b/src/abstract-ops/global-object.mjs
@@ -1,5 +1,5 @@
 import { ExecutionContext, HostEnsureCanCompileStrings, surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { JSStringValue, Value } from '../value.mjs';
 import { InstantiateFunctionObject } from '../runtime-semantics/all.mjs';
 import {
   IsStrict,
@@ -38,7 +38,7 @@ export function PerformEval(x, callerRealm, strictCaller, direct) {
     Assert(strictCaller === false);
   }
   // 2. If Type(x) is not String, return x.
-  if (Type(x) !== 'String') {
+  if (!(x instanceof JSStringValue)) {
     return x;
   }
   // 3. Let evalRealm be the current Realm Record.

--- a/src/abstract-ops/immutable-prototype-objects.mjs
+++ b/src/abstract-ops/immutable-prototype-objects.mjs
@@ -1,11 +1,11 @@
-import { Type, Value } from '../value.mjs';
+import { NullValue, ObjectValue, Value } from '../value.mjs';
 import { Q } from '../completion.mjs';
 import { Assert, SameValue } from './all.mjs';
 
 // #sec-set-immutable-prototype
 export function SetImmutablePrototype(O, V) {
   // 1. Assert: Either Type(V) is Object or Type(V) is Null.
-  Assert(Type(V) === 'Object' || Type(V) === 'Null');
+  Assert(V instanceof ObjectValue || V instanceof NullValue);
   // 2. Let current be ? O.[[GetPrototypeOf]]().
   const current = Q(O.GetPrototypeOf());
   // 3. If SameValue(V, current) is true, return true.

--- a/src/abstract-ops/integer-indexed-objects.mjs
+++ b/src/abstract-ops/integer-indexed-objects.mjs
@@ -1,4 +1,6 @@
-import { Value, Type, Descriptor } from '../value.mjs';
+import {
+  Value, NumberValue, SymbolValue, JSStringValue, Descriptor,
+} from '../value.mjs';
 import { Q, X } from '../completion.mjs';
 import {
   Assert,
@@ -36,7 +38,7 @@ export function IntegerIndexedGetOwnProperty(P) {
   // 2. Assert: O is an Integer-Indexed exotic object.
   Assert(isIntegerIndexedExoticObject(O));
   // 3. If Type(P) is String, then
-  if (Type(P) === 'String') {
+  if (P instanceof JSStringValue) {
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
     const numericIndex = X(CanonicalNumericIndexString(P));
     // b. If numericIndex is not undefined, then
@@ -68,7 +70,7 @@ export function IntegerIndexedHasProperty(P) {
   // 2. Assert: O is an Integer-Indexed exotic object.
   Assert(isIntegerIndexedExoticObject(O));
   // 3. If Type(P) is String, then
-  if (Type(P) === 'String') {
+  if (P instanceof JSStringValue) {
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
     const numericIndex = X(CanonicalNumericIndexString(P));
     // b. If numericIndex is not undefined, then
@@ -99,7 +101,7 @@ export function IntegerIndexedDefineOwnProperty(P, Desc) {
   // 2. Assert: O is an Integer-Indexed exotic object.
   Assert(isIntegerIndexedExoticObject(O));
   // 3. If Type(P) is String, then
-  if (Type(P) === 'String') {
+  if (P instanceof JSStringValue) {
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
     const numericIndex = X(CanonicalNumericIndexString(P));
     // b. If numericIndex is not undefined, then
@@ -145,7 +147,7 @@ export function IntegerIndexedGet(P, Receiver) {
   // 1. Assert: IsPropertykey(P) is true.
   Assert(IsPropertyKey(P));
   // 2. If Type(P) is String, then
-  if (Type(P) === 'String') {
+  if (P instanceof JSStringValue) {
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
     const numericIndex = X(CanonicalNumericIndexString(P));
     // b. If numericIndex is not undefined, then
@@ -164,7 +166,7 @@ export function IntegerIndexedSet(P, V, Receiver) {
   // 1. Assert: IsPropertyKey(P) is true.
   Assert(IsPropertyKey(P));
   // 2. If Type(P) is String, then
-  if (Type(P) === 'String') {
+  if (P instanceof JSStringValue) {
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
     const numericIndex = X(CanonicalNumericIndexString(P));
     // b. If numericIndex is not undefined, then
@@ -187,7 +189,7 @@ export function IntegerIndexedDelete(P) {
   // 2. Assert: O is an Integer-Indexed exotic object.
   Assert(isIntegerIndexedExoticObject(O));
   // 3. If Type(P) is String, then
-  if (Type(P) === 'String') {
+  if (P instanceof JSStringValue) {
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
     const numericIndex = X(CanonicalNumericIndexString(P));
     // b. If numericIndex is not undefined, then
@@ -224,7 +226,7 @@ export function IntegerIndexedOwnPropertyKeys() {
   }
   // 5. For each own property key P of O such that Type(P) is String and P is not an integer index, in ascending chronological order of property creation, do
   for (const P of O.properties.keys()) {
-    if (Type(P) === 'String') {
+    if (P instanceof JSStringValue) {
       if (!isIntegerIndex(P)) {
         // a. Add P as the last element of keys.
         keys.push(P);
@@ -233,7 +235,7 @@ export function IntegerIndexedOwnPropertyKeys() {
   }
   // 6. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
   for (const P of O.properties.keys()) {
-    if (Type(P) === 'Symbol') {
+    if (P instanceof SymbolValue) {
       // a. Add P as the last element of keys.
       keys.push(P);
     }
@@ -247,7 +249,7 @@ export function IntegerIndexedElementGet(O, index) {
   // 1. Assert: O is an Integer-Indexed exotic object.
   Assert(isIntegerIndexedExoticObject(O));
   // 2. Assert: Type(index) is Number.
-  Assert(Type(index) === 'Number');
+  Assert(index instanceof NumberValue);
   // 3. Let buffer be O.[[ViewedArrayBuffer]].
   const buffer = O.ViewedArrayBuffer;
   // 4. If IsDetachedBuffer(buffer) is true, return undefined.
@@ -277,7 +279,7 @@ export function IntegerIndexedElementSet(O, index, value) {
   // 1. Assert: O is an Integer-Indexed exotic object.
   Assert(isIntegerIndexedExoticObject(O));
   // 2. Assert: Type(index) is Number.
-  Assert(Type(index) === 'Number');
+  Assert(index instanceof NumberValue);
   // 3. If O.[[ContentType]] is BigInt, let numValue be ? ToBigInt(value).
   // 4. Otherwise, let numValue be ? ToNumber(value).
   let numValue;

--- a/src/abstract-ops/iterator-operations.mjs
+++ b/src/abstract-ops/iterator-operations.mjs
@@ -1,6 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
-  Type,
+  BooleanValue,
+  ObjectValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -52,7 +53,7 @@ export function GetIterator(obj, hint, method) {
     }
   }
   const iterator = Q(Call(method, obj));
-  if (Type(iterator) !== 'Object') {
+  if (!(iterator instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', iterator);
   }
   const nextMethod = Q(GetV(iterator, new Value('next')));
@@ -72,7 +73,7 @@ export function IteratorNext(iteratorRecord, value) {
   } else {
     result = Q(Call(iteratorRecord.NextMethod, iteratorRecord.Iterator, [value]));
   }
-  if (Type(result) !== 'Object') {
+  if (!(result instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', result);
   }
   return EnsureCompletion(result);
@@ -80,13 +81,13 @@ export function IteratorNext(iteratorRecord, value) {
 
 // 7.4.3 #sec-iteratorcomplete
 export function IteratorComplete(iterResult) {
-  Assert(Type(iterResult) === 'Object');
+  Assert(iterResult instanceof ObjectValue);
   return EnsureCompletion(ToBoolean(Q(Get(iterResult, new Value('done')))));
 }
 
 // 7.4.4 #sec-iteratorvalue
 export function IteratorValue(iterResult) {
-  Assert(Type(iterResult) === 'Object');
+  Assert(iterResult instanceof ObjectValue);
   return EnsureCompletion(Q(Get(iterResult, new Value('value'))));
 }
 
@@ -103,7 +104,7 @@ export function IteratorStep(iteratorRecord) {
 // #sec-iteratorclose
 export function IteratorClose(iteratorRecord, completion) {
   // 1. Assert: Type(iteratorRecord.[[Iterator]]) is Object.
-  Assert(Type(iteratorRecord.Iterator) === 'Object');
+  Assert(iteratorRecord.Iterator instanceof ObjectValue);
   // 2. Assert: completion is a Completion Record.
   // TODO: completion should be a Completion Record so this should not be necessary
   completion = EnsureCompletion(completion);
@@ -132,7 +133,7 @@ export function IteratorClose(iteratorRecord, completion) {
     return Completion(innerResult);
   }
   // 8. If Type(innerResult.[[Value]]) is not Object, throw a TypeError exception.
-  if (Type(innerResult.Value) !== 'Object') {
+  if (!(innerResult.Value instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', innerResult.Value);
   }
   // 9. Return Completion(completion).
@@ -142,7 +143,7 @@ export function IteratorClose(iteratorRecord, completion) {
 // #sec-asynciteratorclose
 export function* AsyncIteratorClose(iteratorRecord, completion) {
   // 1. Assert: Type(iteratorRecord.[[Iterator]]) is Object.
-  Assert(Type(iteratorRecord.Iterator) === 'Object');
+  Assert(iteratorRecord.Iterator instanceof ObjectValue);
   // 2. Assert: completion is a Completion Record.
   Assert(completion instanceof Completion);
   // 3. Let iterator be iteratorRecord.[[Iterator]].
@@ -173,7 +174,7 @@ export function* AsyncIteratorClose(iteratorRecord, completion) {
     return Completion(innerResult);
   }
   // 8. If Type(innerResult.[[Value]]) is not Object, throw a TypeError exception.
-  if (Type(innerResult.Value) !== 'Object') {
+  if (!(innerResult.Value instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', innerResult.Value);
   }
   // 9. Return Completion(completion).
@@ -182,7 +183,7 @@ export function* AsyncIteratorClose(iteratorRecord, completion) {
 
 // 7.4.8 #sec-createiterresultobject
 export function CreateIterResultObject(value, done) {
-  Assert(Type(done) === 'Boolean');
+  Assert(done instanceof BooleanValue);
   const obj = OrdinaryObjectCreate(surroundingAgent.intrinsic('%Object.prototype%'));
   X(CreateDataProperty(obj, new Value('value'), value));
   X(CreateDataProperty(obj, new Value('done'), done));

--- a/src/abstract-ops/module-namespace-exotic-objects.mjs
+++ b/src/abstract-ops/module-namespace-exotic-objects.mjs
@@ -2,7 +2,7 @@ import { surroundingAgent } from '../engine.mjs';
 import { Q, X } from '../completion.mjs';
 import { AbstractModuleRecord, ResolvedBindingRecord } from '../modules.mjs';
 import {
-  Type,
+  SymbolValue,
   Value,
   Descriptor,
   wellKnownSymbols,
@@ -43,7 +43,7 @@ function ModuleNamespacePreventExtensions() {
 function ModuleNamespaceGetOwnProperty(P) {
   const O = this;
 
-  if (Type(P) === 'Symbol') {
+  if (P instanceof SymbolValue) {
     return OrdinaryGetOwnProperty(O, P);
   }
   const exports = O.Exports;
@@ -62,7 +62,7 @@ function ModuleNamespaceGetOwnProperty(P) {
 function ModuleNamespaceDefineOwnProperty(P, Desc) {
   const O = this;
 
-  if (Type(P) === 'Symbol') {
+  if (P instanceof SymbolValue) {
     return OrdinaryDefineOwnProperty(O, P, Desc);
   }
 
@@ -91,7 +91,7 @@ function ModuleNamespaceDefineOwnProperty(P, Desc) {
 function ModuleNamespaceHasProperty(P) {
   const O = this;
 
-  if (Type(P) === 'Symbol') {
+  if (P instanceof SymbolValue) {
     return OrdinaryHasProperty(O, P);
   }
   const exports = O.Exports;
@@ -108,7 +108,7 @@ function ModuleNamespaceGet(P, Receiver) {
   // 1. Assert: IsPropertyKey(P) is true.
   Assert(IsPropertyKey(P));
   // 2. If Type(P) is Symbol, then
-  if (Type(P) === 'Symbol') {
+  if (P instanceof SymbolValue) {
     // a. Return ? OrdinaryGet(O, P, Receiver).
     return OrdinaryGet(O, P, Receiver);
   }
@@ -151,7 +151,7 @@ function ModuleNamespaceDelete(P) {
   const O = this;
 
   Assert(IsPropertyKey(P));
-  if (Type(P) === 'Symbol') {
+  if (P instanceof SymbolValue) {
     return Q(OrdinaryDelete(O, P));
   }
   const exports = O.Exports;

--- a/src/abstract-ops/notational-conventions.mjs
+++ b/src/abstract-ops/notational-conventions.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type } from '../value.mjs';
+import { ObjectValue } from '../value.mjs';
 
 class AssertError extends Error {}
 
@@ -12,7 +12,7 @@ export function Assert(invariant, source) {
 
 // 9.1.15 #sec-requireinternalslot
 export function RequireInternalSlot(O, internalSlot) {
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', O);
   }
   if (!(internalSlot in O)) {

--- a/src/abstract-ops/promise-operations.mjs
+++ b/src/abstract-ops/promise-operations.mjs
@@ -5,7 +5,7 @@ import {
   HostPromiseRejectionTracker,
   surroundingAgent,
 } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value, UndefinedValue } from '../value.mjs';
 import {
   AbruptCompletion,
   Completion,
@@ -89,7 +89,7 @@ export function CreateResolvingFunctions(promise) {
 function PromiseRejectFunctions([reason = Value.undefined]) {
   const F = this;
 
-  Assert('Promise' in F && Type(F.Promise) === 'Object');
+  Assert('Promise' in F && F.Promise instanceof ObjectValue);
   const promise = F.Promise;
   const alreadyResolved = F.AlreadyResolved;
   if (alreadyResolved.Value === true) {
@@ -138,7 +138,7 @@ function PromiseResolveFunctions([resolution = Value.undefined]) {
   // 1. Let F be the active function object.
   const F = this;
   // 2. Assert: F has a [[Promise]] internal slot whose value is an Object.
-  Assert('Promise' in F && Type(F.Promise) === 'Object');
+  Assert('Promise' in F && F.Promise instanceof ObjectValue);
   // 3. Let promise be F.[[Promise]].
   const promise = F.Promise;
   // 4. Let alreadyResolved be F.[[AlreadyResolved]].
@@ -157,7 +157,7 @@ function PromiseResolveFunctions([resolution = Value.undefined]) {
     return RejectPromise(promise, selfResolutionError);
   }
   // 8. If Type(resolution) is not Object, then
-  if (Type(resolution) !== 'Object') {
+  if (!(resolution instanceof ObjectValue)) {
     // a. Return FulfillPromise(promise, resolution).
     return FulfillPromise(promise, resolution);
   }
@@ -208,11 +208,11 @@ export function NewPromiseCapability(C) {
   // 4. Let executorClosure be a new Abstract Closure with parameters (resolve, reject) that captures promiseCapability and performs the following steps when called:
   const executorClosure = ([resolve = Value.undefined, reject = Value.undefined]) => {
     // a. If promiseCapability.[[Resolve]] is not undefined, throw a TypeError exception.
-    if (Type(promiseCapability.Resolve) !== 'Undefined') {
+    if (!(promiseCapability.Resolve instanceof UndefinedValue)) {
       return surroundingAgent.Throw('TypeError', 'PromiseCapabilityFunctionAlreadySet', 'resolve');
     }
     // b. If promiseCapability.[[Reject]] is not undefined, throw a TypeError exception.
-    if (Type(promiseCapability.Reject) !== 'Undefined') {
+    if (!(promiseCapability.Reject instanceof UndefinedValue)) {
       return surroundingAgent.Throw('TypeError', 'PromiseCapabilityFunctionAlreadySet', 'reject');
     }
     // c. Set promiseCapability.[[Resolve]] to resolve.
@@ -242,7 +242,7 @@ export function NewPromiseCapability(C) {
 
 // 25.6.1.6 #sec-ispromise
 export function IsPromise(x) {
-  if (Type(x) !== 'Object') {
+  if (!(x instanceof ObjectValue)) {
     return Value.false;
   }
   if (!('PromiseState' in x)) {
@@ -280,7 +280,7 @@ function TriggerPromiseReactions(reactions, argument) {
 
 // 25.6.4.5.1 #sec-promise-resolve
 export function PromiseResolve(C, x) {
-  Assert(Type(C) === 'Object');
+  Assert(C instanceof ObjectValue);
   if (IsPromise(x) === Value.true) {
     const xConstructor = Q(Get(x, new Value('constructor')));
     if (SameValue(xConstructor, C) === Value.true) {

--- a/src/abstract-ops/proxy-objects.mjs
+++ b/src/abstract-ops/proxy-objects.mjs
@@ -1,5 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import {
+  UndefinedValue, NullValue, ObjectValue, Value,
+} from '../value.mjs';
 import { Q, X } from '../completion.mjs';
 import { ValueSet } from '../helpers.mjs';
 import {
@@ -32,14 +34,14 @@ function ProxyGetPrototypeOf() {
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'getPrototypeOf');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   const trap = Q(GetMethod(handler, new Value('getPrototypeOf')));
   if (trap === Value.undefined) {
     return Q(target.GetPrototypeOf());
   }
   const handlerProto = Q(Call(trap, handler, [target]));
-  if (Type(handlerProto) !== 'Object' && Type(handlerProto) !== 'Null') {
+  if (!(handlerProto instanceof ObjectValue) && !(handlerProto instanceof NullValue)) {
     return surroundingAgent.Throw('TypeError', 'ProxyGetPrototypeOfInvalid');
   }
   const extensibleTarget = Q(IsExtensible(target));
@@ -57,12 +59,12 @@ function ProxyGetPrototypeOf() {
 function ProxySetPrototypeOf(V) {
   const O = this;
 
-  Assert(Type(V) === 'Object' || Type(V) === 'Null');
+  Assert(V instanceof ObjectValue || V instanceof NullValue);
   const handler = O.ProxyHandler;
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'setPrototypeOf');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   const trap = Q(GetMethod(handler, new Value('setPrototypeOf')));
   if (trap === Value.undefined) {
@@ -91,7 +93,7 @@ function ProxyIsExtensible() {
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'isExtensible');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   const trap = Q(GetMethod(handler, new Value('isExtensible')));
   if (trap === Value.undefined) {
@@ -113,7 +115,7 @@ function ProxyPreventExtensions() {
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'preventExtensions');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   const trap = Q(GetMethod(handler, new Value('preventExtensions')));
   if (trap === Value.undefined) {
@@ -142,7 +144,7 @@ function ProxyGetOwnProperty(P) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'getOwnPropertyDescriptor');
   }
   // 4. Assert: Type(Handler) is Object.
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   // 5. Let target be O.[[ProxyTarget]].
   const target = O.ProxyTarget;
   // 6. Let trap be ? Getmethod(handler, "getOwnPropertyDescriptor").
@@ -155,7 +157,7 @@ function ProxyGetOwnProperty(P) {
   // 8. Let trapResultObj be ? Call(trap, handler, « target, P »).
   const trapResultObj = Q(Call(trap, handler, [target, P]));
   // 9. If Type(trapResultObj) is neither Object nor Undefined, throw a TypeError exception.
-  if (Type(trapResultObj) !== 'Object' && Type(trapResultObj) !== 'Undefined') {
+  if (!(trapResultObj instanceof ObjectValue) && !(trapResultObj instanceof UndefinedValue)) {
     return surroundingAgent.Throw('TypeError', 'ProxyGetOwnPropertyDescriptorInvalid', P);
   }
   // 10. Let targetDesc be ? target.[[GetOwnProperty]](P).
@@ -223,7 +225,7 @@ function ProxyDefineOwnProperty(P, Desc) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'defineProperty');
   }
   // 4. Assert: Type(handler) is Object.
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   // 5. Let target be O.[[ProxyTarget]].
   const target = O.ProxyTarget;
   // 6. Let trap be ? GetMethod(handler, "defineProperty").
@@ -295,7 +297,7 @@ function ProxyHasProperty(P) {
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'has');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   const trap = Q(GetMethod(handler, new Value('has')));
   if (trap === Value.undefined) {
@@ -326,7 +328,7 @@ function ProxyGet(P, Receiver) {
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'get');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   const trap = Q(GetMethod(handler, new Value('get')));
   if (trap === Value.undefined) {
@@ -358,7 +360,7 @@ function ProxySet(P, V, Receiver) {
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'set');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   const trap = Q(GetMethod(handler, new Value('set')));
   if (trap === Value.undefined) {
@@ -397,7 +399,7 @@ function ProxyDelete(P) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'deleteProperty');
   }
   // 4. Assert: Type(handler) is Object.
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   // 5. Let target be O.[[ProxyTarget]].
   const target = O.ProxyTarget;
   // 6. Let trap be ? GetMethod(handler, "deleteProperty").
@@ -441,7 +443,7 @@ function ProxyOwnPropertyKeys() {
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'ownKeys');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   const trap = Q(GetMethod(handler, new Value('ownKeys')));
   if (trap === Value.undefined) {
@@ -499,7 +501,7 @@ function ProxyCall(thisArgument, argumentsList) {
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'apply');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   const trap = Q(GetMethod(handler, new Value('apply')));
   if (trap === Value.undefined) {
@@ -517,7 +519,7 @@ function ProxyConstruct(argumentsList, newTarget) {
   if (handler === Value.null) {
     return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'construct');
   }
-  Assert(Type(handler) === 'Object');
+  Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
   Assert(IsConstructor(target) === Value.true);
   const trap = Q(GetMethod(handler, new Value('construct')));
@@ -526,7 +528,7 @@ function ProxyConstruct(argumentsList, newTarget) {
   }
   const argArray = X(CreateArrayFromList(argumentsList));
   const newObj = Q(Call(trap, handler, [target, argArray, newTarget]));
-  if (Type(newObj) !== 'Object') {
+  if (!(newObj instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', newObj);
   }
   return newObj;
@@ -539,11 +541,11 @@ export function isProxyExoticObject(O) {
 // #sec-proxycreate
 export function ProxyCreate(target, handler) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'CannotCreateProxyWith', 'non-object', 'target');
   }
   // 2. If Type(handler) is not Object, throw a TypeError exception.
-  if (Type(handler) !== 'Object') {
+  if (!(handler instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'CannotCreateProxyWith', 'non-object', 'handler');
   }
   // 3. Let P be ! MakeBasicObject(« [[ProxyHandler]], [[ProxyTarget]] »).

--- a/src/abstract-ops/regexp-objects.mjs
+++ b/src/abstract-ops/regexp-objects.mjs
@@ -1,5 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Descriptor, Value, Type } from '../value.mjs';
+import {
+  Descriptor, Value, ObjectValue, BooleanValue, JSStringValue,
+} from '../value.mjs';
 import { Q, X } from '../completion.mjs';
 import { Evaluate_Pattern } from '../runtime-semantics/all.mjs';
 import { ParsePattern } from '../parse.mjs';
@@ -155,7 +157,7 @@ export function EscapeRegExpPattern(P, _F) {
 // #sec-getstringindex
 export function GetStringIndex(S, Input, e) {
   // 1. Assert: Type(S) is String.
-  Assert(Type(S) === 'String');
+  Assert(S instanceof JSStringValue);
   // 2. Assert: Input is a List of the code points of S interpreted as a UTF-16 encoded string.
   Assert(Array.isArray(Input));
   // 3. Assert: e is an integer value ≥ 0.
@@ -181,7 +183,7 @@ export function GetStringIndex(S, Input, e) {
 // #sec-getmatchstring
 export function GetMatchString(S, match) {
   // 1. Assert: Type(S) is String.
-  Assert(Type(S) === 'String');
+  Assert(S instanceof JSStringValue);
   // 2. Assert: match is a Match Record.
   Assert('StartIndex' in match && 'EndIndex' in match);
   // 3. Assert: match.[[StartIndex]] is an integer value ≥ 0 and ≤ the length of S.
@@ -195,7 +197,7 @@ export function GetMatchString(S, match) {
 // #sec-getmatchindexpair
 export function GetMatchIndexPair(S, match) {
   // 1. Assert: Type(S) is String.
-  Assert(Type(S) === 'String');
+  Assert(S instanceof JSStringValue);
   // 2. Assert: match is a Match Record.
   Assert('StartIndex' in match && 'EndIndex' in match);
   // 3. Assert: match.[[StartIndex]] is an integer value ≥ 0 and ≤ the length of S.
@@ -212,7 +214,7 @@ export function GetMatchIndexPair(S, match) {
 // #sec-makematchindicesindexpairarray
 export function MakeMatchIndicesIndexPairArray(S, indices, groupNames, hasGroups) {
   // 1. Assert: Type(S) is String.
-  Assert(Type(S) === 'String');
+  Assert(S instanceof JSStringValue);
   // 2. Assert: indices is a List.
   Assert(Array.isArray(indices));
   // 3. Let n be the number of elements in indices.
@@ -223,7 +225,7 @@ export function MakeMatchIndicesIndexPairArray(S, indices, groupNames, hasGroups
   Assert(Array.isArray(groupNames) && groupNames.length === n - 1);
   // 6. NOTE: The groupNames List contains elements aligned with the indices List starting at indices[1].
   // 7. Assert: Type(hasGroups) is Boolean.
-  Assert(Type(hasGroups) === 'Boolean');
+  Assert(hasGroups instanceof BooleanValue);
   // 8. Set A to ! ArrayCreate(n).
   // 9. Assert: The value of A's "length" property is n.
   const A = X(ArrayCreate(n));
@@ -266,7 +268,7 @@ export function MakeMatchIndicesIndexPairArray(S, indices, groupNames, hasGroups
 // #sec-regexphasflag
 export function RegExpHasFlag(R, codeUnit) {
   // 1. If Type(R) is not Object, throw a TypeError exception.
-  if (Type(R) !== 'Object') {
+  if (!(R instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', R);
   }
   // 2. If R does not have an [[OriginalFlags]] internal slot, then

--- a/src/abstract-ops/spec-types.mjs
+++ b/src/abstract-ops/spec-types.mjs
@@ -5,6 +5,8 @@ import {
   Descriptor,
   NumberValue,
   Type,
+  ObjectValue,
+  UndefinedValue,
   Value,
 } from '../value.mjs';
 import { NormalCompletion, Q, X } from '../completion.mjs';
@@ -33,7 +35,7 @@ export function Z(x) {
 
 // 6.2.5.1 IsAccessorDescriptor
 export function IsAccessorDescriptor(Desc) {
-  if (Type(Desc) === 'Undefined') {
+  if (Desc instanceof UndefinedValue) {
     return false;
   }
 
@@ -46,7 +48,7 @@ export function IsAccessorDescriptor(Desc) {
 
 // 6.2.5.2 IsDataDescriptor
 export function IsDataDescriptor(Desc) {
-  if (Type(Desc) === 'Undefined') {
+  if (Desc instanceof UndefinedValue) {
     return false;
   }
 
@@ -59,7 +61,7 @@ export function IsDataDescriptor(Desc) {
 
 // 6.2.5.3 IsGenericDescriptor
 export function IsGenericDescriptor(Desc) {
-  if (Type(Desc) === 'Undefined') {
+  if (Desc instanceof UndefinedValue) {
     return false;
   }
 
@@ -72,7 +74,7 @@ export function IsGenericDescriptor(Desc) {
 
 // 6.2.5.4 #sec-frompropertydescriptor
 export function FromPropertyDescriptor(Desc) {
-  if (Type(Desc) === 'Undefined') {
+  if (Desc instanceof UndefinedValue) {
     return Value.undefined;
   }
   const obj = OrdinaryObjectCreate(surroundingAgent.intrinsic('%Object.prototype%'));
@@ -100,7 +102,7 @@ export function FromPropertyDescriptor(Desc) {
 
 // 6.2.5.5 #sec-topropertydescriptor
 export function ToPropertyDescriptor(Obj) {
-  if (Type(Obj) !== 'Object') {
+  if (!(Obj instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', Obj);
   }
 
@@ -128,7 +130,7 @@ export function ToPropertyDescriptor(Obj) {
   const hasGet = Q(HasProperty(Obj, new Value('get')));
   if (hasGet === Value.true) {
     const getter = Q(Get(Obj, new Value('get')));
-    if (IsCallable(getter) === Value.false && Type(getter) !== 'Undefined') {
+    if (IsCallable(getter) === Value.false && !(getter instanceof UndefinedValue)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', getter);
     }
     desc.Get = getter;
@@ -136,7 +138,7 @@ export function ToPropertyDescriptor(Obj) {
   const hasSet = Q(HasProperty(Obj, new Value('set')));
   if (hasSet === Value.true) {
     const setter = Q(Get(Obj, new Value('set')));
-    if (IsCallable(setter) === Value.false && Type(setter) !== 'Undefined') {
+    if (IsCallable(setter) === Value.false && !(setter instanceof UndefinedValue)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', setter);
     }
     desc.Set = setter;
@@ -151,7 +153,7 @@ export function ToPropertyDescriptor(Obj) {
 
 // 6.2.5.6 #sec-completepropertydescriptor
 export function CompletePropertyDescriptor(Desc) {
-  Assert(Type(Desc) === 'Descriptor');
+  Assert(Desc instanceof Descriptor);
   const like = Descriptor({
     Value: Value.undefined,
     Writable: Value.false,
@@ -199,8 +201,8 @@ export function CreateByteDataBlock(size) {
 // 6.2.7.3 #sec-copydatablockbytes
 export function CopyDataBlockBytes(toBlock, toIndex, fromBlock, fromIndex, count) {
   Assert(fromBlock !== toBlock);
-  Assert(Type(fromBlock) === 'Data Block' || Type(fromBlock) === 'Shared Data Block');
-  Assert(Type(toBlock) === 'Data Block' || Type(toBlock) === 'Shared Data Block');
+  Assert(fromBlock instanceof DataBlock || Type(fromBlock) === 'Shared Data Block');
+  Assert(toBlock instanceof DataBlock || Type(toBlock) === 'Shared Data Block');
   Assert(Number.isSafeInteger(fromIndex) && fromIndex >= 0);
   Assert(Number.isSafeInteger(toIndex) && toIndex >= 0);
   Assert(Number.isSafeInteger(count) && count >= 0);

--- a/src/abstract-ops/symbol-objects.mjs
+++ b/src/abstract-ops/symbol-objects.mjs
@@ -1,11 +1,11 @@
-import { Type, Value } from '../value.mjs';
+import { UndefinedValue, SymbolValue, Value } from '../value.mjs';
 import { Assert } from './all.mjs';
 
 // 19.4.3.3.1 #sec-symboldescriptivestring
 export function SymbolDescriptiveString(sym) {
-  Assert(Type(sym) === 'Symbol');
+  Assert(sym instanceof SymbolValue);
   let desc = sym.Description;
-  if (Type(desc) === 'Undefined') {
+  if (desc instanceof UndefinedValue) {
     desc = new Value('');
   }
   return new Value(`Symbol(${desc.stringValue()})`);

--- a/src/abstract-ops/typedarray-objects.mjs
+++ b/src/abstract-ops/typedarray-objects.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value, NumberValue } from '../value.mjs';
 import { Q, X } from '../completion.mjs';
 import {
   Assert,
@@ -122,7 +122,7 @@ export function TypedArrayCreate(constructor, argumentList) {
   // 2. Perform ? ValidateTypedArray(newTypedArray).
   Q(ValidateTypedArray(newTypedArray));
   // 3. If argumentList is a List of a single Number, then
-  if (argumentList.length === 1 && Type(argumentList[0]) === 'Number') {
+  if (argumentList.length === 1 && argumentList[0] instanceof NumberValue) {
     // a. If newTypedArray.[[ArrayLength]] < argumentList[0], throw a TypeError exception.
     if (newTypedArray.ArrayLength < argumentList[0].numberValue()) {
       return surroundingAgent.Throw('TypeError', 'TypedArrayTooSmall');
@@ -168,7 +168,7 @@ export function AllocateTypedArray(constructorName, newTarget, defaultProto, len
 // #sec-allocatetypedarraybuffer
 export function AllocateTypedArrayBuffer(O, length) {
   // 1. Assert: O is an Object that has a [[ViewedArrayBuffer]] internal slot.
-  Assert(Type(O) === 'Object' && 'ViewedArrayBuffer' in O);
+  Assert(O instanceof ObjectValue && 'ViewedArrayBuffer' in O);
   // 2. Assert: O.[[ViewedArrayBuffer]] is undefined.
   Assert(O.ViewedArrayBuffer === Value.undefined);
   // 3. Assert: length is a non-negative integer.
@@ -196,7 +196,7 @@ export function AllocateTypedArrayBuffer(O, length) {
 // #typedarray-species-create
 export function TypedArraySpeciesCreate(exemplar, argumentList) {
   // 1. Assert: exemplar is an Object that has [[TypedArrayName]] and [[ContentType]] internal slots.
-  Assert(Type(exemplar) === 'Object'
+  Assert(exemplar instanceof ObjectValue
          && 'TypedArrayName' in exemplar
          && 'ContentType' in exemplar);
   // 2. Let defaultConstructor be the intrinsic object listed in column one of Table 61 for exemplar.[[TypedArrayName]].

--- a/src/environment.mjs
+++ b/src/environment.mjs
@@ -2,7 +2,8 @@ import { AbstractModuleRecord } from './modules.mjs';
 import {
   Descriptor,
   ReferenceRecord,
-  Type,
+  UndefinedValue,
+  ObjectValue,
   Value,
   wellKnownSymbols,
 } from './value.mjs';
@@ -240,7 +241,7 @@ export class ObjectEnvironmentRecord extends EnvironmentRecord {
     // 6. Let unscopables be ? Get(bindings, @@unscopables).
     const unscopables = Q(Get(bindings, wellKnownSymbols.unscopables));
     // 7. If Type(unscopables) is Object, then
-    if (Type(unscopables) === 'Object') {
+    if (unscopables instanceof ObjectValue) {
       // a. Let blocked be ! ToBoolean(? Get(unscopables, N)).
       const blocked = X(ToBoolean(Q(Get(unscopables, N))));
       // b. If blocked is true, return false.
@@ -438,7 +439,7 @@ export class FunctionEnvironmentRecord extends DeclarativeEnvironmentRecord {
       return Value.undefined;
     }
     // 3. Assert: Type(home) is Object.
-    Assert(Type(home) === 'Object');
+    Assert(home instanceof ObjectValue);
     // 4. Return ? home.[[GetPrototypeOf]]().
     return Q(home.GetPrototypeOf());
   }
@@ -926,7 +927,7 @@ export function NewFunctionEnvironment(F, newTarget) {
   // 1. Assert: F is an ECMAScript function.
   Assert(isECMAScriptFunctionObject(F));
   // 2. Assert: Type(newTarget) is Undefined or Object.
-  Assert(Type(newTarget) === 'Undefined' || Type(newTarget) === 'Object');
+  Assert(newTarget instanceof UndefinedValue || newTarget instanceof ObjectValue);
   // 3. Let env be a new function Environment Record containing no bindings.
   const env = new FunctionEnvironmentRecord();
   // 4. Set env.[[FunctionObject]] to F.

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -1,19 +1,19 @@
 import { surroundingAgent } from './engine.mjs';
-import { Type, Value, Descriptor } from './value.mjs';
+import {
+  Value, Descriptor, JSStringValue, NumberValue,
+} from './value.mjs';
 import { ToString, DefinePropertyOrThrow, CreateBuiltinFunction } from './abstract-ops/all.mjs';
 import { X } from './completion.mjs';
 
 export const kInternal = Symbol('kInternal');
 
 function convertValueForKey(key) {
-  switch (Type(key)) {
-    case 'String':
-      return key.stringValue();
-    case 'Number':
-      return key.numberValue();
-    default:
-      return key;
+  if (key instanceof JSStringValue) {
+    return key.stringValue();
+  } else if (key instanceof NumberValue) {
+    return key.numberValue();
   }
+  return key;
 }
 
 export class ValueMap {

--- a/src/inspect.mjs
+++ b/src/inspect.mjs
@@ -1,5 +1,7 @@
 import { surroundingAgent } from './engine.mjs';
-import { Type, Value, wellKnownSymbols } from './value.mjs';
+import {
+  Type, JSStringValue, ObjectValue, Value, wellKnownSymbols,
+} from './value.mjs';
 import {
   Call, IsArray, Get, LengthOfArrayLike,
   EscapeRegExpPattern,
@@ -35,7 +37,7 @@ const compactObject = (realm, value) => {
     } else {
       const tag = getObjectTag(value, false) || 'Unknown';
       const ctor = X(Get(value, new Value('constructor')));
-      if (Type(ctor) === 'Object') {
+      if (ctor instanceof ObjectValue) {
         const ctorName = X(Get(ctor, new Value('name'))).stringValue();
         if (ctorName !== '') {
           return `#<${ctorName}>`;
@@ -168,7 +170,7 @@ const INSPECTORS = {
         const C = X(v.GetOwnProperty(key));
         if (C.Enumerable === Value.true) {
           cache.push([
-            Type(key) === 'String' && bareKeyRe.test(key.stringValue()) ? key.stringValue() : i(key),
+            key instanceof JSStringValue && bareKeyRe.test(key.stringValue()) ? key.stringValue() : i(key),
             C.Value ? i(C.Value) : '<accessor>',
           ]);
         }

--- a/src/intrinsics/Array.mjs
+++ b/src/intrinsics/Array.mjs
@@ -31,7 +31,8 @@ import {
   F,
 } from '../abstract-ops/all.mjs';
 import {
-  Type,
+  NumberValue,
+  UndefinedValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -44,7 +45,7 @@ function ArrayConstructor(argumentsList, { NewTarget }) {
   if (numberOfArgs === 0) {
     // 22.1.1.1 #sec-array-constructor-array
     Assert(numberOfArgs === 0);
-    if (Type(NewTarget) === 'Undefined') {
+    if (NewTarget instanceof UndefinedValue) {
       NewTarget = surroundingAgent.activeFunctionObject;
     }
     const proto = GetPrototypeFromConstructor(NewTarget, '%Array.prototype%');
@@ -53,13 +54,13 @@ function ArrayConstructor(argumentsList, { NewTarget }) {
     // 22.1.1.2 #sec-array-len
     const [len] = argumentsList;
     Assert(numberOfArgs === 1);
-    if (Type(NewTarget) === 'Undefined') {
+    if (NewTarget instanceof UndefinedValue) {
       NewTarget = surroundingAgent.activeFunctionObject;
     }
     const proto = GetPrototypeFromConstructor(NewTarget, '%Array.prototype%');
     const array = ArrayCreate(0, proto);
     let intLen;
-    if (Type(len) !== 'Number') {
+    if (!(len instanceof NumberValue)) {
       const defineStatus = X(CreateDataProperty(array, new Value('0'), len));
       Assert(defineStatus === Value.true);
       intLen = F(1);
@@ -75,7 +76,7 @@ function ArrayConstructor(argumentsList, { NewTarget }) {
     // 22.1.1.3 #sec-array-items
     const items = argumentsList;
     Assert(numberOfArgs >= 2);
-    if (Type(NewTarget) === 'Undefined') {
+    if (NewTarget instanceof UndefinedValue) {
       NewTarget = surroundingAgent.activeFunctionObject;
     }
     const proto = GetPrototypeFromConstructor(NewTarget, '%Array.prototype%');

--- a/src/intrinsics/ArrayBuffer.mjs
+++ b/src/intrinsics/ArrayBuffer.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value, wellKnownSymbols } from '../value.mjs';
+import { ObjectValue, Value, wellKnownSymbols } from '../value.mjs';
 import { Q } from '../completion.mjs';
 import { ToIndex, AllocateArrayBuffer } from '../abstract-ops/all.mjs';
 import { bootstrapConstructor } from './bootstrap.mjs';
@@ -19,7 +19,7 @@ function ArrayBufferConstructor([length = Value.undefined], { NewTarget }) {
 // #sec-arraybuffer.isview
 function ArrayBuffer_isView([arg = Value.undefined]) {
   // 1. If Type(arg) is not Object, return false.
-  if (Type(arg) !== 'Object') {
+  if (!(arg instanceof ObjectValue)) {
     return Value.false;
   }
   // 2. If arg has a [[ViewedArrayBuffer]] internal slot, return true.

--- a/src/intrinsics/ArrayPrototype.mjs
+++ b/src/intrinsics/ArrayPrototype.mjs
@@ -1,7 +1,8 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
   Descriptor,
-  Type,
+  ObjectValue,
+  UndefinedValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -146,7 +147,7 @@ function ArrayProto_fill([value = Value.undefined, start = Value.undefined, end 
     k = Math.min(relativeStart, len);
   }
   let relativeEnd;
-  if (Type(end) === 'Undefined') {
+  if (end instanceof UndefinedValue) {
     relativeEnd = len;
   } else {
     relativeEnd = Q(ToIntegerOrInfinity(end));
@@ -193,8 +194,8 @@ function ArrayProto_filter([callbackfn = Value.undefined, thisArg = Value.undefi
 
 // 22.1.3.10.1 #sec-flattenintoarray
 function FlattenIntoArray(target, source, sourceLen, start, depth, mapperFunction, thisArg) {
-  Assert(Type(target) === 'Object');
-  Assert(Type(source) === 'Object');
+  Assert(target instanceof ObjectValue);
+  Assert(source instanceof ObjectValue);
   Assert(sourceLen >= 0);
   Assert(start >= 0);
   // Assert: _depth_ is an integer Number, *+&infin;*, or *-&infin;*.
@@ -356,7 +357,7 @@ function ArrayProto_slice([start = Value.undefined, end = Value.undefined], { th
     k = Math.min(relativeStart, len);
   }
   let relativeEnd;
-  if (Type(end) === 'Undefined') {
+  if (end instanceof UndefinedValue) {
     relativeEnd = len;
   } else {
     relativeEnd = Q(ToIntegerOrInfinity(end));

--- a/src/intrinsics/ArrayPrototypeShared.mjs
+++ b/src/intrinsics/ArrayPrototypeShared.mjs
@@ -17,7 +17,7 @@ import {
 } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { NullValue, UndefinedValue, Value } from '../value.mjs';
 import { assignProps } from './bootstrap.mjs';
 
 // Algorithms and methods shared between %Array.prototype% and
@@ -348,7 +348,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
     let sep;
-    if (Type(separator) === 'Undefined') {
+    if (separator instanceof UndefinedValue) {
       sep = ',';
     } else {
       sep = Q(ToString(separator)).stringValue();
@@ -362,7 +362,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
       const kStr = X(ToString(F(k)));
       const element = Q(Get(O, kStr));
       let next;
-      if (Type(element) === 'Undefined' || Type(element) === 'Null') {
+      if (element instanceof UndefinedValue || element instanceof NullValue) {
         next = '';
       } else {
         next = Q(ToString(element)).stringValue();

--- a/src/intrinsics/AsyncFromSyncIteratorPrototype.mjs
+++ b/src/intrinsics/AsyncFromSyncIteratorPrototype.mjs
@@ -8,7 +8,7 @@ import {
   NewPromiseCapability,
   Assert,
 } from '../abstract-ops/all.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value } from '../value.mjs';
 import { IfAbruptRejectPromise, X } from '../completion.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
@@ -17,7 +17,7 @@ function AsyncFromSyncIteratorPrototype_next([value], { thisValue }) {
   // 1. Let O be the this value.
   const O = thisValue;
   // 2. Assert: Type(O) is Object and O has a [[SyncIteratorRecord]] internal slot.
-  Assert(Type(O) === 'Object' && 'SyncIteratorRecord' in O);
+  Assert(O instanceof ObjectValue && 'SyncIteratorRecord' in O);
   // 3. Let promiseCapability be ! NewPromiseCapability(%Promise%).
   const promiseCapability = X(NewPromiseCapability(surroundingAgent.intrinsic('%Promise%')));
   // 4. Let syncIteratorRecord be O.[[SyncIteratorRecord]].
@@ -42,7 +42,7 @@ function AsyncFromSyncIteratorPrototype_return([value], { thisValue }) {
   // 1. Let O be the this value.
   const O = thisValue;
   // 2. Assert: Type(O) is Object and O has a [[SyncIteratorRecord]] internal slot.
-  Assert(Type(O) === 'Object' && 'SyncIteratorRecord' in O);
+  Assert(O instanceof ObjectValue && 'SyncIteratorRecord' in O);
   // 3. Let promiseCapability be ! NewPromiseCapability(%Promise%).
   const promiseCapability = X(NewPromiseCapability(surroundingAgent.intrinsic('%Promise%')));
   // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
@@ -72,7 +72,7 @@ function AsyncFromSyncIteratorPrototype_return([value], { thisValue }) {
   // 10. IfAbruptRejectPromise(result, promiseCapability).
   IfAbruptRejectPromise(result, promiseCapability);
   // 11. If Type(result) is not Object, then
-  if (Type(result) !== 'Object') {
+  if (!(result instanceof ObjectValue)) {
     // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
     X(Call(promiseCapability.Reject, Value.undefined, [
       surroundingAgent.Throw('TypeError', 'NotAnObject', result).Value,
@@ -89,7 +89,7 @@ function AsyncFromSyncIteratorPrototype_throw([value], { thisValue }) {
   // 1. Let O be this value.
   const O = thisValue;
   // 2. Assert: Type(O) is Object and O has a [[SyncIteratorRecord]] internal slot.
-  Assert(Type(O) === 'Object' && 'SyncIteratorRecord' in O);
+  Assert(O instanceof ObjectValue && 'SyncIteratorRecord' in O);
   // 3. Let promiseCapability be ! NewPromiseCapability(%Promise%).
   const promiseCapability = X(NewPromiseCapability(surroundingAgent.intrinsic('%Promise%')));
   // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
@@ -117,7 +117,7 @@ function AsyncFromSyncIteratorPrototype_throw([value], { thisValue }) {
   // 10. IfAbruptRejectPromise(result, promiseCapability).
   IfAbruptRejectPromise(result, promiseCapability);
   // 11. If Type(result) is not Object, then
-  if (Type(result) !== 'Object') {
+  if (!(result instanceof ObjectValue)) {
     // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
     X(Call(promiseCapability.Reject, Value.undefined, [
       surroundingAgent.Throw('TypeError', 'NotAnObject', result).Value,

--- a/src/intrinsics/BigInt.mjs
+++ b/src/intrinsics/BigInt.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { NumberValue, Value } from '../value.mjs';
 import {
   ToBigInt,
   ToIndex,
@@ -20,7 +20,7 @@ function BigIntConstructor([value], { NewTarget }) {
   const prim = Q(ToPrimitive(value, 'number'));
   // 3. If Type(prim) is Number, return ? NumberToBigInt(prim).
   // 4. Otherwise, return ? ToBigInt(value).
-  if (Type(prim) === 'Number') {
+  if (prim instanceof NumberValue) {
     return Q(NumberToBigInt(prim));
   } else {
     return Q(ToBigInt(value));

--- a/src/intrinsics/BigIntPrototype.mjs
+++ b/src/intrinsics/BigIntPrototype.mjs
@@ -1,5 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import {
+  ObjectValue, BigIntValue, Value,
+} from '../value.mjs';
 import { Assert, ToIntegerOrInfinity, ToString } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
@@ -7,13 +9,13 @@ import { bootstrapPrototype } from './bootstrap.mjs';
 // #sec-thisbigintvalue
 function thisBigIntValue(value) {
   // 1. If Type(value) is BigInt, return value.
-  if (Type(value) === 'BigInt') {
+  if (value instanceof BigIntValue) {
     return value;
   }
   // 2. If Type(value) is Object and value has a [[BigIntData]] internal slot, then
-  if (Type(value) === 'Object' && 'BigIntData' in value) {
+  if (value instanceof ObjectValue && 'BigIntData' in value) {
     // a. Assert: Type(value.[[BigIntData]]) is BigInt.
-    Assert(Type(value.BigIntData) === 'BigInt');
+    Assert(value.BigIntData instanceof BigIntValue);
     // b. Return value.[[BigIntData]].
     return value.BigIntData;
   }

--- a/src/intrinsics/BooleanPrototype.mjs
+++ b/src/intrinsics/BooleanPrototype.mjs
@@ -1,5 +1,6 @@
 import {
-  Type,
+  ObjectValue,
+  BooleanValue,
   Value,
 } from '../value.mjs';
 import {
@@ -11,13 +12,13 @@ import { bootstrapPrototype } from './bootstrap.mjs';
 
 
 function thisBooleanValue(value) {
-  if (Type(value) === 'Boolean') {
+  if (value instanceof BooleanValue) {
     return value;
   }
 
-  if (Type(value) === 'Object' && 'BooleanData' in value) {
+  if (value instanceof ObjectValue && 'BooleanData' in value) {
     const b = value.BooleanData;
-    Assert(Type(b) === 'Boolean');
+    Assert(b instanceof BooleanValue);
     return b;
   }
 

--- a/src/intrinsics/Date.mjs
+++ b/src/intrinsics/Date.mjs
@@ -12,7 +12,7 @@ import {
   TimeClip,
   F,
 } from '../abstract-ops/all.mjs';
-import { Value, Type } from '../value.mjs';
+import { Value, JSStringValue, ObjectValue } from '../value.mjs';
 import {
   AbruptCompletion,
   Q, X,
@@ -88,11 +88,11 @@ function DateConstructor(args, { NewTarget }) {
       return ToDateString(F(now));
     } else {
       let tv;
-      if (Type(value) === 'Object' && 'DateValue' in value) {
+      if (value instanceof ObjectValue && 'DateValue' in value) {
         tv = thisTimeValue(value);
       } else {
         const v = Q(ToPrimitive(value));
-        if (Type(v) === 'String') {
+        if (v instanceof JSStringValue) {
           // Assert: The next step never returns an abrupt completion because Type(v) is String.
           tv = parseDate(v);
         } else {

--- a/src/intrinsics/DatePrototype.mjs
+++ b/src/intrinsics/DatePrototype.mjs
@@ -27,7 +27,9 @@ import {
   F,
 } from '../abstract-ops/all.mjs';
 import {
-  Type,
+  JSStringValue,
+  NumberValue,
+  ObjectValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -37,7 +39,7 @@ import { bootstrapPrototype } from './bootstrap.mjs';
 
 
 export function thisTimeValue(value) {
-  if (Type(value) === 'Object' && 'DateValue' in value) {
+  if (value instanceof ObjectValue && 'DateValue' in value) {
     return value.DateValue;
   }
   return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Date', value);
@@ -473,7 +475,7 @@ function DateProto_setUTCSeconds([sec = Value.undefined, ms], { thisValue }) {
 // 20.3.4.35 #sec-date.prototype.todatestring
 function DateProto_toDateString(args, { thisValue }) {
   const O = thisValue;
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Date', O);
   }
   const tv = Q(thisTimeValue(O));
@@ -517,7 +519,7 @@ function DateProto_toISOString(args, { thisValue }) {
 function DateProto_toJSON(args, { thisValue }) {
   const O = Q(ToObject(thisValue));
   const tv = Q(ToPrimitive(O, 'number'));
-  if (Type(tv) === 'Number' && !Number.isFinite(tv.numberValue())) {
+  if (tv instanceof NumberValue && !Number.isFinite(tv.numberValue())) {
     return Value.null;
   }
   return Q(Invoke(O, new Value('toISOString')));
@@ -549,7 +551,7 @@ function DateProto_toString(args, { thisValue }) {
 
 // 20.3.4.41.1 #sec-timestring
 function TimeString(tv) {
-  Assert(Type(tv) === 'Number');
+  Assert(tv instanceof NumberValue);
   Assert(!tv.isNaN());
   const hour = String(HourFromTime(tv).numberValue()).padStart(2, '0');
   const minute = String(MinFromTime(tv).numberValue()).padStart(2, '0');
@@ -564,7 +566,7 @@ const monthsOfTheYear = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
 
 // 20.3.4.41.2 #sec-datestring
 function DateString(tv) {
-  Assert(Type(tv) === 'Number');
+  Assert(tv instanceof NumberValue);
   Assert(!tv.isNaN());
   const weekday = daysOfTheWeek[WeekDay(tv).numberValue()];
   const month = monthsOfTheYear[MonthFromTime(tv).numberValue()];
@@ -578,7 +580,7 @@ function DateString(tv) {
 
 // 20.3.4.41.3 #sec-timezoneestring
 export function TimeZoneString(tv) {
-  Assert(Type(tv) === 'Number');
+  Assert(tv instanceof NumberValue);
   Assert(!tv.isNaN());
   const offset = LocalTZA(tv, true);
   const offsetSign = offset >= 0 ? '+' : '-';
@@ -590,7 +592,7 @@ export function TimeZoneString(tv) {
 
 // 20.3.4.41.4 #sec-todatestring
 export function ToDateString(tv) {
-  Assert(Type(tv) === 'Number');
+  Assert(tv instanceof NumberValue);
   if (tv.isNaN()) {
     return new Value('Invalid Date');
   }
@@ -601,7 +603,7 @@ export function ToDateString(tv) {
 // 20.3.4.42 #sec-date.prototype.totimestring
 function DateProto_toTimeString(args, { thisValue }) {
   const O = thisValue;
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Date', O);
   }
   const tv = Q(thisTimeValue(O));
@@ -615,7 +617,7 @@ function DateProto_toTimeString(args, { thisValue }) {
 // 20.3.4.43 #sec-date.prototype.toutcstring
 function DateProto_toUTCString(args, { thisValue }) {
   const O = thisValue;
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Date', O);
   }
   const tv = Q(thisTimeValue(O));
@@ -640,13 +642,13 @@ function DateProto_valueOf(args, { thisValue }) {
 // 20.3.4.45 #sec-date.prototype-@@toprimitive
 function DateProto_toPrimitive([hint = Value.undefined], { thisValue }) {
   const O = thisValue;
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Date', O);
   }
   let tryFirst;
-  if (Type(hint) === 'String' && (hint.stringValue() === 'string' || hint.stringValue() === 'default')) {
+  if (hint instanceof JSStringValue && (hint.stringValue() === 'string' || hint.stringValue() === 'default')) {
     tryFirst = 'string';
-  } else if (Type(hint) === 'String' && hint.stringValue() === 'number') {
+  } else if (hint instanceof JSStringValue && hint.stringValue() === 'number') {
     tryFirst = 'number';
   } else {
     return surroundingAgent.Throw('TypeError', 'InvalidHint', hint);

--- a/src/intrinsics/ErrorPrototype.mjs
+++ b/src/intrinsics/ErrorPrototype.mjs
@@ -2,7 +2,7 @@ import {
   surroundingAgent,
 } from '../engine.mjs';
 import {
-  Type,
+  ObjectValue,
   Value,
 } from '../value.mjs';
 import {
@@ -17,7 +17,7 @@ function ErrorProto_toString(args, { thisValue }) {
   // 1. Let O be this value.
   const O = thisValue;
   // 2. If Type(O) is not Object, throw a TypeError exception.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', O);
   }
   // 3. Let name be ? Get(O, "name").

--- a/src/intrinsics/FinalizationRegistryPrototype.mjs
+++ b/src/intrinsics/FinalizationRegistryPrototype.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Value, Type } from '../value.mjs';
+import { Value, ObjectValue } from '../value.mjs';
 import {
   CleanupFinalizationRegistry,
   IsCallable,
@@ -32,7 +32,7 @@ function FinalizationRegistryProto_register([target = Value.undefined, heldValue
   // 2. Perform ? RequireInternalSlot(finalizationRegistry, [[Cells]]).
   Q(RequireInternalSlot(finalizationRegistry, 'Cells'));
   // 3. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 4. If SameValue(target, heldValue), throw a TypeError exception.
@@ -40,7 +40,7 @@ function FinalizationRegistryProto_register([target = Value.undefined, heldValue
     return surroundingAgent.Throw('TypeError', 'TargetMatchesHeldValue', heldValue);
   }
   // 5. If Type(unregisterToken) is not Object,
-  if (Type(unregisterToken) !== 'Object') {
+  if (!(unregisterToken instanceof ObjectValue)) {
     // a. If unregisterToken is not undefined, throw a TypeError exception.
     if (unregisterToken !== Value.undefined) {
       return surroundingAgent.Throw('TypeError', 'NotAnObject', unregisterToken);
@@ -67,7 +67,7 @@ function FinalizationRegistryProto_unregister([unregisterToken = Value.undefined
   // 2. Perform ? RequireInternalSlot(finalizationRegistry, [[Cells]]).
   Q(RequireInternalSlot(finalizationRegistry, 'Cells'));
   // 3. If Type(unregisterToken) is not Object, throw a TypeError exception.
-  if (Type(unregisterToken) !== 'Object') {
+  if (!(unregisterToken instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', unregisterToken);
   }
   // 4. Let removed be false.

--- a/src/intrinsics/ForInIteratorPrototype.mjs
+++ b/src/intrinsics/ForInIteratorPrototype.mjs
@@ -1,4 +1,4 @@
-import { Value, Type } from '../value.mjs';
+import { Value, JSStringValue, ObjectValue } from '../value.mjs';
 import { surroundingAgent } from '../engine.mjs';
 import {
   Assert,
@@ -12,7 +12,7 @@ import { bootstrapPrototype } from './bootstrap.mjs';
 // #sec-createforiniterator
 export function CreateForInIterator(object) {
   // 1. Assert: Type(object) is Object.
-  Assert(Type(object) === 'Object');
+  Assert(object instanceof ObjectValue);
   // 2. Let iterator be ObjectCreate(%ForInIteratorPrototype%, « [[Object]], [[ObjectWasVisited]], [[VisitedKeys]], [[RemainingKeys]] »).
   const iterator = OrdinaryObjectCreate(surroundingAgent.intrinsic('%ForInIteratorPrototype%'), [
     'Object',
@@ -37,7 +37,7 @@ function ForInIteratorPrototype_next(args, { thisValue }) {
   // 1. Let O be this value.
   const O = thisValue;
   // 2. Assert: Type(O) is Object.
-  Assert(Type(O) === 'Object');
+  Assert(O instanceof ObjectValue);
   // 3. Assert: O has all the internal slot sof a For-In Iterator Instance.
   Assert('Object' in O && 'ObjectWasVisited' in O && 'VisitedKeys' in O && 'RemainingKeys in O');
   // 4. Let object be O.[[Object]].
@@ -55,7 +55,7 @@ function ForInIteratorPrototype_next(args, { thisValue }) {
       // ii. for each key of keys in List order, do
       for (const key of keys) {
         // 1. If Type(key) is String, then
-        if (Type(key) === 'String') {
+        if (key instanceof JSStringValue) {
           // a. Append key to remaining.
           remaining.push(key);
         }

--- a/src/intrinsics/FunctionPrototype.mjs
+++ b/src/intrinsics/FunctionPrototype.mjs
@@ -21,7 +21,9 @@ import {
   MakeBasicObject,
 } from '../abstract-ops/all.mjs';
 import {
-  Type,
+  JSStringValue,
+  NumberValue,
+  ObjectValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -83,7 +85,7 @@ function BoundFunctionExoticObjectConstruct(argumentsList, newTarget) {
 // #sec-boundfunctioncreate
 function BoundFunctionCreate(targetFunction, boundThis, boundArgs) {
   // 1. Assert: Type(targetFunction) is Object.
-  Assert(Type(targetFunction) === 'Object');
+  Assert(targetFunction instanceof ObjectValue);
   // 2. Let proto be ? targetFunction.[[GetPrototypeOf]]().
   const proto = Q(targetFunction.GetPrototypeOf());
   // 3. Let internalSlotsList be the internal slots listed in Table 30, plus [[Prototype]] and [[Extensible]].
@@ -134,7 +136,7 @@ function FunctionProto_bind([thisArg = Value.undefined, ...args], { thisValue })
     // a. Let targetLen be ? Get(Target, "length").
     const targetLen = Q(Get(Target, new Value('length')));
     // b. If Type(targetLen) is Number, then
-    if (Type(targetLen) === 'Number') {
+    if (targetLen instanceof NumberValue) {
       // i. If targetLen is +∞𝔽, set L to +∞.
       if (targetLen.numberValue() === +Infinity) {
         L = +Infinity;
@@ -157,7 +159,7 @@ function FunctionProto_bind([thisArg = Value.undefined, ...args], { thisValue })
   // 8. Let targetName be ? Get(Target, "name").
   let targetName = Q(Get(Target, new Value('name')));
   // 9. If Type(targetName) is not String, set targetName to the empty String.
-  if (Type(targetName) !== 'String') {
+  if (!(targetName instanceof JSStringValue)) {
     targetName = new Value('');
   }
   // 10. Perform SetFunctionName(F, targetName, "bound").
@@ -192,7 +194,7 @@ function FunctionProto_toString(args, { thisValue }) {
   const func = thisValue;
   // 2. If Type(func) is Object and func has a [[SourceText]] internal slot and func.[[SourceText]]
   //    is a sequence of Unicode code points and ! HostHasSourceTextAvailable(func) is true, then
-  if (Type(func) === 'Object'
+  if (func instanceof ObjectValue
       && 'SourceText' in func
       && X(HostHasSourceTextAvailable(func)) === Value.true) {
     // Return ! UTF16Encode(func.[[SourceText]]).
@@ -213,7 +215,7 @@ function FunctionProto_toString(args, { thisValue }) {
   // 4. If Type(func) is Object and IsCallable(func) is true, then return an implementation
   //    dependent String source code representation of func. The representation must have
   //    the syntax of a NativeFunction.
-  if (Type(func) === 'Object' && IsCallable(func) === Value.true) {
+  if (func instanceof ObjectValue && IsCallable(func) === Value.true) {
     return new Value('function() { [native code] }');
   }
   // 5. Throw a TypeError exception.

--- a/src/intrinsics/Map.mjs
+++ b/src/intrinsics/Map.mjs
@@ -11,7 +11,7 @@ import {
   OrdinaryCreateFromConstructor,
 } from '../abstract-ops/all.mjs';
 import {
-  Type,
+  ObjectValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -33,7 +33,7 @@ export function AddEntriesFromIterable(target, iterable, adder) {
       return target;
     }
     const nextItem = Q(IteratorValue(next));
-    if (Type(nextItem) !== 'Object') {
+    if (!(nextItem instanceof ObjectValue)) {
       const error = surroundingAgent.Throw('TypeError', 'NotAnObject', nextItem);
       return Q(IteratorClose(iteratorRecord, error));
     }

--- a/src/intrinsics/MapPrototype.mjs
+++ b/src/intrinsics/MapPrototype.mjs
@@ -7,7 +7,7 @@ import {
   SameValueZero,
 } from '../abstract-ops/all.mjs';
 import {
-  Type,
+  NumberValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -155,7 +155,7 @@ function MapProto_set([key = Value.undefined, value = Value.undefined], { thisVa
     }
   }
   // 5. If key is -0𝔽, set key to +0𝔽.
-  if (Type(key) === 'Number' && Object.is(key.numberValue(), -0)) {
+  if (key instanceof NumberValue && Object.is(key.numberValue(), -0)) {
     key = F(+0);
   }
   // 6. Let p be the Record { [[Key]]: key, [[Value]]: value }.

--- a/src/intrinsics/NativeError.mjs
+++ b/src/intrinsics/NativeError.mjs
@@ -9,7 +9,7 @@ import {
 } from '../abstract-ops/all.mjs';
 import {
   Descriptor,
-  Type,
+  UndefinedValue,
   Value,
 } from '../value.mjs';
 import { Q, X } from '../completion.mjs';
@@ -34,7 +34,7 @@ export function bootstrapNativeError(realmRec) {
     const Constructor = ([message = Value.undefined, options = Value.undefined], { NewTarget }) => {
       // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
       let newTarget;
-      if (Type(NewTarget) === 'Undefined') {
+      if (NewTarget instanceof UndefinedValue) {
         newTarget = surroundingAgent.activeFunctionObject;
       } else {
         newTarget = NewTarget;

--- a/src/intrinsics/Number.mjs
+++ b/src/intrinsics/Number.mjs
@@ -6,7 +6,8 @@ import {
 } from '../abstract-ops/all.mjs';
 import {
   Descriptor,
-  Type,
+  NumberValue,
+  BigIntValue,
   Value,
 } from '../value.mjs';
 import { Q, X } from '../completion.mjs';
@@ -17,7 +18,7 @@ function NumberConstructor([value], { NewTarget }) {
   let n;
   if (value !== undefined) {
     const prim = Q(ToNumeric(value));
-    if (Type(prim) === 'BigInt') {
+    if (prim instanceof BigIntValue) {
       n = F(Number(prim.bigintValue()));
     } else {
       n = prim;
@@ -35,7 +36,7 @@ function NumberConstructor([value], { NewTarget }) {
 
 // 20.1.2.2 #sec-number.isfinite
 function Number_isFinite([number = Value.undefined]) {
-  if (Type(number) !== 'Number') {
+  if (!(number instanceof NumberValue)) {
     return Value.false;
   }
 
@@ -52,7 +53,7 @@ function Number_isInteger([number = Value.undefined]) {
 
 // 20.1.2.4 #sec-number.isnan
 function Number_isNaN([number = Value.undefined]) {
-  if (Type(number) !== 'Number') {
+  if (!(number instanceof NumberValue)) {
     return Value.false;
   }
 
@@ -64,7 +65,7 @@ function Number_isNaN([number = Value.undefined]) {
 
 // 20.1.2.5 #sec-number.issafeinteger
 function Number_isSafeInteger([number = Value.undefined]) {
-  if (Type(number) !== 'Number') {
+  if (!(number instanceof NumberValue)) {
     return Value.false;
   }
 

--- a/src/intrinsics/NumberPrototype.mjs
+++ b/src/intrinsics/NumberPrototype.mjs
@@ -1,5 +1,5 @@
 import {
-  Type,
+  ObjectValue,
   Value,
   NumberValue,
 } from '../value.mjs';
@@ -14,12 +14,12 @@ import { Q, X } from '../completion.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
 function thisNumberValue(value) {
-  if (Type(value) === 'Number') {
+  if (value instanceof NumberValue) {
     return value;
   }
-  if (Type(value) === 'Object' && 'NumberData' in value) {
+  if (value instanceof ObjectValue && 'NumberData' in value) {
     const n = value.NumberData;
-    Assert(Type(n) === 'Number');
+    Assert(n instanceof NumberValue);
     return n;
   }
   return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Number', value);

--- a/src/intrinsics/Object.mjs
+++ b/src/intrinsics/Object.mjs
@@ -1,5 +1,7 @@
 import {
   Type,
+  NullValue,
+  ObjectValue,
   Value,
 } from '../value.mjs';
 import {
@@ -85,7 +87,7 @@ function Object_assign([target = Value.undefined, ...sources]) {
 // #sec-object.create
 function Object_create([O = Value.undefined, Properties = Value.undefined]) {
   // 1. If Type(O) is neither Object nor Null, throw a TypeError exception.
-  if (Type(O) !== 'Object' && Type(O) !== 'Null') {
+  if (!(O instanceof ObjectValue) && !(O instanceof NullValue)) {
     return surroundingAgent.Throw('TypeError', 'ObjectPrototypeType');
   }
   // 2. Let obj be OrdinaryObjectCreate(O).
@@ -108,7 +110,7 @@ function Object_defineProperties([O = Value.undefined, Properties = Value.undefi
 // #sec-objectdefineproperties ObjectDefineProperties
 function ObjectDefineProperties(O, Properties) {
   // 1. If Type(O) is not Object, throw a TypeError exception.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', O);
   }
   // 2. Let props be ? ToObject(Properties).
@@ -147,7 +149,7 @@ function ObjectDefineProperties(O, Properties) {
 // #sec-object.defineproperty
 function Object_defineProperty([O = Value.undefined, P = Value.undefined, Attributes = Value.undefined]) {
   // 1. If Type(O) is not Object, throw a TypeError exception.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', O);
   }
   // 2. Let key be ? ToPropertyKey(P).
@@ -173,7 +175,7 @@ function Object_entries([O = Value.undefined]) {
 // #sec-object.freeze
 function Object_freeze([O = Value.undefined]) {
   // 1. If Type(O) is not Object, return O.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return O;
   }
   // 2. Let status be ? SetIntegrityLevel(O, frozen).
@@ -302,7 +304,7 @@ function Object_is([value1 = Value.undefined, value2 = Value.undefined]) {
 // #sec-object.isextensible
 function Object_isExtensible([O = Value.undefined]) {
   // 1. If Type(O) is not Object, return false.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return Value.false;
   }
   // 2. Return ? IsExtensible(O).
@@ -312,7 +314,7 @@ function Object_isExtensible([O = Value.undefined]) {
 // #sec-object.isfrozen
 function Object_isFrozen([O = Value.undefined]) {
   // 1. If Type(O) is not Object, return true.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return Value.true;
   }
   // 2. Return ? TestIntegrityLevel(O, frozen).
@@ -322,7 +324,7 @@ function Object_isFrozen([O = Value.undefined]) {
 // #sec-object.issealed
 function Object_isSealed([O = Value.undefined]) {
   // 1. If Type(O) is not Object, return true.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return Value.true;
   }
   // 2. Return ? TestIntegrityLevel(O, sealed).
@@ -342,7 +344,7 @@ function Object_keys([O = Value.undefined]) {
 // #sec-object.preventextensions
 function Object_preventExtensions([O = Value.undefined]) {
   // 1. If Type(O) is not Object, return O.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return O;
   }
   // 2. Let status be ? O.[[PreventExtensions]]().
@@ -358,7 +360,7 @@ function Object_preventExtensions([O = Value.undefined]) {
 // #sec-object.seal
 function Object_seal([O = Value.undefined]) {
   // 1. If Type(O) is not Object, return O.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return O;
   }
   // 2. Let status be ? SetIntegrityLevel(O, sealed).
@@ -376,11 +378,11 @@ function Object_setPrototypeOf([O = Value.undefined, proto = Value.undefined]) {
   // 1. Set O to ? RequireObjectCoercible(O).
   O = Q(RequireObjectCoercible(O));
   // 2. If Type(proto) is neither Object nor Null, throw a TypeError exception.
-  if (Type(proto) !== 'Object' && Type(proto) !== 'Null') {
+  if (!(proto instanceof ObjectValue) && !(proto instanceof NullValue)) {
     return surroundingAgent.Throw('TypeError', 'ObjectPrototypeType');
   }
   // 3. If Type(O) is not Object, return O.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return O;
   }
   // 4. Let status be ? O.[[SetPrototypeOf]](proto).

--- a/src/intrinsics/ObjectPrototype.mjs
+++ b/src/intrinsics/ObjectPrototype.mjs
@@ -1,6 +1,9 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
-  Type,
+  NullValue,
+  JSStringValue,
+  UndefinedValue,
+  ObjectValue,
   Value,
   Descriptor,
   wellKnownSymbols,
@@ -34,7 +37,7 @@ function ObjectProto_hasOwnProperty([V = Value.undefined], { thisValue }) {
 // #sec-object.prototype.isprototypeof
 function ObjectProto_isPrototypeOf([V = Value.undefined], { thisValue }) {
   // 1. If Type(V) is not Object, return false.
-  if (Type(V) !== 'Object') {
+  if (!(V instanceof ObjectValue)) {
     return Value.false;
   }
   // 2. Let O be ? ToObject(this value).
@@ -63,7 +66,7 @@ function ObjectProto_propertyIsEnumerable([V = Value.undefined], { thisValue }) 
   // 3. Let desc be ? O.[[GetOwnProperty]](P).
   const desc = Q(O.GetOwnProperty(P));
   // 4. If desc is undefined, return false.
-  if (Type(desc) === 'Undefined') {
+  if (desc instanceof UndefinedValue) {
     return Value.false;
   }
   // 5. Return desc.[[Enumerable]].
@@ -118,7 +121,7 @@ function ObjectProto_toString(argList, { thisValue }) {
   // 15. Let tag be ? Get(O, @@toStringTag).
   let tag = Q(Get(O, wellKnownSymbols.toStringTag));
   // 16. If Type(tag) is not String, set tag to builtinTag.
-  if (Type(tag) !== 'String') {
+  if (!(tag instanceof JSStringValue)) {
     tag = builtinTag;
   }
   // 17. Return the string-concatenation of "[object ", tag, and "]".
@@ -244,11 +247,11 @@ function ObjectProto__proto__Set([proto = Value.undefined], { thisValue }) {
   // 1. Let O be ? RequireObjectCoercible(this value).
   const O = Q(RequireObjectCoercible(thisValue));
   // 2. If Type(proto) is neither Object nor Null, return undefined.
-  if (Type(proto) !== 'Object' && Type(proto) !== 'Null') {
+  if (!(proto instanceof ObjectValue) && !(proto instanceof NullValue)) {
     return Value.undefined;
   }
   // 3. If Type(O) is not Object, return undefined.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return Value.undefined;
   }
   // 4. Let status be ? O.[[SetPrototypeOf]](proto).

--- a/src/intrinsics/Promise.mjs
+++ b/src/intrinsics/Promise.mjs
@@ -3,7 +3,7 @@ import {
 } from '../engine.mjs';
 import {
   Descriptor,
-  Type,
+  ObjectValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -645,7 +645,7 @@ function Promise_resolve([x = Value.undefined], { thisValue }) {
   // 1. Let C be the this value.
   const C = thisValue;
   // 2. If Type(C) is not Object, throw a TypeError exception.
-  if (Type(C) !== 'Object') {
+  if (!(C instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'InvalidReceiver', 'Promise.resolve', C);
   }
   // 3. Return ? PromiseResolve(C, x).

--- a/src/intrinsics/PromisePrototype.mjs
+++ b/src/intrinsics/PromisePrototype.mjs
@@ -13,7 +13,7 @@ import {
   PromiseResolve,
   SpeciesConstructor,
 } from '../abstract-ops/all.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value } from '../value.mjs';
 import { Q, ThrowCompletion, X } from '../completion.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
@@ -30,7 +30,7 @@ function PromiseProto_finally([onFinally = Value.undefined], { thisValue }) {
   // 1. Let promise be the this value.
   const promise = thisValue;
   // 2. If Type(promise) is not Object, throw a TypeError exception.
-  if (Type(promise) !== 'Object') {
+  if (!(promise instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'Promise', promise);
   }
   // 3. Let C be ? SpeciesConstructor(promise, %Promise%).

--- a/src/intrinsics/Reflect.mjs
+++ b/src/intrinsics/Reflect.mjs
@@ -11,7 +11,7 @@ import {
   ToPropertyDescriptor,
   ToPropertyKey,
 } from '../abstract-ops/all.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value } from '../value.mjs';
 import { Q } from '../completion.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
@@ -50,7 +50,7 @@ function Reflect_construct([target = Value.undefined, argumentsList = Value.unde
 // #sec-reflect.defineproperty
 function Reflect_defineProperty([target = Value.undefined, propertyKey = Value.undefined, attributes = Value.undefined]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Let key be ? ToPropertyKey(propertyKey).
@@ -64,7 +64,7 @@ function Reflect_defineProperty([target = Value.undefined, propertyKey = Value.u
 // #sec-reflect.deleteproperty
 function Reflect_deleteProperty([target = Value.undefined, propertyKey = Value.undefined]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Let key be ? ToPropertyKey(propertyKey).
@@ -76,7 +76,7 @@ function Reflect_deleteProperty([target = Value.undefined, propertyKey = Value.u
 // #sec-reflect.get
 function Reflect_get([target = Value.undefined, propertyKey = Value.undefined, receiver]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Let key be ? ToPropertyKey(propertyKey).
@@ -93,7 +93,7 @@ function Reflect_get([target = Value.undefined, propertyKey = Value.undefined, r
 // #sec-reflect.getownpropertydescriptor
 function Reflect_getOwnPropertyDescriptor([target = Value.undefined, propertyKey = Value.undefined]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Let key be ? ToPropertyKey(propertyKey).
@@ -107,7 +107,7 @@ function Reflect_getOwnPropertyDescriptor([target = Value.undefined, propertyKey
 // #sec-reflect.getprototypeof
 function Reflect_getPrototypeOf([target = Value.undefined]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Return ? target.[[GetPrototypeOf]]().
@@ -117,7 +117,7 @@ function Reflect_getPrototypeOf([target = Value.undefined]) {
 // #sec-reflect.has
 function Reflect_has([target = Value.undefined, propertyKey = Value.undefined]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Let key be ? ToPropertyKey(propertyKey).
@@ -129,7 +129,7 @@ function Reflect_has([target = Value.undefined, propertyKey = Value.undefined]) 
 // #sec-reflect.isextensible
 function Reflect_isExtensible([target = Value.undefined]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Return ? target.[[IsExtensible]]().
@@ -139,7 +139,7 @@ function Reflect_isExtensible([target = Value.undefined]) {
 // #sec-reflect.ownkeys
 function Reflect_ownKeys([target = Value.undefined]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Let keys be ? target.[[OwnPropertyKeys]]().
@@ -151,7 +151,7 @@ function Reflect_ownKeys([target = Value.undefined]) {
 // #sec-reflect.preventextensions
 function Reflect_preventExtensions([target = Value.undefined]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Return ? target.[[PreventExtensions]]().
@@ -161,7 +161,7 @@ function Reflect_preventExtensions([target = Value.undefined]) {
 // #sec-reflect.set
 function Reflect_set([target = Value.undefined, propertyKey = Value.undefined, V = Value.undefined, receiver]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Let key be ? ToPropertyKey(propertyKey).
@@ -177,11 +177,11 @@ function Reflect_set([target = Value.undefined, propertyKey = Value.undefined, V
 // #sec-reflect.setprototypeof
 function Reflect_setPrototypeOf([target = Value.undefined, proto = Value.undefined]) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. If Type(proto) is not Object and proto is not null, throw a TypeError exception.
-  if (Type(proto) !== 'Object' && proto !== Value.null) {
+  if (!(proto instanceof ObjectValue) && proto !== Value.null) {
     return surroundingAgent.Throw('TypeError', 'ObjectPrototypeType');
   }
   // 3. Return ? target.[[SetPrototypeOf]](proto).

--- a/src/intrinsics/RegExp.mjs
+++ b/src/intrinsics/RegExp.mjs
@@ -9,7 +9,7 @@ import {
   SameValue,
 } from '../abstract-ops/all.mjs';
 import {
-  Type,
+  ObjectValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -40,7 +40,7 @@ function RegExpConstructor([pattern = Value.undefined, flags = Value.undefined],
   let P;
   let F;
   // 4. If Type(pattern) is Object and pattern has a [[RegExpMatcher]] internal slot, then
-  if (Type(pattern) === 'Object' && 'RegExpMatcher' in pattern) {
+  if (pattern instanceof ObjectValue && 'RegExpMatcher' in pattern) {
     // a. Let P be pattern.[[OriginalSource]].
     P = pattern.OriginalSource;
     // b. If flags is undefined, let F be pattern.[[OriginalFlags]].

--- a/src/intrinsics/RegExpPrototype.mjs
+++ b/src/intrinsics/RegExpPrototype.mjs
@@ -1,6 +1,9 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
-  Type,
+  BooleanValue,
+  NullValue,
+  JSStringValue,
+  ObjectValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -50,13 +53,13 @@ function RegExpProto_exec([string = Value.undefined], { thisValue }) {
 
 // 21.2.5.2.1 #sec-regexpexec
 export function RegExpExec(R, S) {
-  Assert(Type(R) === 'Object');
-  Assert(Type(S) === 'String');
+  Assert(R instanceof ObjectValue);
+  Assert(S instanceof JSStringValue);
 
   const exec = Q(Get(R, new Value('exec')));
   if (IsCallable(exec) === Value.true) {
     const result = Q(Call(exec, R, [S]));
-    if (Type(result) !== 'Object' && Type(result) !== 'Null') {
+    if (!(result instanceof ObjectValue) && !(result instanceof NullValue)) {
       return surroundingAgent.Throw('TypeError', 'RegExpExecNotObject', result);
     }
     return result;
@@ -70,7 +73,7 @@ export function RegExpBuiltinExec(R, S) {
   // 1. Assert: R is an initialized RegExp instance.
   Assert('RegExpMatcher' in R);
   // 2. Assert: Type(S) is String.
-  Assert(Type(S) === 'String');
+  Assert(S instanceof JSStringValue);
   // 3. Let length be the number of code units in S.
   const length = S.stringValue().length;
   // 4. Let lastIndex be ? ℝ(ToLength(? Get(R, "lastIndex"))).
@@ -240,11 +243,11 @@ export function RegExpBuiltinExec(R, S) {
 // #sec-advancestringindex
 export function AdvanceStringIndex(S, index, unicode) {
   // 1. Assert: Type(S) is String.
-  Assert(Type(S) === 'String');
+  Assert(S instanceof JSStringValue);
   // 2. Assert: index is a non-negative integer which is ≤ 2 ** (53 - 1).
   Assert(isNonNegativeInteger(index) && index <= (2 ** 53) - 1);
   // 3. Assert: Type(unicode) is Boolean.
-  Assert(Type(unicode) === 'Boolean');
+  Assert(unicode instanceof BooleanValue);
   // 4. If unicode is false, return index + 1.
   if (unicode === Value.false) {
     return index + 1;
@@ -274,7 +277,7 @@ function RegExpProto_dotAllGetter(args, { thisValue }) {
 // 21.2.5.4 #sec-get-regexp.prototype.flags
 function RegExpProto_flagsGetter(args, { thisValue }) {
   const R = thisValue;
-  if (Type(R) !== 'Object') {
+  if (!(R instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', R);
   }
   let result = '';
@@ -312,7 +315,7 @@ function RegExpProto_flagsGetter(args, { thisValue }) {
 // 21.2.5.5 #sec-get-regexp.prototype.global
 function RegExpProto_globalGetter(args, { thisValue }) {
   const R = thisValue;
-  if (Type(R) !== 'Object') {
+  if (!(R instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', R);
   }
   if (!('OriginalFlags' in R)) {
@@ -353,7 +356,7 @@ function RegExpProto_match([string = Value.undefined], { thisValue }) {
   // 1. Let rx be the this value.
   const rx = thisValue;
   // 2. If Type(rx) is not Object, throw a TypeError exception.
-  if (Type(rx) !== 'Object') {
+  if (!(rx instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', rx);
   }
   // 3. Let S be ? ToString(string).
@@ -411,7 +414,7 @@ function RegExpProto_match([string = Value.undefined], { thisValue }) {
 // 21.2.5.8 #sec-regexp-prototype-matchall
 function RegExpProto_matchAll([string = Value.undefined], { thisValue }) {
   const R = thisValue;
-  if (Type(R) !== 'Object') {
+  if (!(R instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', R);
   }
   const S = Q(ToString(string));
@@ -448,7 +451,7 @@ function RegExpProto_multilineGetter(args, { thisValue }) {
 // 21.2.5.10 #sec-regexp.prototype-@@replace
 function RegExpProto_replace([string = Value.undefined, replaceValue = Value.undefined], { thisValue }) {
   const rx = thisValue;
-  if (Type(rx) !== 'Object') {
+  if (!(rx instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', rx);
   }
   const S = Q(ToString(string));
@@ -543,7 +546,7 @@ function RegExpProto_replace([string = Value.undefined, replaceValue = Value.und
 // 21.2.5.11 #sec-regexp.prototype-@@search
 function RegExpProto_search([string = Value.undefined], { thisValue }) {
   const rx = thisValue;
-  if (Type(rx) !== 'Object') {
+  if (!(rx instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', rx);
   }
   const S = Q(ToString(string));
@@ -569,7 +572,7 @@ function RegExpProto_search([string = Value.undefined], { thisValue }) {
 // 21.2.5.12 #sec-get-regexp.prototype.source
 function RegExpProto_sourceGetter(args, { thisValue }) {
   const R = thisValue;
-  if (Type(R) !== 'Object') {
+  if (!(R instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', R);
   }
   if (!('OriginalSource' in R)) {
@@ -587,7 +590,7 @@ function RegExpProto_sourceGetter(args, { thisValue }) {
 // 21.2.5.13 #sec-regexp.prototype-@@split
 function RegExpProto_split([string = Value.undefined, limit = Value.undefined], { thisValue }) {
   const rx = thisValue;
-  if (Type(rx) !== 'Object') {
+  if (!(rx instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', rx);
   }
   const S = Q(ToString(string));
@@ -680,7 +683,7 @@ function RegExpProto_stickyGetter(args, { thisValue }) {
 // 21.2.5.15 #sec-regexp.prototype.test
 function RegExpProto_test([S = Value.undefined], { thisValue }) {
   const R = thisValue;
-  if (Type(R) !== 'Object') {
+  if (!(R instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', R);
   }
   const string = Q(ToString(S));
@@ -694,7 +697,7 @@ function RegExpProto_test([S = Value.undefined], { thisValue }) {
 // 21.2.5.16 #sec-regexp.prototype.tostring
 function RegExpProto_toString(args, { thisValue }) {
   const R = thisValue;
-  if (Type(R) !== 'Object') {
+  if (!(R instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'RegExp', R);
   }
   const pattern = Q(ToString(Q(Get(R, new Value('source')))));

--- a/src/intrinsics/RegExpStringIteratorPrototype.mjs
+++ b/src/intrinsics/RegExpStringIteratorPrototype.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { BooleanValue, JSStringValue, Value } from '../value.mjs';
 import {
   Assert,
   CreateIteratorFromClosure,
@@ -20,11 +20,11 @@ const kRegExpStringIteratorPrototype = new Value('%RegExpStringIteratorPrototype
 // 21.2.5.8.1 #sec-createregexpstringiterator
 export function CreateRegExpStringIterator(R, S, global, fullUnicode) {
   // 1. Assert: Type(S) is String.
-  Assert(Type(S) === 'String');
+  Assert(S instanceof JSStringValue);
   // 2. Assert: Type(global) is Boolean.
-  Assert(Type(global) === 'Boolean');
+  Assert(global instanceof BooleanValue);
   // 3. Assert: Type(fullUnicode) is Boolean.
-  Assert(Type(fullUnicode) === 'Boolean');
+  Assert(fullUnicode instanceof BooleanValue);
   // 4. Let closure be a new Abstract Closure with no parameters that captures R, S, global, and fullUnicode and performs the following steps when called:
   const closure = function* closure() {
     // a. Repeat,

--- a/src/intrinsics/SetPrototype.mjs
+++ b/src/intrinsics/SetPrototype.mjs
@@ -7,7 +7,7 @@ import {
   SameValueZero,
 } from '../abstract-ops/all.mjs';
 import {
-  Type,
+  NumberValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -32,7 +32,7 @@ function SetProto_add([value = Value.undefined], { thisValue }) {
     }
   }
   // 5. If value is -0𝔽, set value to +0𝔽.
-  if (Type(value) === 'Number' && Object.is(value.numberValue(), -0)) {
+  if (value instanceof NumberValue && Object.is(value.numberValue(), -0)) {
     value = F(+0);
   }
   // 6. Append value as the last element of entries.

--- a/src/intrinsics/String.mjs
+++ b/src/intrinsics/String.mjs
@@ -1,6 +1,6 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
-  Type,
+  SymbolValue,
   Value,
 } from '../value.mjs';
 import {
@@ -26,7 +26,7 @@ function StringConstructor([value], { NewTarget }) {
   if (value === undefined) {
     s = new Value('');
   } else {
-    if (NewTarget === Value.undefined && Type(value) === 'Symbol') {
+    if (NewTarget === Value.undefined && value instanceof SymbolValue) {
       return X(SymbolDescriptiveString(value));
     }
     s = Q(ToString(value));

--- a/src/intrinsics/StringPrototype.mjs
+++ b/src/intrinsics/StringPrototype.mjs
@@ -1,6 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
-  Type,
+  ObjectValue,
+  JSStringValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -37,12 +38,12 @@ import { assignProps } from './bootstrap.mjs';
 
 
 function thisStringValue(value) {
-  if (Type(value) === 'String') {
+  if (value instanceof JSStringValue) {
     return value;
   }
-  if (Type(value) === 'Object' && 'StringData' in value) {
+  if (value instanceof ObjectValue && 'StringData' in value) {
     const s = value.StringData;
-    Assert(Type(s) === 'String');
+    Assert(s instanceof JSStringValue);
     return s;
   }
   return surroundingAgent.Throw('TypeError', 'NotATypeObject', 'String', value);
@@ -428,7 +429,7 @@ function StringProto_replaceAll([searchValue = Value.undefined, replaceValue = V
       replacement = Q(ToString(Q(Call(replaceValue, Value.undefined, [searchString, F(position), string]))));
     } else { // b. Else,
       // i. Assert: Type(replaceValue) is String.
-      Assert(Type(replaceValue) === 'String');
+      Assert(replaceValue instanceof JSStringValue);
       // ii. Let captures be a new empty List.
       const captures = [];
       // iii. Let replacement be GetSubstitution(searchString, string, position, captures, undefined, replaceValue).
@@ -555,7 +556,7 @@ function StringProto_split([separator = Value.undefined, limit = Value.undefined
 
 // 21.1.3.20.1 #sec-splitmatch
 function SplitMatch(S, q, R) {
-  Assert(Type(R) === 'String');
+  Assert(R instanceof JSStringValue);
   const r = R.stringValue().length;
   const s = S.stringValue().length;
   if (q + r > s) {

--- a/src/intrinsics/Symbol.mjs
+++ b/src/intrinsics/Symbol.mjs
@@ -1,7 +1,6 @@
 import {
   Descriptor,
   SymbolValue,
-  Type,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -57,7 +56,7 @@ function Symbol_for([key = Value.undefined]) {
 // #sec-symbol.keyfor
 function Symbol_keyFor([sym = Value.undefined]) {
   // 1. If Type(sym) is not Symbol, throw a TypeError exception.
-  if (Type(sym) !== 'Symbol') {
+  if (!(sym instanceof SymbolValue)) {
     return surroundingAgent.Throw('TypeError', 'NotASymbol', sym);
   }
   // 2. For each element e of the GlobalSymbolRegistry List, do

--- a/src/intrinsics/SymbolPrototype.mjs
+++ b/src/intrinsics/SymbolPrototype.mjs
@@ -1,5 +1,6 @@
 import {
-  Type,
+  ObjectValue,
+  SymbolValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -16,15 +17,15 @@ import { bootstrapPrototype } from './bootstrap.mjs';
 // #sec-thissymbolvalue
 function thisSymbolValue(value) {
   // 1. If Type(value) is Symbol, return value.
-  if (Type(value) === 'Symbol') {
+  if (value instanceof SymbolValue) {
     return value;
   }
   // 2. If Type(value) is Object and value has a [[SymbolData]] internal slot, then
-  if (Type(value) === 'Object' && 'SymbolData' in value) {
+  if (value instanceof ObjectValue && 'SymbolData' in value) {
     // a. Let s be value.[[SymbolData]].
     const s = value.SymbolData;
     // b. Assert: Type(s) is Symbol.
-    Assert(Type(s) === 'Symbol');
+    Assert(s instanceof SymbolValue);
     // c. Return s.
     return s;
   }

--- a/src/intrinsics/TypedArrayConstructors.mjs
+++ b/src/intrinsics/TypedArrayConstructors.mjs
@@ -1,5 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value, wellKnownSymbols } from '../value.mjs';
+import {
+  ObjectValue, Value, wellKnownSymbols,
+} from '../value.mjs';
 import {
   AllocateArrayBuffer,
   AllocateTypedArray,
@@ -39,11 +41,11 @@ export function bootstrapTypedArrayConstructors(realmRec) {
         const constructorName = new Value(TypedArray);
         // 3. Return ? AllocateTypedArray(constructorName, NewTarget, "%TypedArray.prototype%", 0).
         return Q(AllocateTypedArray(constructorName, NewTarget, `%${TypedArray}.prototype%`, 0));
-      } else if (Type(args[0]) !== 'Object') {
+      } else if (!(args[0] instanceof ObjectValue)) {
         // #sec-typedarray-length
         const [length] = args;
         // 1. Assert: Type(length) is not Object.
-        Assert(Type(length) !== 'Object');
+        Assert(!(length instanceof ObjectValue));
         // 2. If NewTarget is undefined, throw a TypeError exception.
         if (NewTarget === Value.undefined) {
           return surroundingAgent.Throw('TypeError', 'ConstructorNonCallable', this);
@@ -58,7 +60,7 @@ export function bootstrapTypedArrayConstructors(realmRec) {
         // #sec-typedarray-typedarray
         const [typedArray] = args;
         // 1. Assert: Type(typedArray) is Object and typedArray has a [[TypedArrayName]] internal slot.
-        Assert(Type(typedArray) === 'Object' && 'TypedArrayName' in typedArray);
+        Assert(typedArray instanceof ObjectValue && 'TypedArrayName' in typedArray);
         // 2. If NewTarget is undefined, throw a TypeError exception.
         if (NewTarget === Value.undefined) {
           return surroundingAgent.Throw('TypeError', 'ConstructorNonCallable', this);
@@ -149,7 +151,7 @@ export function bootstrapTypedArrayConstructors(realmRec) {
         // 22.2.4.4 #sec-typedarray-object
         const [object] = args;
         // 1. Assert: Type(object) is Object and object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
-        Assert(Type(object) === 'Object' && !('TypedArrayName' in object) && !('ArrayBufferData' in object));
+        Assert(object instanceof ObjectValue && !('TypedArrayName' in object) && !('ArrayBufferData' in object));
         // 2. If NewTarget is undefined, throw a TypeError exception.
         if (NewTarget === Value.undefined) {
           return surroundingAgent.Throw('TypeError', 'ConstructorNonCallable', this);
@@ -212,7 +214,7 @@ export function bootstrapTypedArrayConstructors(realmRec) {
         // #sec-typedarray-buffer-byteoffset-length
         const [buffer = Value.undefined, byteOffset = Value.undefined, length = Value.undefined] = args;
         // 1. Assert: Type(buffer) is Object and buffer has an [[ArrayBufferData]] internal slot.
-        Assert(Type(buffer) === 'Object' && 'ArrayBufferData' in buffer);
+        Assert(buffer instanceof ObjectValue && 'ArrayBufferData' in buffer);
         // 2. If NewTarget is undefined, throw a TypeError exception.
         if (NewTarget === Value.undefined) {
           return surroundingAgent.Throw('TypeError', 'ConstructorNonCallable', this);

--- a/src/intrinsics/TypedArrayPrototype.mjs
+++ b/src/intrinsics/TypedArrayPrototype.mjs
@@ -29,7 +29,8 @@ import {
 import { Q, X } from '../completion.mjs';
 import { surroundingAgent } from '../engine.mjs';
 import {
-  Descriptor, Type, Value, wellKnownSymbols,
+  BigIntValue,
+  Descriptor, JSStringValue, NumberValue, ObjectValue, Value, wellKnownSymbols,
 } from '../value.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 import { ArrayProto_sortBody, bootstrapArrayPrototypeShared } from './ArrayPrototypeShared.mjs';
@@ -513,7 +514,7 @@ function TypedArrayProto_set([source = Value.undefined, offset = Value.undefined
     return surroundingAgent.Throw('RangeError', 'NegativeIndex', 'Offset');
   }
   // 6. If source is an Object that has a [[TypedArrayName]] internal slot, then
-  if (Type(source) === 'Object' && 'TypedArrayName' in source) {
+  if (source instanceof ObjectValue && 'TypedArrayName' in source) {
     // a. Perform ? SetTypedArrayFromTypedArray(target, targetOffset, source).
     Q(SetTypedArrayFromTypedArray(target, targetOffset, source));
   } else { // 7. Else,
@@ -641,8 +642,8 @@ function TypedArrayProto_sort([comparefn = Value.undefined], { thisValue }) {
 
 function TypedArraySortCompare(x, y, comparefn) {
   // 1. Assert: Both Type(x) and Type(y) are Number or both are BigInt.
-  Assert((Type(x) === 'Number' && Type(y) === 'Number')
-         || (Type(x) === 'BigInt' && Type(y) === 'BigInt'));
+  Assert((x instanceof NumberValue && y instanceof NumberValue)
+         || (x instanceof BigIntValue && y instanceof BigIntValue));
   // 2. If comparefn is not undefined, then
   if (comparefn !== Value.undefined) {
     // a. Let v be ? ToNumber(? Call(comparefn, undefined, « x, y »)).
@@ -754,7 +755,7 @@ function TypedArrayProto_toStringTag(args, { thisValue }) {
   // 1. Let O be the this value.
   const O = thisValue;
   // 2. If Type(O) is not Object, return undefined.
-  if (Type(O) !== 'Object') {
+  if (!(O instanceof ObjectValue)) {
     return Value.undefined;
   }
   // 3. If O does not have a [[TypedArrayName]] internal slot, return undefined.
@@ -764,7 +765,7 @@ function TypedArrayProto_toStringTag(args, { thisValue }) {
   // 4. Let name be O.[[TypedArrayName]].
   const name = O.TypedArrayName;
   // 5. Assert: Type(name) is String.
-  Assert(Type(name) === 'String');
+  Assert(name instanceof JSStringValue);
   // 6. Return name.
   return name;
 }
@@ -798,7 +799,7 @@ function TypedArrayProto_at([index = Value.undefined], { thisValue }) {
 
 export function bootstrapTypedArrayPrototype(realmRec) {
   const ArrayProto_toString = X(Get(realmRec.Intrinsics['%Array.prototype%'], new Value('toString')));
-  Assert(Type(ArrayProto_toString) === 'Object');
+  Assert(ArrayProto_toString instanceof ObjectValue);
 
   const proto = bootstrapPrototype(realmRec, [
     ['buffer', [TypedArrayProto_buffer]],

--- a/src/intrinsics/WeakMapPrototype.mjs
+++ b/src/intrinsics/WeakMapPrototype.mjs
@@ -4,7 +4,7 @@ import {
   RequireInternalSlot,
 } from '../abstract-ops/all.mjs';
 import {
-  Type,
+  ObjectValue,
   Value,
 } from '../value.mjs';
 import { Q } from '../completion.mjs';
@@ -19,7 +19,7 @@ function WeakMapProto_delete([key = Value.undefined], { thisValue }) {
   // 3. Let entries be the List that is M.[[WeakMapData]].
   const entries = M.WeakMapData;
   // 4. If Type(key) is not Object, return false.
-  if (Type(key) !== 'Object') {
+  if (!(key instanceof ObjectValue)) {
     return Value.false;
   }
   // 5. For each Record { [[Key]], [[Value]] } p that is an element of entries, do
@@ -48,7 +48,7 @@ function WeakMapProto_get([key = Value.undefined], { thisValue }) {
   // 3. Let entries be the List that is M.[[WeakMapData]].
   const entries = M.WeakMapData;
   // 4. If Type(key) is not Object, return undefined.
-  if (Type(key) !== 'Object') {
+  if (!(key instanceof ObjectValue)) {
     return Value.undefined;
   }
   // 5. For each Record { [[Key]], [[Value]] } p that is an element of entries, do
@@ -71,7 +71,7 @@ function WeakMapProto_has([key = Value.undefined], { thisValue }) {
   // 3. Let entries be the List that is M.[[WeakMapData]].
   const entries = M.WeakMapData;
   // 4. If Type(key) is not Object, return false.
-  if (Type(key) !== 'Object') {
+  if (!(key instanceof ObjectValue)) {
     return Value.false;
   }
   // 5. For each Record { [[Key]], [[Value]] } p that is an element of entries, do
@@ -94,7 +94,7 @@ function WeakMapProto_set([key = Value.undefined, value = Value.undefined], { th
   // 3. Let entries be the List that is M.[[WeakMapData]].
   const entries = M.WeakMapData;
   // 4. If Type(key) is not Object, throw a TypeError exception.
-  if (Type(key) !== 'Object') {
+  if (!(key instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'WeakCollectionNotObject', key);
   }
   // 5. For each Record { [[Key]], [[Value]] } p that is an element of entries, do

--- a/src/intrinsics/WeakRef.mjs
+++ b/src/intrinsics/WeakRef.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value } from '../value.mjs';
 import { AddToKeptObjects, OrdinaryCreateFromConstructor } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { bootstrapConstructor } from './bootstrap.mjs';
@@ -11,7 +11,7 @@ function WeakRefConstructor([target = Value.undefined], { NewTarget }) {
     return surroundingAgent.Throw('TypeError', 'ConstructorNonCallable', this);
   }
   // 2. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 3. Let weakRef be ? OrdinaryCreateFromConstructor(NewTarget, "%WeakRefPrototype%", « [[WeakRefTarget]] »).

--- a/src/intrinsics/WeakSetPrototype.mjs
+++ b/src/intrinsics/WeakSetPrototype.mjs
@@ -4,7 +4,7 @@ import {
   RequireInternalSlot,
 } from '../abstract-ops/all.mjs';
 import {
-  Type,
+  ObjectValue,
   Value,
 } from '../value.mjs';
 import { Q } from '../completion.mjs';
@@ -17,7 +17,7 @@ function WeakSetProto_add([value = Value.undefined], { thisValue }) {
   // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).
   Q(RequireInternalSlot(S, 'WeakSetData'));
   // 3. If Type(value) is not Object, throw a TypeError exception.
-  if (Type(value) !== 'Object') {
+  if (!(value instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'WeakCollectionNotObject', value);
   }
   // 4. Let entries be the List that is S.[[WeakSetData]].
@@ -43,7 +43,7 @@ function WeakSetProto_delete([value = Value.undefined], { thisValue }) {
   // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).
   Q(RequireInternalSlot(S, 'WeakSetData'));
   // 3. If Type(value) is not Object, return false.
-  if (Type(value) !== 'Object') {
+  if (!(value instanceof ObjectValue)) {
     return Value.false;
   }
   // 4. Let entries be the List that is S.[[WeakSetData]].
@@ -72,7 +72,7 @@ function WeakSetProto_has([value = Value.undefined], { thisValue }) {
   // 3. Let entries be the List that is S.[[WeakSetData]].
   const entries = S.WeakSetData;
   // 4. If Type(value) is not Object, return false.
-  if (Type(value) !== 'Object') {
+  if (!(value instanceof ObjectValue)) {
     return Value.false;
   }
   // 5. For each e that is an element of entries, do

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -1,5 +1,5 @@
 import { NewModuleEnvironment } from './environment.mjs';
-import { Value, Type } from './value.mjs';
+import { Value, JSStringValue } from './value.mjs';
 import { ExecutionContext, HostResolveImportedModule, surroundingAgent } from './engine.mjs';
 import {
   Assert,
@@ -34,7 +34,7 @@ import { Evaluate } from './evaluator.mjs';
 export class ResolvedBindingRecord {
   constructor({ Module, BindingName }) {
     Assert(Module instanceof AbstractModuleRecord);
-    Assert(BindingName === 'namespace' || Type(BindingName) === 'String');
+    Assert(BindingName === 'namespace' || BindingName instanceof JSStringValue);
     this.Module = Module;
     this.BindingName = BindingName;
   }

--- a/src/runtime-semantics/ApplyStringOrNumericBinaryOperator.mjs
+++ b/src/runtime-semantics/ApplyStringOrNumericBinaryOperator.mjs
@@ -1,5 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, TypeForMethod, Value } from '../value.mjs';
+import {
+  Type, JSStringValue, TypeForMethod, Value,
+} from '../value.mjs';
 import { ToNumeric, ToPrimitive, ToString } from '../abstract-ops/all.mjs';
 import { Q } from '../completion.mjs';
 
@@ -12,7 +14,7 @@ export function ApplyStringOrNumericBinaryOperator(lval, opText, rval) {
     // b. Let rprim be ? ToPrimitive(rval).
     const rprim = Q(ToPrimitive(rval));
     // c. If Type(lprim) is String or Type(rprim) is String, then
-    if (Type(lprim) === 'String' || Type(rprim) === 'String') {
+    if (lprim instanceof JSStringValue || rprim instanceof JSStringValue) {
       // i. Let lstr be ? ToString(lprim).
       const lstr = Q(ToString(lprim));
       // ii. Let rstr be ? ToString(rprim).

--- a/src/runtime-semantics/BindingInitialization.mjs
+++ b/src/runtime-semantics/BindingInitialization.mjs
@@ -1,4 +1,4 @@
-import { Type, Value } from '../value.mjs';
+import { JSStringValue, Value } from '../value.mjs';
 import {
   Assert,
   PutValue,
@@ -19,7 +19,7 @@ import {
 // #sec-initializeboundname
 export function InitializeBoundName(name, value, environment) {
   // 1. Assert: Type(name) is String.
-  Assert(Type(name) === 'String');
+  Assert(name instanceof JSStringValue);
   // 2. If environment is not undefined, then
   if (environment !== Value.undefined) {
     // a. Perform environment.InitializeBinding(name, value).

--- a/src/runtime-semantics/CallExpression.mjs
+++ b/src/runtime-semantics/CallExpression.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value, ReferenceRecord } from '../value.mjs';
+import { Value, ReferenceRecord, JSStringValue } from '../value.mjs';
 import {
   GetValue,
   IsPropertyReference,
@@ -29,7 +29,7 @@ export function* Evaluate_CallExpression(CallExpression) {
   // 6. If Type(ref) is Reference, IsPropertyReference(ref) is false, and GetReferencedName(ref) is "eval", then
   if (ref instanceof ReferenceRecord
       && IsPropertyReference(ref) === Value.false
-      && (Type(ref.ReferencedName) === 'String'
+      && (ref.ReferencedName instanceof JSStringValue
       && ref.ReferencedName.stringValue() === 'eval')) {
     // a. If SameValue(func, %eval%) is true, then
     if (SameValue(func, surroundingAgent.intrinsic('%eval%')) === Value.true) {

--- a/src/runtime-semantics/ClassDefinitionEvaluation.mjs
+++ b/src/runtime-semantics/ClassDefinitionEvaluation.mjs
@@ -1,5 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Value, Type, PrivateName } from '../value.mjs';
+import {
+  Value, NullValue, ObjectValue, PrivateName,
+} from '../value.mjs';
 import { Evaluate } from '../evaluator.mjs';
 import {
   Assert,
@@ -124,7 +126,7 @@ export function* ClassDefinitionEvaluation(ClassTail, classBinding, className) {
       // i. Let protoParent be ? Get(superclass, "prototype").
       protoParent = Q(Get(superclass, new Value('prototype')));
       // ii. If Type(protoParent) is neither Object nor Null, throw a TypeError exception.
-      if (Type(protoParent) !== 'Object' && Type(protoParent) !== 'Null') {
+      if (!(protoParent instanceof ObjectValue) && !(protoParent instanceof NullValue)) {
         return surroundingAgent.Throw('TypeError', 'ObjectPrototypeType');
       }
       // iii. Let constructorParent be superclass.

--- a/src/runtime-semantics/CreateDynamicFunction.mjs
+++ b/src/runtime-semantics/CreateDynamicFunction.mjs
@@ -15,7 +15,9 @@ import {
 } from '../engine.mjs';
 import { wrappedParse } from '../parse.mjs';
 import { Token } from '../parser/tokens.mjs';
-import { Descriptor, Type, Value } from '../value.mjs';
+import {
+  Descriptor, UndefinedValue, Value,
+} from '../value.mjs';
 import { OutOfRange } from '../helpers.mjs';
 
 // #table-dynamic-function-sourcetext-prefixes
@@ -38,7 +40,7 @@ export function CreateDynamicFunction(constructor, newTarget, kind, args) {
   // 5. Perform ? HostEnsureCanCompileStrings(callerRealm, calleeRealm).
   Q(HostEnsureCanCompileStrings(callerRealm, calleeRealm));
   // 6. If newTarget is undefined, set newTarget to constructor.
-  if (Type(newTarget) === 'Undefined') {
+  if (newTarget instanceof UndefinedValue) {
     newTarget = constructor;
   }
   // 7. If kind is normal, then

--- a/src/runtime-semantics/EvaluateCall.mjs
+++ b/src/runtime-semantics/EvaluateCall.mjs
@@ -1,5 +1,7 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value, ReferenceRecord } from '../value.mjs';
+import {
+  ObjectValue, Value, ReferenceRecord,
+} from '../value.mjs';
 import {
   Assert,
   IsPropertyReference,
@@ -36,7 +38,7 @@ export function* EvaluateCall(func, ref, args, tailPosition) {
   // 3. Let argList be ? ArgumentListEvaluation of arguments.
   const argList = Q(yield* ArgumentListEvaluation(args));
   // 4. If Type(func) is not Object, throw a TypeError exception.
-  if (Type(func) !== 'Object') {
+  if (!(func instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', func);
   }
   // 5. If IsCallable(func) is false, throw a TypeError exception.

--- a/src/runtime-semantics/GetSubstitution.mjs
+++ b/src/runtime-semantics/GetSubstitution.mjs
@@ -4,17 +4,19 @@ import {
   ToString,
   isNonNegativeInteger,
 } from '../abstract-ops/all.mjs';
-import { Type, Value } from '../value.mjs';
+import {
+  ObjectValue, UndefinedValue, JSStringValue, Value,
+} from '../value.mjs';
 import { Q } from '../completion.mjs';
 
 // #sec-getsubstitution
 export function GetSubstitution(matched, str, position, captures, namedCaptures, replacement) {
   // 1. Assert: Type(matched) is String.
-  Assert(Type(matched) === 'String');
+  Assert(matched instanceof JSStringValue);
   // 2. Let matchLength be the number of code units in matched.
   const matchLength = matched.stringValue().length;
   // 3. Assert: Type(str) is String.
-  Assert(Type(str) === 'String');
+  Assert(str instanceof JSStringValue);
   // 4. Let stringLength be the number of code units in str.
   const stringLength = str.stringValue().length;
   // 5. Assert: position is a non-negative integer.
@@ -22,9 +24,9 @@ export function GetSubstitution(matched, str, position, captures, namedCaptures,
   // 6. Assert: position ≤ stringLength.
   Assert(position <= stringLength);
   // 7. Assert: captures is a possibly empty List of Strings.
-  Assert(Array.isArray(captures) && captures.every((value) => Type(value) === 'String' || Type(value) === 'Undefined'));
+  Assert(Array.isArray(captures) && captures.every((value) => value instanceof JSStringValue || value instanceof UndefinedValue));
   // 8. Assert: Type(replacement) is String.
-  Assert(Type(replacement) === 'String');
+  Assert(replacement instanceof JSStringValue);
   // 9. Let tailPos be position + matchLength.
   const tailPos = position + matchLength;
   // 10. Let m be the number of elements in captures.
@@ -87,7 +89,7 @@ export function GetSubstitution(matched, str, position, captures, namedCaptures,
           result += '$<';
           i += 2;
         } else {
-          Assert(Type(namedCaptures) === 'Object');
+          Assert(namedCaptures instanceof ObjectValue);
           const nextSign = replacementStr.indexOf('>', i);
           if (nextSign === -1) {
             result += '$<';

--- a/src/runtime-semantics/ImportMeta.mjs
+++ b/src/runtime-semantics/ImportMeta.mjs
@@ -1,5 +1,5 @@
 import { HostGetImportMetaProperties, HostFinalizeImportMeta } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value } from '../value.mjs';
 import {
   Assert,
   GetActiveScriptOrModule,
@@ -37,7 +37,7 @@ export function Evaluate_ImportMeta(_ImportMeta) {
     return importMeta;
   } else { // 5. Else,
     // a. Assert: Type(importMeta) is Object.
-    Assert(Type(importMeta) === 'Object');
+    Assert(importMeta instanceof ObjectValue);
     // b. Return importMeta.
     return importMeta;
   }

--- a/src/runtime-semantics/LabelledEvaluation.mjs
+++ b/src/runtime-semantics/LabelledEvaluation.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value } from '../value.mjs';
 import { Evaluate } from '../evaluator.mjs';
 import { NewDeclarativeEnvironment, DeclarativeEnvironmentRecord } from '../environment.mjs';
 import {
@@ -592,7 +592,7 @@ function* ForInOfBodyEvaluation(lhs, stmt, iteratorRecord, iterationKind, lhsKin
       nextResult = Q(yield* Await(nextResult));
     }
     // c. If Type(nextResult) is not Object, throw a TypeError exception.
-    if (Type(nextResult) !== 'Object') {
+    if (!(nextResult instanceof ObjectValue)) {
       return surroundingAgent.Throw('TypeError', 'NotAnObject', nextResult);
     }
     // d. Let done be ? IteratorComplete(nextResult).

--- a/src/runtime-semantics/NumberToBigInt.mjs
+++ b/src/runtime-semantics/NumberToBigInt.mjs
@@ -1,11 +1,11 @@
 import { surroundingAgent } from '../engine.mjs';
 import { Assert, IsIntegralNumber, Z } from '../abstract-ops/all.mjs';
-import { Value, Type } from '../value.mjs';
+import { Value, NumberValue } from '../value.mjs';
 
 // #sec-numbertobigint
 export function NumberToBigInt(number) {
   // 1. Assert: Type(number) is Number.
-  Assert(Type(number) === 'Number');
+  Assert(number instanceof NumberValue);
   // 2. If IsIntegralNumber(number) is false, throw a RangeError exception.
   if (IsIntegralNumber(number) === Value.false) {
     return surroundingAgent.Throw('RangeError', 'CannotConvertDecimalToBigInt', number);

--- a/src/runtime-semantics/PropertyDefinitionEvaluation.mjs
+++ b/src/runtime-semantics/PropertyDefinitionEvaluation.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Value, Type } from '../value.mjs';
+import { Value, NullValue, ObjectValue } from '../value.mjs';
 import {
   Assert,
   GetValue,
@@ -92,7 +92,7 @@ function* PropertyDefinitionEvaluation_PropertyDefinition(PropertyDefinition, ob
   // 7. If isProtoSetter is true, then
   if (isProtoSetter) {
     // a. If Type(propValue) is either Object or Null, then
-    if (Type(propValue) === 'Object' || Type(propValue) === 'Null') {
+    if (propValue instanceof ObjectValue || propValue instanceof NullValue) {
       // i. Return object.[[SetPrototypeOf]](propValue).
       return object.SetPrototypeOf(propValue);
     }

--- a/src/runtime-semantics/RegExp.mjs
+++ b/src/runtime-semantics/RegExp.mjs
@@ -1,6 +1,6 @@
 import unicodeCaseFoldingCommon from '@unicode/unicode-14.0.0/Case_Folding/C/symbols.js';
 import unicodeCaseFoldingSimple from '@unicode/unicode-14.0.0/Case_Folding/S/symbols.js';
-import { Type, Value } from '../value.mjs';
+import { JSStringValue, Value } from '../value.mjs';
 import { Assert, isNonNegativeInteger } from '../abstract-ops/all.mjs';
 import { CharacterValue, StringToCodePoints } from '../static-semantics/all.mjs';
 import { X } from '../completion.mjs';
@@ -146,7 +146,7 @@ export function Evaluate_Pattern(Pattern, flags) {
     // 2. Return a new abstract closure with parameters (str, index) that captures m and performs the following steps when called:
     return (str, index) => {
       // a. Assert: Type(str) is String.
-      Assert(Type(str) === 'String');
+      Assert(str instanceof JSStringValue);
       // b. Assert: index is a non-negative integer which is ≤ the length of str.
       Assert(isNonNegativeInteger(index) && index <= str.stringValue().length);
       // c. If Unicode is true, let Input be a List consisting of the sequence of code points of ! StringToCodePoints(str).

--- a/src/runtime-semantics/RelationalExpression.mjs
+++ b/src/runtime-semantics/RelationalExpression.mjs
@@ -16,7 +16,7 @@ import {
 } from '../abstract-ops/all.mjs';
 import { StringValue } from '../static-semantics/all.mjs';
 import {
-  Type,
+  ObjectValue,
   Value,
   wellKnownSymbols,
 } from '../value.mjs';
@@ -27,7 +27,7 @@ import { OutOfRange } from '../helpers.mjs';
 // #sec-instanceofoperator
 export function InstanceofOperator(V, target) {
   // 1. If Type(target) is not Object, throw a TypeError exception.
-  if (Type(target) !== 'Object') {
+  if (!(target instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', target);
   }
   // 2. Let instOfHandler be ? GetMethod(target, @@hasInstance).
@@ -54,7 +54,7 @@ export function* Evaluate_RelationalExpression_PrivateIdentifier({ PrivateIdenti
   // 3. Let rval be ? GetValue(rref).
   const rval = Q(GetValue(rref));
   // 4. If Type(rval) is not Object, throw a TypeError exception.
-  if (Type(rval) !== 'Object') {
+  if (!(rval instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', rval);
   }
   // 5. Let privateEnv be the running execution context's PrivateEnvironment.
@@ -143,7 +143,7 @@ export function* Evaluate_RelationalExpression(expr) {
       return Q(InstanceofOperator(lval, rval));
     case 'in':
       // 5. Return ? InstanceofOperator(lval, rval).
-      if (Type(rval) !== 'Object') {
+      if (!(rval instanceof ObjectValue)) {
         return surroundingAgent.Throw('TypeError', 'NotAnObject', rval);
       }
       // 6. Return ? HasProperty(rval, ? ToPropertyKey(lval)).

--- a/src/runtime-semantics/StringIndexOf.mjs
+++ b/src/runtime-semantics/StringIndexOf.mjs
@@ -1,12 +1,12 @@
-import { Type } from '../value.mjs';
+import { JSStringValue } from '../value.mjs';
 import { Assert, F, isNonNegativeInteger } from '../abstract-ops/all.mjs';
 
 // https://tc39.es/proposal-string-replaceall/#sec-stringindexof
 export function StringIndexOf(string, searchValue, fromIndex) {
   // 1. Assert: Type(string) is String.
-  Assert(Type(string) === 'String');
+  Assert(string instanceof JSStringValue);
   // 2. Assert: Type(searchValue) is String.
-  Assert(Type(searchValue) === 'String');
+  Assert(searchValue instanceof JSStringValue);
   // 3. Assert: fromIndex is a non-negative integer.
   Assert(isNonNegativeInteger(fromIndex));
   const stringStr = string.stringValue();

--- a/src/runtime-semantics/SuperCall.mjs
+++ b/src/runtime-semantics/SuperCall.mjs
@@ -8,7 +8,7 @@ import {
   InitializeInstanceElements,
   isECMAScriptFunctionObject,
 } from '../abstract-ops/all.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value } from '../value.mjs';
 import { Q, X } from '../completion.mjs';
 import { FunctionEnvironmentRecord } from '../environment.mjs';
 import { ArgumentListEvaluation } from './all.mjs';
@@ -19,7 +19,7 @@ export function* Evaluate_SuperCall({ Arguments }) {
   // 1. Let newTarget be GetNewTarget().
   const newTarget = GetNewTarget();
   // 2. Assert: Type(newTarget) is Object.
-  Assert(Type(newTarget) === 'Object');
+  Assert(newTarget instanceof ObjectValue);
   // 3. Let func be ! GetSuperConstructor().
   const func = X(GetSuperConstructor());
   // 4. Let argList be ? ArgumentListEvaluation of Arguments.

--- a/src/runtime-semantics/UnaryExpression.mjs
+++ b/src/runtime-semantics/UnaryExpression.mjs
@@ -14,7 +14,7 @@ import {
 import { Evaluate } from '../evaluator.mjs';
 import { Q, ReturnIfAbrupt, X } from '../completion.mjs';
 import {
-  Type, TypeForMethod, Value, ReferenceRecord,
+  TypeForMethod, Value, ReferenceRecord, UndefinedValue, BigIntValue, BooleanValue, JSStringValue, NullValue, NumberValue, ObjectValue, SymbolValue,
 } from '../value.mjs';
 import { EnvironmentRecord } from '../environment.mjs';
 import { OutOfRange } from '../helpers.mjs';
@@ -89,30 +89,27 @@ function* Evaluate_UnaryExpression_Typeof({ UnaryExpression }) {
   // 3. Set val to ? GetValue(val).
   val = Q(GetValue(val));
   // 4. Return a String according to Table 37.
-  const type = Type(val);
-  switch (type) {
-    case 'Undefined':
-      return new Value('undefined');
-    case 'Null':
-      return new Value('object');
-    case 'Boolean':
-      return new Value('boolean');
-    case 'Number':
-      return new Value('number');
-    case 'String':
-      return new Value('string');
-    case 'BigInt':
-      return new Value('bigint');
-    case 'Symbol':
-      return new Value('symbol');
-    case 'Object':
-      if (IsCallable(val) === Value.true) {
-        return new Value('function');
-      }
-      return new Value('object');
-    default:
-      throw new OutOfRange('Evaluate_UnaryExpression_Typeof', type);
+  if (val instanceof UndefinedValue) {
+    return new JSStringValue('undefined');
+  } else if (val instanceof NullValue) {
+    return new JSStringValue('object');
+  } else if (val instanceof BooleanValue) {
+    return new JSStringValue('boolean');
+  } else if (val instanceof NumberValue) {
+    return new JSStringValue('number');
+  } else if (val instanceof JSStringValue) {
+    return new JSStringValue('string');
+  } else if (val instanceof BigIntValue) {
+    return new JSStringValue('bigint');
+  } else if (val instanceof SymbolValue) {
+    return new JSStringValue('symbol');
+  } else if (val instanceof ObjectValue) {
+    if (IsCallable(val) === Value.true) {
+      return new JSStringValue('function');
+    }
+    return new JSStringValue('object');
   }
+  throw new OutOfRange('Evaluate_UnaryExpression_Typeof', val);
 }
 
 // #sec-unary-plus-operator-runtime-semantics-evaluation

--- a/src/runtime-semantics/YieldExpression.mjs
+++ b/src/runtime-semantics/YieldExpression.mjs
@@ -1,5 +1,5 @@
 import { surroundingAgent } from '../engine.mjs';
-import { Type, Value } from '../value.mjs';
+import { ObjectValue, Value } from '../value.mjs';
 import {
   Assert,
   Call,
@@ -54,7 +54,7 @@ export function* Evaluate_YieldExpression({ hasStar, AssignmentExpression }) {
           innerResult = Q(yield* Await(innerResult));
         }
         // iii. If Type(innerResult) is not Object, throw a TypeError exception.
-        if (Type(innerResult) !== 'Object') {
+        if (!(innerResult instanceof ObjectValue)) {
           return surroundingAgent.Throw('TypeError', 'NotAnObject', innerResult);
         }
         // iv. Let done be ? IteratorComplete(innerResult).
@@ -83,7 +83,7 @@ export function* Evaluate_YieldExpression({ hasStar, AssignmentExpression }) {
           }
           // 3. NOTE: Exceptions from the inner iterator throw method are propagated. Normal completions from an inner throw method are processed similarly to an inner next.
           // 4. If Type(innerResult) is not Object, throw a TypeError exception.
-          if (Type(innerResult) !== 'Object') {
+          if (!(innerResult instanceof ObjectValue)) {
             return surroundingAgent.Throw('TypeError', 'NotAnObject', innerResult);
           }
           // 5. Let done be ? IteratorComplete(innerResult).
@@ -135,7 +135,7 @@ export function* Evaluate_YieldExpression({ hasStar, AssignmentExpression }) {
           innerReturnResult = Q(yield* Await(innerReturnResult));
         }
         // vi. If Type(innerReturnResult) is not Object, throw a TypeError exception.
-        if (Type(innerReturnResult) !== 'Object') {
+        if (!(innerReturnResult instanceof ObjectValue)) {
           return surroundingAgent.Throw('TypeError', 'NotAnObject', innerReturnResult);
         }
         // vii. Let done be ? IteratorComplete(innerReturnResult).

--- a/test/test262/test262.js
+++ b/test/test262/test262.js
@@ -242,7 +242,8 @@ if (!process.send) {
 
     IsCallable,
     IsDataDescriptor,
-    Type,
+    JSStringValue,
+    ObjectValue,
 
     AbruptCompletion,
     Throw,
@@ -250,11 +251,11 @@ if (!process.send) {
   const { createRealm } = require('../../bin/test262_realm');
 
   const isError = (type, value) => {
-    if (Type(value) !== 'Object') {
+    if (!(value instanceof ObjectValue)) {
       return false;
     }
     const proto = value.Prototype;
-    if (!proto || Type(proto) !== 'Object') {
+    if (!proto || !(proto instanceof ObjectValue)) {
       return false;
     }
     const ctorDesc = proto.properties.get(new Value('constructor'));
@@ -262,7 +263,7 @@ if (!process.send) {
       return false;
     }
     const ctor = ctorDesc.Value;
-    if (Type(ctor) !== 'Object' || IsCallable(ctor) !== Value.true) {
+    if (!(ctor instanceof ObjectValue) || IsCallable(ctor) !== Value.true) {
       return false;
     }
     const namePropDesc = ctor.properties.get(new Value('name'));
@@ -270,7 +271,7 @@ if (!process.send) {
       return false;
     }
     const nameProp = namePropDesc.Value;
-    return Type(nameProp) === 'String' && nameProp.stringValue() === type;
+    return nameProp instanceof JSStringValue && nameProp.stringValue() === type;
   };
 
   const includeCache = {};


### PR DESCRIPTION
This PR converts all `Type(value) === 'T'` to `value instanceof TValue` when possible.

This follows the new convention in the spec that prefers `value is a Object` than `Type(value) is *"Object"*` and it is also more friendly for TypeScript.

This is part of #202