### PR TITLE
Fix README build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This project can be run against [test262][], which is particularly useful
 for developing new features and/or tests:
 ```sh
 $ # build engine262
-$ npm build
+$ npm run build
 
 $ # update local test262 in test/test262/test262
 $ git submodule update --init --recursive


### PR DESCRIPTION
`npm build` doesn't actually work.
```sh
$ npm build
Unknown command: "build"

Did you mean this?
    npm run build # run the "build" package script
```