### PR TITLE
refactor(ts): add type for Completion and Value

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "dist/engine262",
   "scripts": {
     "lint": "eslint rollup.config.js test/ src/ bin/ inspector/ scripts/ --cache --ext=js,mjs,mts",
+    "lint:fix": "eslint rollup.config.js test/ src/ bin/ inspector/ scripts/ --cache --ext=js,mjs,mts --fix",
     "build": "run-s build:*",
     "build:regex_data": "node scripts/gen_regex_sets.js",
     "build:engine": "rollup -c",

--- a/src/abstract-ops/function-operations.mts
+++ b/src/abstract-ops/function-operations.mts
@@ -502,7 +502,7 @@ function BuiltinFunctionConstruct(argumentsList, newTarget) {
 }
 
 /** http://tc39.es/ecma262/#sec-createbuiltinfunction */
-export function CreateBuiltinFunction(steps, length, name, internalSlotsList, realm, prototype, prefix, isConstructor = Value.false) {
+export function CreateBuiltinFunction(steps, length, name, internalSlotsList, realm?, prototype?, prefix?, isConstructor = Value.false) {
   // 1. Assert: steps is either a set of algorithm steps or other definition of a function's behaviour provided in this specification.
   Assert(typeof steps === 'function');
   // 2. If realm is not present, set realm to the current Realm Record.

--- a/src/abstract-ops/notational-conventions.mts
+++ b/src/abstract-ops/notational-conventions.mts
@@ -1,10 +1,11 @@
 // @ts-nocheck
+import type { ThrowCompletion, Value } from '../api.mjs';
 import { surroundingAgent } from '../engine.mjs';
 import { ObjectValue } from '../value.mjs';
 
 class AssertError extends Error {}
 
-export function Assert(invariant, source) {
+export function Assert(invariant: boolean, source?: string): asserts invariant {
   /* c8 ignore next */
   if (!invariant) {
     throw new AssertError(source);
@@ -12,7 +13,7 @@ export function Assert(invariant, source) {
 }
 
 /** http://tc39.es/ecma262/#sec-requireinternalslot */
-export function RequireInternalSlot(O, internalSlot) {
+export function RequireInternalSlot(O: Value, internalSlot: string): ThrowCompletion<ObjectValue> | undefined {
   if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', O);
   }

--- a/src/abstract-ops/promise-operations.mts
+++ b/src/abstract-ops/promise-operations.mts
@@ -362,7 +362,7 @@ function NewPromiseReactionJob(reaction, argument) {
 }
 
 /** http://tc39.es/ecma262/#sec-performpromisethen */
-export function PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability) {
+export function PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability?) {
   // 1. Assert: IsPromise(promise) is true.
   Assert(IsPromise(promise) === Value.true);
   // 2. If resultCapability is not present, then

--- a/src/completion.mts
+++ b/src/completion.mts
@@ -1,41 +1,65 @@
-// @ts-nocheck
-import { surroundingAgent } from './engine.mjs';
+import { type GCMarker, surroundingAgent } from './engine.mjs';
 import {
   Assert,
   CreateBuiltinFunction,
   PerformPromiseThen,
+  PromiseCapabilityRecord,
   PromiseResolve,
 } from './abstract-ops/all.mjs';
 import { Value } from './value.mjs';
-import { kAsyncContext, resume } from './helpers.mjs';
+import { callable, kAsyncContext, resume } from './helpers.mjs';
 
-/** http://tc39.es/ecma262/#sec-completion-record-specification-type */
-export function Completion(init) {
-  if (new.target === undefined) {
-    // 1. Assert: completionRecord is a Completion Record.
-    Assert(init instanceof Completion);
-    // 2. Return completionRecord as the Completion Record of this abstract operation.
-    return init;
-  }
-
-  this.Type = init.Type;
-  this.Value = init.Value;
-  this.Target = init.Target;
+export type CompletionType = 'normal' | 'break' | 'continue' | 'return' | 'throw';
+export interface CompletionRecord<T> {
+  readonly Target: string | undefined;
+  readonly Type: CompletionType;
+  readonly Value: T;
+}
+export interface NormalCompletionRecord<T> extends CompletionRecord<T> {
+  readonly Type: 'normal';
+  readonly Value: T;
+  readonly Target: undefined;
 }
 
-// NON-SPEC
-Completion.prototype.mark = function mark(m) {
-  m(this.Value);
-};
+/** http://tc39.es/ecma262/#sec-completion-record-specification-type */ // @ts-expect-error
+export declare function Completion<T>(_init: NormalCompletion<T>): NormalCompletion<T> // @ts-expect-error
+export declare function Completion<T>(_init: Completion<T>): Completion<T>
+/** http://tc39.es/ecma262/#sec-completion-record-specification-type */
+export @callable((_CompletionClass, _thisValue, [init]) => {
+  // 1. Assert: completionRecord is a Completion Record.
+  Assert(init instanceof Completion);
+  // 2. Return completionRecord as the Completion Record of this abstract operation.
+  return init;
+}) // @ts-expect-error
+class Completion<T = unknown> {
+  constructor(init: CompletionRecord<T>) {
+    this.Type = init.Type;
+    this.Value = init.Value;
+    this.Target = init.Target;
+  }
+
+  readonly Type: CompletionType;
+  readonly Value: T;
+  readonly Target: string | undefined;
+
+  // NON-SPEC
+  mark(m: GCMarker) {
+    m(this.Value);
+  }
+}
 
 /** http://tc39.es/ecma262/#sec-normalcompletion */
-export function NormalCompletion(argument) {
+export interface NormalCompletion<T> extends Completion<T> {
+  readonly Type: 'normal';
+  readonly Target: undefined;
+}
+export function NormalCompletion<T>(argument: T): NormalCompletion<T> {
   // 1. Return Completion { [[Type]]: normal, [[Value]]: argument, [[Target]]: empty }.
-  return new Completion({ Type: 'normal', Value: argument, Target: undefined });
+  return new Completion({ Type: 'normal', Value: argument, Target: undefined }) as NormalCompletion<T>;
 }
 
 Object.defineProperty(NormalCompletion, Symbol.hasInstance, {
-  value: function hasInstance(v) {
+  value: function hasInstance(v: unknown) {
     return v instanceof Completion && v.Type === 'normal';
   },
   writable: true,
@@ -43,20 +67,32 @@ Object.defineProperty(NormalCompletion, Symbol.hasInstance, {
   configurable: true,
 });
 
-export class AbruptCompletion {
-  static [Symbol.hasInstance](v) {
+export abstract class AbruptCompletion<T> extends Completion<T> {
+  private constructor() {
+    Assert(false, 'AbruptCompletion is not a real class.');
+    super(null!);
+  }
+
+  declare readonly Type: 'break' | 'continue' | 'return' | 'throw';
+  declare readonly Target: string | undefined;
+  declare readonly Value: T;
+  static [Symbol.hasInstance](v: unknown) {
     return v instanceof Completion && v.Type !== 'normal';
   }
 }
 
+export interface ThrowCompletion<T = unknown> extends Completion<T> {
+  readonly Type: 'throw';
+  readonly Target: undefined;
+}
 /** http://tc39.es/ecma262/#sec-throwcompletion */
-export function ThrowCompletion(argument) {
+export function ThrowCompletion<T>(argument: T): ThrowCompletion<T> {
   // 1. Return Completion { [[Type]]: throw, [[Value]]: argument, [[Target]]: empty }.
-  return new Completion({ Type: 'throw', Value: argument, Target: undefined });
+  return new Completion({ Type: 'throw', Value: argument, Target: undefined }) as ThrowCompletion<T>;
 }
 
 /** http://tc39.es/ecma262/#sec-updateempty */
-export function UpdateEmpty(completionRecord, value) {
+export function UpdateEmpty<T, Q>(completionRecord: Completion<Q>, value: T): Completion<T | Q> {
   Assert(completionRecord instanceof Completion);
   // 1. Assert: If completionRecord.[[Type]] is either return or throw, then completionRecord.[[Value]] is not empty.
   Assert(!(completionRecord.Type === 'return' || completionRecord.Type === 'throw') || completionRecord.Value !== undefined);
@@ -68,45 +104,53 @@ export function UpdateEmpty(completionRecord, value) {
   return new Completion({ Type: completionRecord.Type, Value: value, Target: completionRecord.Target });
 }
 
-/** http://tc39.es/ecma262/#sec-returnifabrupt */
-export function ReturnIfAbrupt(_completion) {
+/**
+ * http://tc39.es/ecma262/#sec-returnifabrupt
+ * http://tc39.es/ecma262/#sec-returnifabrupt-shorthands ? OperationName()
+ */
+export function ReturnIfAbrupt<T>(_completion: Completion<T> | T): T
+export function ReturnIfAbrupt<T, Q>(_completion: Completion<T> | Q): T | Q
+export function ReturnIfAbrupt<T>(_completion: Completion<T> | T): never {
   /* c8 skip next */
   throw new TypeError('ReturnIfAbrupt requires build');
 }
 
-/** http://tc39.es/ecma262/#sec-returnifabrupt-shorthands ? OperationName() */
-export const Q = ReturnIfAbrupt;
+export { ReturnIfAbrupt as Q };
 
 /** http://tc39.es/ecma262/#sec-returnifabrupt-shorthands ! OperationName() */
-export function X(_completion) {
+export function X<T>(_completion: NormalCompletion<T> | AbruptCompletion<unknown>): T
+export function X<T>(_completion: T): T
+export function X<T, Q>(_completion: NormalCompletion<T> | AbruptCompletion<unknown> | Q): T | Q
+export function X(_completion: unknown): never {
   /* c8 skip next */
   throw new TypeError('X() requires build');
 }
 
 /** http://tc39.es/ecma262/#sec-ifabruptcloseiterator */
-export function IfAbruptCloseIterator(_value, _iteratorRecord) {
+// TODO(TS):
+export function IfAbruptCloseIterator(_value: Completion, _iteratorRecord: unknown) {
   /* c8 skip next */
   throw new TypeError('IfAbruptCloseIterator() requires build');
 }
 
 /** http://tc39.es/ecma262/#sec-ifabruptrejectpromise */
-export function IfAbruptRejectPromise(_value, _capability) {
+export function IfAbruptRejectPromise(_value: Completion, _capability: PromiseCapabilityRecord) {
   /* c8 skip next */
   throw new TypeError('IfAbruptRejectPromise requires build');
 }
 
-export function EnsureCompletion(val) {
+export function EnsureCompletion<T>(val: T | Completion<T>): Completion<T> {
   if (val instanceof Completion) {
     return val;
   }
   return NormalCompletion(val);
 }
 
-export function* Await(value) {
+export function* Await(value: Value): Generator<Value, Completion, Completion> {
   // 1. Let asyncContext be the running execution context.
   const asyncContext = surroundingAgent.runningExecutionContext;
   // 2. Let promise be ? PromiseResolve(%Promise%, value).
-  const promise = Q(PromiseResolve(surroundingAgent.intrinsic('%Promise%'), value));
+  const promise = ReturnIfAbrupt(PromiseResolve(surroundingAgent.intrinsic('%Promise%'), value));
   // 3. Let fulfilledClosure be a new Abstract Closure with parameters (value) that captures asyncContext and performs the following steps when called:
   const fulfilledClosure = ([valueInner = Value.undefined]) => {
     // a. Let prevContext be the running execution context.
@@ -122,7 +166,8 @@ export function* Await(value) {
     return Value.undefined;
   };
   // 4. Let onFulfilled be ! CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
-  const onFulfilled = X(CreateBuiltinFunction(fulfilledClosure, 1, new Value(''), []));
+  const onFulfilled = X(CreateBuiltinFunction(fulfilledClosure, 1, Value(''), []));
+  // @ts-expect-error TODO(ts): CreateBuiltinFunction should return a specalized type FunctionObjectValue that has a kAsyncContext on it.
   onFulfilled[kAsyncContext] = asyncContext;
   // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the following steps when called:
   const rejectedClosure = ([reason = Value.undefined]) => {
@@ -139,7 +184,8 @@ export function* Await(value) {
     return Value.undefined;
   };
   // 6. Let onRejected be ! CreateBuiltinFunction(rejectedClosure, 1, "", « »).
-  const onRejected = X(CreateBuiltinFunction(rejectedClosure, 1, new Value(''), []));
+  const onRejected = X(CreateBuiltinFunction(rejectedClosure, 1, Value(''), []));
+  // @ts-expect-error TODO(ts): CreateBuiltinFunction should return a specalized type FunctionObjectValue that has a kAsyncContext on it.
   onRejected[kAsyncContext] = asyncContext;
   // 7. Perform ! PerformPromiseThen(promise, onFulfilled, onRejected).
   X(PerformPromiseThen(promise, onFulfilled, onRejected));

--- a/src/engine.mts
+++ b/src/engine.mts
@@ -351,3 +351,4 @@ export function HostCallJobCallback(jobCallback, V, argumentsList) {
   // 1. Return ? Call(jobCallback.[[Callback]], V, argumentsList).
   return Q(Call(jobCallback.Callback, V, argumentsList));
 }
+export type GCMarker = (value: unknown) => void;

--- a/src/helpers.mts
+++ b/src/helpers.mts
@@ -1,14 +1,16 @@
 // @ts-nocheck
-import { surroundingAgent } from './engine.mjs';
+import { ExecutionContext, type GCMarker, surroundingAgent } from './engine.mjs';
 import {
-  Value, Descriptor, JSStringValue, NumberValue,
+  Value, Descriptor, JSStringValue, NumberValue, ObjectValue, UndefinedValue, NullValue,
 } from './value.mjs';
-import { ToString, DefinePropertyOrThrow, CreateBuiltinFunction } from './abstract-ops/all.mjs';
-import { X } from './completion.mjs';
+import {
+  ToString, DefinePropertyOrThrow, CreateBuiltinFunction,
+} from './abstract-ops/all.mjs';
+import { Completion, X } from './completion.mjs';
 
 export const kInternal = Symbol('kInternal');
 
-function convertValueForKey(key) {
+function convertValueForKey<T>(key: JSStringValue | NumberValue | T): string | number | T {
   if (key instanceof JSStringValue) {
     return key.stringValue();
   } else if (key instanceof NumberValue) {
@@ -17,7 +19,8 @@ function convertValueForKey(key) {
   return key;
 }
 
-export class ValueMap {
+export class ValueMap<K, V> {
+  private map: Map<K, V>;
   constructor() {
     this.map = new Map();
   }
@@ -26,20 +29,20 @@ export class ValueMap {
     return this.map.size;
   }
 
-  get(key) {
+  get(key: K) {
     return this.map.get(convertValueForKey(key));
   }
 
-  set(key, value) {
+  set(key: K, value: V) {
     this.map.set(convertValueForKey(key), value);
     return this;
   }
 
-  has(key) {
+  has(key: K) {
     return this.map.has(convertValueForKey(key));
   }
 
-  delete(key) {
+  delete(key: K) {
     return this.map.delete(convertValueForKey(key));
   }
 
@@ -53,7 +56,7 @@ export class ValueMap {
     return this[Symbol.iterator]();
   }
 
-  forEach(cb) {
+  forEach(cb: (value: V, key: K | JSStringValue | NumberValue, thisValue: ValueMap<K, V>) => void) {
     for (const [key, value] of this.entries()) {
       cb(value, key, this);
     }
@@ -62,14 +65,14 @@ export class ValueMap {
   * [Symbol.iterator]() {
     for (const [key, value] of this.map.entries()) {
       if (typeof key === 'string' || typeof key === 'number') {
-        yield [new Value(key), value];
+        yield [Value(key), value] as const;
       } else {
-        yield [key, value];
+        yield [key, value] as const;
       }
     }
   }
 
-  mark(m) {
+  mark(m: GCMarker) {
     for (const [k, v] of this.entries()) {
       m(k);
       m(v);
@@ -77,8 +80,9 @@ export class ValueMap {
   }
 }
 
-export class ValueSet {
-  constructor(init) {
+export class ValueSet<T> {
+  private set: Set<T>;
+  constructor(init: undefined | null | Iterable<T>) {
     this.set = new Set();
     if (init !== undefined && init !== null) {
       for (const item of init) {
@@ -91,16 +95,16 @@ export class ValueSet {
     return this.set.size;
   }
 
-  add(item) {
+  add(item: T) {
     this.set.add(convertValueForKey(item));
     return this;
   }
 
-  has(item) {
+  has(item: T) {
     return this.set.has(convertValueForKey(item));
   }
 
-  delete(item) {
+  delete(item: T) {
     return this.set.delete(convertValueForKey(item));
   }
 
@@ -111,14 +115,14 @@ export class ValueSet {
   * [Symbol.iterator]() {
     for (const key of this.set.values()) {
       if (typeof key === 'string' || typeof key === 'number') {
-        yield new Value(key);
+        yield Value(key);
       } else {
         yield key;
       }
     }
   }
 
-  mark(m) {
+  mark(m: GCMarker) {
     for (const v of this.values()) {
       m(v);
     }
@@ -126,8 +130,9 @@ export class ValueSet {
 }
 
 export class OutOfRange extends RangeError {
+  detail: unknown;
   /* c8 ignore next */
-  constructor(fn, detail) {
+  constructor(fn: string, detail: unknown) {
     super(`${fn}() argument out of range`);
     this.detail = detail;
   }
@@ -150,13 +155,13 @@ export function unwind(iterator, maxSteps = 1) {
 
 const kSafeToResume = Symbol('kSameToResume');
 
-export function handleInResume(fn, ...args) {
+export function handleInResume<T extends((...arg: Args) => Return), Args extends unknown[], Return>(fn: T, ...args: Args) {
   const bound = () => fn(...args);
-  bound[kSafeToResume] = true;
+  Reflect.set(bound, kSafeToResume, true);
   return bound;
 }
 
-export function resume(context, completion) {
+export function resume(context: ExecutionContext, completion: Completion) {
   const { value } = context.codeEvaluationState.next(completion);
   if (typeof value === 'function' && value[kSafeToResume] === true) {
     return X(value());
@@ -165,12 +170,13 @@ export function resume(context, completion) {
 }
 
 export class CallSite {
-  constructor(context) {
+  context: ExecutionContext;
+  lastNode = null;
+  lastCallNode = null;
+  inheritedLastCallNode = null;
+  constructCall = false;
+  constructor(context: ExecutionContext) {
     this.context = context;
-    this.lastNode = null;
-    this.lastCallNode = null;
-    this.inheritedLastCallNode = null;
-    this.constructCall = false;
   }
 
   clone(context = this.context) {
@@ -191,7 +197,7 @@ export class CallSite {
   }
 
   isAsync() {
-    if (this.context.Function !== Value.null && this.context.Function.ECMAScriptCode) {
+    if (!(this.context.Function instanceof NullValue) && this.context.Function.ECMAScriptCode) {
       const code = this.context.Function.ECMAScriptCode;
       return code.type === 'AsyncFunctionBody' || code.type === 'AsyncGeneratorBody';
     }
@@ -199,11 +205,11 @@ export class CallSite {
   }
 
   isNative() {
-    return !!this.context.Function.nativeFunction;
+    return !!(this.context.Function as FunctionObjectValue).nativeFunction;
   }
 
   getFunctionName() {
-    if (this.context.Function !== Value.null) {
+    if (!(this.context.Function instanceof NullValue)) {
       const name = this.context.Function.properties.get(new Value('name'));
       if (name) {
         return X(ToString(name.Value)).stringValue();
@@ -213,7 +219,7 @@ export class CallSite {
   }
 
   getSpecifier() {
-    if (this.context.ScriptOrModule !== Value.null) {
+    if (!(this.context.Function instanceof NullValue)) {
       return this.context.ScriptOrModule.HostDefined.specifier;
     }
     return null;
@@ -305,7 +311,7 @@ export class CallSite {
 
 export const kAsyncContext = Symbol('kAsyncContext');
 
-function captureAsyncStack(stack) {
+function captureAsyncStack(stack: CallSite[]) {
   let promise = stack[0].context.promiseCapability.Promise;
   for (let i = 0; i < 10; i += 1) {
     if (promise.PromiseFulfillReactions.length !== 1) {
@@ -330,8 +336,8 @@ function captureAsyncStack(stack) {
   }
 }
 
-export function captureStack(O) {
-  const stack = [];
+export function captureStack(O: ObjectValue) {
+  const stack: CallSite[] = [];
   for (let i = surroundingAgent.executionContextStack.length - 2; i >= 0; i -= 1) {
     const e = surroundingAgent.executionContextStack[i];
     if (e.VariableEnvironment === undefined && e.Function === Value.null) {
@@ -352,9 +358,9 @@ export function captureStack(O) {
     captureAsyncStack(stack);
   }
 
-  let cache = null;
+  let cache: null | JSStringValue | UndefinedValue = null;
 
-  const name = new Value('stack');
+  const name = Value('stack');
   X(DefinePropertyOrThrow(O, name, Descriptor({
     Get: CreateBuiltinFunction(() => {
       if (cache === null) {
@@ -362,15 +368,29 @@ export function captureStack(O) {
         stack.forEach((s) => {
           errorString = `${errorString}\n    at ${s.toString()}`;
         });
-        cache = new Value(errorString);
+        cache = Value(errorString);
       }
       return cache;
-    }, 0, name, [], undefined, undefined, new Value('get')),
+    }, 0, name, [], undefined, undefined, Value('get')),
     Set: CreateBuiltinFunction(([value = Value.undefined]) => {
       cache = value;
       return Value.undefined;
-    }, 1, name, [], undefined, undefined, new Value('set')),
+    }, 1, name, [], undefined, undefined, Value('set')),
     Enumerable: Value.false,
     Configurable: Value.true,
   })));
 }
+
+export function callable<Class extends object>(onCalled = (target: Class, _thisArg: unknown, args: unknown[]) => Reflect.construct(target, args)) {
+  return function decoartor(classValue: Class, _classContext: ClassDecoratorContext<Class>) {
+    return new Proxy(classValue, {
+      apply: onCalled,
+    });
+  };
+}
+
+export type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+}
+
+export const isArray: (arg: unknown) => arg is readonly unknown[] = Array.isArray;

--- a/src/value.mts
+++ b/src/value.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { surroundingAgent } from './engine.mjs';
+import { type GCMarker, surroundingAgent } from './engine.mjs';
 import {
   Assert,
   CreateBuiltinFunction,
@@ -21,41 +20,67 @@ import {
 } from './abstract-ops/all.mjs';
 import { EnvironmentRecord } from './environment.mjs';
 import { Completion, X } from './completion.mjs';
-import { ValueMap, OutOfRange } from './helpers.mjs';
+import { ValueMap, OutOfRange, callable } from './helpers.mjs';
+import type { PrivateElementRecord } from './runtime-semantics/MethodDefinitionEvaluation.mjs';
 
+
+// @ts-expect-error callable class
+export declare function Value(value: string): StringValue; // @ts-expect-error callable class
+export declare function Value(value: number): NumberValue; // @ts-expect-error callable class
+export declare function Value(value: bigint): BigIntValue; // @ts-expect-error callable class
+export declare function Value(value: undefined): UndefinedValue; // @ts-expect-error callable class
+export declare function Value(value: null): NullValue; // @ts-expect-error callable class
+// TODO(ts): define a FunctionObjectValue type.
+export declare function Value(value: (...args: unknown[]) => unknown): ObjectValue; // @ts-expect-error callable class
+export declare function Value(value: string | number): StringValue | NumberValue;
 /** http://tc39.es/ecma262/#sec-ecmascript-language-types */
-export class Value {
-  constructor(value = undefined) {
+export @callable((_target, _thisArg, [value]) => {
+  if (value === null) {
+    return Value.null;
+  }
+  switch (typeof value) {
+    case 'undefined':
+      return Value.undefined;
+    case 'string':
+      return new StringValue(value);
+    case 'number':
+      return new NumberValue(value);
+    case 'bigint':
+      return new BigIntValue(value);
+    case 'function':
+      return CreateBuiltinFunction(value, 0, Value(''), []);
+    default:
+      throw new OutOfRange('new Value', value);
+  }
+}) // @ts-expect-error callable class
+abstract class Value {
+  /** @deprecated Use Value() instead of new Value() */
+  constructor(value?: never) {
     if (new.target !== Value) {
       return this;
     }
-
-    switch (typeof value) {
-      case 'string':
-        return new StringValue(value);
-      case 'number':
-        return new NumberValue(value);
-      case 'bigint':
-        return new BigIntValue(value);
-      case 'function':
-        return CreateBuiltinFunction(value, 0, new Value(''), []);
-      default:
-        throw new OutOfRange('new Value', value);
-    }
+    return Value(value);
   }
+
+  static declare readonly null: NullValue;
+  static declare readonly undefined: UndefinedValue;
+  static declare readonly true: BooleanValue;
+  static declare readonly false: BooleanValue;
 }
 
-export class PrimitiveValue extends Value {}
+export class PrimitiveValue extends Value { }
+export type PropertyKeyValue = StringValue | SymbolValue;
 
 /** http://tc39.es/ecma262/#sec-ecmascript-language-types-undefined-type */
-export class UndefinedValue extends PrimitiveValue {}
+export class UndefinedValue extends PrimitiveValue { }
 
 /** http://tc39.es/ecma262/#sec-ecmascript-language-types-null-type */
-export class NullValue extends PrimitiveValue {}
+export class NullValue extends PrimitiveValue { }
 
 /** http://tc39.es/ecma262/#sec-ecmascript-language-types-boolean-type */
 export class BooleanValue extends PrimitiveValue {
-  constructor(v) {
+  readonly boolean: boolean;
+  constructor(v: boolean) {
     super();
     this.boolean = v;
   }
@@ -78,7 +103,8 @@ Object.defineProperties(Value, {
 
 /** http://tc39.es/ecma262/#sec-ecmascript-language-types-string-type */
 class StringValue extends PrimitiveValue {
-  constructor(string) {
+  readonly string: string;
+  constructor(string: string) {
     super();
     this.string = string;
   }
@@ -92,36 +118,35 @@ export { StringValue as JSStringValue };
 
 /** http://tc39.es/ecma262/#sec-ecmascript-language-types-symbol-type */
 export class SymbolValue extends PrimitiveValue {
-  constructor(Description) {
+  readonly Description: StringValue;
+  constructor(Description: StringValue) {
     super();
     this.Description = Description;
   }
 }
 
-export const wellKnownSymbols = Object.create(null);
-for (const name of [
-  'asyncIterator',
-  'hasInstance',
-  'isConcatSpreadable',
-  'iterator',
-  'match',
-  'matchAll',
-  'replace',
-  'search',
-  'species',
-  'split',
-  'toPrimitive',
-  'toStringTag',
-  'unscopables',
-]) {
-  const sym = new SymbolValue(new StringValue(`Symbol.${name}`));
-  wellKnownSymbols[name] = sym;
-}
+export const wellKnownSymbols = {
+  asyncIterator: new SymbolValue(new StringValue('Symbol.asyncIterator')),
+  hasInstance: new SymbolValue(new StringValue('Symbol.hasInstance')),
+  isConcatSpreadable: new SymbolValue(new StringValue('Symbol.isConcatSpreadable')),
+  iterator: new SymbolValue(new StringValue('Symbol.iterator')),
+  match: new SymbolValue(new StringValue('Symbol.match')),
+  matchAll: new SymbolValue(new StringValue('Symbol.matchAll')),
+  replace: new SymbolValue(new StringValue('Symbol.replace')),
+  search: new SymbolValue(new StringValue('Symbol.search')),
+  species: new SymbolValue(new StringValue('Symbol.species')),
+  split: new SymbolValue(new StringValue('Symbol.split')),
+  toPrimitive: new SymbolValue(new StringValue('Symbol.toPrimitive')),
+  toStringTag: new SymbolValue(new StringValue('Symbol.toStringTag')),
+  unscopables: new SymbolValue(new StringValue('Symbol.unscopables')),
+} as const;
+Object.setPrototypeOf(wellKnownSymbols, null);
 Object.freeze(wellKnownSymbols);
 
 /** http://tc39.es/ecma262/#sec-ecmascript-language-types-number-type */
 export class NumberValue extends PrimitiveValue {
-  constructor(number) {
+  readonly number: number;
+  constructor(number: number) {
     super();
     this.number = number;
   }
@@ -143,7 +168,7 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-unaryMinus */
-  static unaryMinus(x) {
+  static unaryMinus(x: NumberValue) {
     if (x.isNaN()) {
       return F(NaN);
     }
@@ -151,7 +176,7 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-bitwiseNOT */
-  static bitwiseNOT(x) {
+  static bitwiseNOT(x: NumberValue) {
     // 1. Let oldValue be ! ToInt32(x).
     const oldValue = X(ToInt32(x));
     // 2. Return the result of applying bitwise complement to oldValue. The result is a signed 32-bit integer.
@@ -159,38 +184,38 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-exponentiate */
-  static exponentiate(base, exponent) {
+  static exponentiate(base: NumberValue, exponent: NumberValue) {
     return F(base.numberValue() ** exponent.numberValue());
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-multiply */
-  static multiply(x, y) {
+  static multiply(x: NumberValue, y: NumberValue) {
     return F(x.numberValue() * y.numberValue());
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-divide */
-  static divide(x, y) {
+  static divide(x: NumberValue, y: NumberValue) {
     return F(x.numberValue() / y.numberValue());
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-remainder */
-  static remainder(n, d) {
+  static remainder(n: NumberValue, d: NumberValue) {
     return F(n.numberValue() % d.numberValue());
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-add */
-  static add(x, y) {
+  static add(x: NumberValue, y: NumberValue) {
     return F(x.numberValue() + y.numberValue());
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-subtract */
-  static subtract(x, y) {
+  static subtract(x: NumberValue, y: NumberValue) {
     // The result of - operator is x + (-y).
     return NumberValue.add(x, F(-y.numberValue()));
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-leftShift */
-  static leftShift(x, y) {
+  static leftShift(x: NumberValue, y: NumberValue) {
     // 1. Let lnum be ! ToInt32(x).
     const lnum = X(ToInt32(x));
     // 2. Let rnum be ! ToUint32(y).
@@ -202,7 +227,7 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-signedRightShift */
-  static signedRightShift(x, y) {
+  static signedRightShift(x: NumberValue, y: NumberValue) {
     // 1. Let lnum be ! ToInt32(x).
     const lnum = X(ToInt32(x));
     // 2. Let rnum be ! ToUint32(y).
@@ -215,7 +240,7 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-unsignedRightShift */
-  static unsignedRightShift(x, y) {
+  static unsignedRightShift(x: NumberValue, y: NumberValue) {
     // 1. Let lnum be ! ToInt32(x).
     const lnum = X(ToInt32(x));
     // 2. Let rnum be ! ToUint32(y).
@@ -228,7 +253,7 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-lessThan */
-  static lessThan(x, y) {
+  static lessThan(x: NumberValue, y: NumberValue) {
     if (x.isNaN()) {
       return Value.undefined;
     }
@@ -257,7 +282,7 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-equal */
-  static equal(x, y) {
+  static equal(x: NumberValue, y: NumberValue) {
     if (x.isNaN()) {
       return Value.false;
     }
@@ -279,7 +304,7 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-sameValue */
-  static sameValue(x, y) {
+  static sameValue(x: NumberValue, y: NumberValue) {
     if (x.isNaN() && y.isNaN()) {
       return Value.true;
     }
@@ -298,7 +323,7 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-sameValueZero */
-  static sameValueZero(x, y) {
+  static sameValueZero(x: NumberValue, y: NumberValue) {
     if (x.isNaN() && y.isNaN()) {
       return Value.true;
     }
@@ -317,48 +342,48 @@ export class NumberValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-bitwiseAND */
-  static bitwiseAND(x, y) {
+  static bitwiseAND(x: NumberValue, y: NumberValue) {
     // 1. Return NumberBitwiseOp(&, x, y).
     return NumberBitwiseOp('&', x, y);
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-bitwiseXOR */
-  static bitwiseXOR(x, y) {
+  static bitwiseXOR(x: NumberValue, y: NumberValue) {
     // 1. Return NumberBitwiseOp(^, x, y).
     return NumberBitwiseOp('^', x, y);
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-bitwiseOR */
-  static bitwiseOR(x, y) {
+  static bitwiseOR(x: NumberValue, y: NumberValue) {
     // 1. Return NumberBitwiseOp(|, x, y).
     return NumberBitwiseOp('|', x, y);
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-number-tostring */
-  static toString(x) {
+  static override toString(x: NumberValue): StringValue {
     if (x.isNaN()) {
-      return new Value('NaN');
+      return Value('NaN');
     }
     const xVal = x.numberValue();
     if (xVal === 0) {
-      return new Value('0');
+      return Value('0');
     }
     if (xVal < 0) {
       const str = X(NumberValue.toString(F(-xVal))).stringValue();
-      return new Value(`-${str}`);
+      return Value(`-${str}`);
     }
     if (x.isInfinity()) {
-      return new Value('Infinity');
+      return Value('Infinity');
     }
     // TODO: implement properly
-    return new Value(`${xVal}`);
+    return Value(`${xVal}`);
   }
+
+  static readonly unit = new NumberValue(1);
 }
 
-NumberValue.unit = new NumberValue(1);
-
 /** http://tc39.es/ecma262/#sec-numberbitwiseop */
-function NumberBitwiseOp(op, x, y) {
+function NumberBitwiseOp(op: '&' | '|' | '^', x: NumberValue, y: NumberValue) {
   // 1. Let lnum be ! ToInt32(x).
   const lnum = X(ToInt32(x));
   // 2. Let rnum be ! ToUint32(y).
@@ -378,7 +403,8 @@ function NumberBitwiseOp(op, x, y) {
 
 /** http://tc39.es/ecma262/#sec-ecmascript-language-types-bigint-type */
 export class BigIntValue extends PrimitiveValue {
-  constructor(bigint) {
+  readonly bigint: bigint;
+  constructor(bigint: bigint) {
     super();
     this.bigint = bigint;
   }
@@ -396,7 +422,7 @@ export class BigIntValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-unaryMinus */
-  static unaryMinus(x) {
+  static unaryMinus(x: BigIntValue) {
     if (x.bigintValue() === 0n) {
       return Z(0n);
     }
@@ -404,12 +430,12 @@ export class BigIntValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-bitwiseNOT */
-  static bitwiseNOT(x) {
+  static bitwiseNOT(x: BigIntValue) {
     return Z(-x.bigintValue() - 1n);
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-exponentiate */
-  static exponentiate(base, exponent) {
+  static exponentiate(base: BigIntValue, exponent: BigIntValue) {
     // 1. If exponent < 0n, throw a RangeError exception.
     if (exponent.bigintValue() < 0n) {
       return surroundingAgent.Throw('RangeError', 'BigIntNegativeExponent');
@@ -423,12 +449,12 @@ export class BigIntValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-multiply */
-  static multiply(x, y) {
+  static multiply(x: BigIntValue, y: BigIntValue) {
     return Z(x.bigintValue() * y.bigintValue());
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-divide */
-  static divide(x, y) {
+  static divide(x: BigIntValue, y: BigIntValue) {
     // 1. If y is 0n, throw a RangeError exception.
     if (y.bigintValue() === 0n) {
       return surroundingAgent.Throw('RangeError', 'BigIntDivideByZero');
@@ -440,7 +466,7 @@ export class BigIntValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-remainder */
-  static remainder(n, d) {
+  static remainder(n: BigIntValue, d: BigIntValue) {
     // 1. If d is 0n, throw a RangeError exception.
     if (d.bigintValue() === 0n) {
       return surroundingAgent.Throw('RangeError', 'BigIntDivideByZero');
@@ -459,85 +485,85 @@ export class BigIntValue extends PrimitiveValue {
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-add */
-  static add(x, y) {
+  static add(x: BigIntValue, y: BigIntValue) {
     return Z(x.bigintValue() + y.bigintValue());
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-subtract */
-  static subtract(x, y) {
+  static subtract(x: BigIntValue, y: BigIntValue) {
     return Z(x.bigintValue() - y.bigintValue());
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-leftShift */
-  static leftShift(x, y) {
+  static leftShift(x: BigIntValue, y: BigIntValue) {
     return Z(x.bigintValue() << y.bigintValue()); // eslint-disable-line no-bitwise
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-signedRightShift */
-  static signedRightShift(x, y) {
+  static signedRightShift(x: BigIntValue, y: BigIntValue) {
     // 1. Return BigInt::leftShift(x, -y).
     return BigIntValue.leftShift(x, Z(-y.bigintValue()));
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-unsignedRightShift */
-  static unsignedRightShift(_x, _y) {
+  static unsignedRightShift(_x: BigIntValue, _y: BigIntValue) {
     return surroundingAgent.Throw('TypeError', 'BigIntUnsignedRightShift');
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-lessThan */
-  static lessThan(x, y) {
+  static lessThan(x: BigIntValue, y: BigIntValue) {
     return x.bigintValue() < y.bigintValue() ? Value.true : Value.false;
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-equal */
-  static equal(x, y) {
+  static equal(x: BigIntValue, y: BigIntValue) {
     // Return true if x and y have the same mathematical integer value and false otherwise.
     return x.bigintValue() === y.bigintValue() ? Value.true : Value.false;
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-sameValue */
-  static sameValue(x, y) {
+  static sameValue(x: BigIntValue, y: BigIntValue) {
     // 1. Return BigInt::equal(x, y).
     return BigIntValue.equal(x, y);
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-sameValueZero */
-  static sameValueZero(x, y) {
+  static sameValueZero(x: BigIntValue, y: BigIntValue) {
     // 1. Return BigInt::equal(x, y).
     return BigIntValue.equal(x, y);
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-bitwiseAND */
-  static bitwiseAND(x, y) {
+  static bitwiseAND(x: BigIntValue, y: BigIntValue) {
     // 1. Return BigIntBitwiseOp(&, x, y).
     return BigIntBitwiseOp('&', x, y);
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-bitwiseXOR */
-  static bitwiseXOR(x, y) {
+  static bitwiseXOR(x: BigIntValue, y: BigIntValue) {
     // 1. Return BigIntBitwiseOp(^, x, y).
     return BigIntBitwiseOp('^', x, y);
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-bitwiseOR */
-  static bitwiseOR(x, y) {
+  static bitwiseOR(x: BigIntValue, y: BigIntValue) {
     // 1. Return BigIntBitwiseOp(|, x, y);
     return BigIntBitwiseOp('|', x, y);
   }
 
   /** http://tc39.es/ecma262/#sec-numeric-types-bigint-tostring */
-  static toString(x) {
+  static override toString(x: BigIntValue): StringValue {
     // 1. If x is less than zero, return the string-concatenation of the String "-" and ! BigInt::toString(-x).
     if (x.bigintValue() < 0n) {
       const str = X(BigIntValue.toString(Z(-x.bigintValue()))).stringValue();
-      return new Value(`-${str}`);
+      return Value(`-${str}`);
     }
     // 2. Return the String value consisting of the code units of the digits of the decimal representation of x.
-    return new Value(`${x.bigintValue()}`);
+    return Value(`${x.bigintValue()}`);
   }
-}
 
-BigIntValue.unit = new BigIntValue(1n);
+  static readonly unit = new BigIntValue(1n);
+}
 
 /*
 /** http://tc39.es/ecma262/#sec-binaryand */
@@ -589,7 +615,7 @@ BigIntValue.unit = new BigIntValue(1n);
 // }
 
 /** http://tc39.es/ecma262/#sec-bigintbitwiseop */
-function BigIntBitwiseOp(op, x, y) {
+function BigIntBitwiseOp(op: '&' | '|' | '^', x: BigIntValue, y: BigIntValue) {
   // TODO: figure out why this doesn't work, probably the modulo.
   /*
   // 1. Assert: op is "&", "|", or "^".
@@ -658,7 +684,8 @@ function BigIntBitwiseOp(op, x, y) {
 
 /** http://tc39.es/ecma262/#sec-private-names */
 export class PrivateName extends Value {
-  constructor(Description) {
+  readonly Description: StringValue;
+  constructor(Description: StringValue) {
     super();
 
     this.Description = Description;
@@ -667,11 +694,13 @@ export class PrivateName extends Value {
 
 /** http://tc39.es/ecma262/#sec-object-type */
 export class ObjectValue extends Value {
-  constructor(internalSlotsList) {
+  readonly properties: ValueMap<StringValue | SymbolValue, Descriptor>;
+  readonly internalSlotsList: readonly string[];
+  readonly PrivateElements: PrivateElementRecord[];
+  constructor(internalSlotsList: readonly string[]) {
     super();
 
     this.PrivateElements = [];
-
     this.properties = new ValueMap();
     this.internalSlotsList = internalSlotsList;
   }
@@ -680,7 +709,7 @@ export class ObjectValue extends Value {
     return OrdinaryGetPrototypeOf(this);
   }
 
-  SetPrototypeOf(V) {
+  SetPrototypeOf(V: Value) {
     return OrdinarySetPrototypeOf(this, V);
   }
 
@@ -692,27 +721,27 @@ export class ObjectValue extends Value {
     return OrdinaryPreventExtensions(this);
   }
 
-  GetOwnProperty(P) {
+  GetOwnProperty(P: PropertyKeyValue) {
     return OrdinaryGetOwnProperty(this, P);
   }
 
-  DefineOwnProperty(P, Desc) {
+  DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor) {
     return OrdinaryDefineOwnProperty(this, P, Desc);
   }
 
-  HasProperty(P) {
+  HasProperty(P: PropertyKeyValue) {
     return OrdinaryHasProperty(this, P);
   }
 
-  Get(P, Receiver) {
+  Get(P: PropertyKeyValue, Receiver: Value) {
     return OrdinaryGet(this, P, Receiver);
   }
 
-  Set(P, V, Receiver) {
+  Set(P: PropertyKeyValue, V: Value, Receiver: Value) {
     return OrdinarySet(this, P, V, Receiver);
   }
 
-  Delete(P) {
+  Delete(P: PropertyKeyValue) {
     return OrdinaryDelete(this, P);
   }
 
@@ -721,21 +750,26 @@ export class ObjectValue extends Value {
   }
 
   // NON-SPEC
-  mark(m) {
+  mark(m: GCMarker) {
     m(this.properties);
     this.internalSlotsList.forEach((s) => {
+      // @ts-ignore
       m(this[s]);
     });
   }
 }
 
 export class ReferenceRecord {
+  Base: 'unresolvable' | Value;
+  ReferencedName: StringValue | SymbolValue | PrivateName;
+  Strict: BooleanValue;
+  ThisValue: ObjectValue | undefined;
   constructor({
     Base,
     ReferencedName,
     Strict,
     ThisValue,
-  }) {
+  }: Pick<ReferenceRecord, 'Base' | 'ReferencedName' | 'Strict' | 'ThisValue'>) {
     this.Base = Base;
     this.ReferencedName = ReferencedName;
     this.Strict = Strict;
@@ -743,47 +777,54 @@ export class ReferenceRecord {
   }
 
   // NON-SPEC
-  mark(m) {
+  mark(m: GCMarker) {
     m(this.Base);
     m(this.ReferencedName);
     m(this.ThisValue);
   }
 }
 
-export function Descriptor(O) {
-  if (new.target === undefined) {
-    return new Descriptor(O);
+// @ts-expect-error
+export function Descriptor(O: Pick<Descriptor, 'Configurable' | 'Enumerable' | 'Get' | 'Set' | 'Value' | 'Writable'>): Descriptor // @ts-expect-error
+export @callable() class Descriptor {
+  readonly Value?: Value;
+  // TODO(ts): should be FunctionObjectValue
+  readonly Get?: ObjectValue;
+  // TODO(ts): should be FunctionObjectValue
+  readonly Set?: ObjectValue;
+  readonly Writable?: BooleanValue;
+  readonly Enumerable?: BooleanValue;
+  readonly Configurable?: BooleanValue;
+  constructor(O: Pick<Descriptor, 'Configurable' | 'Enumerable' | 'Get' | 'Set' | 'Value' | 'Writable'>) {
+    this.Value = O.Value;
+    this.Get = O.Get;
+    this.Set = O.Set;
+    this.Writable = O.Writable;
+    this.Enumerable = O.Enumerable;
+    this.Configurable = O.Configurable;
   }
 
-  this.Value = O.Value;
-  this.Get = O.Get;
-  this.Set = O.Set;
-  this.Writable = O.Writable;
-  this.Enumerable = O.Enumerable;
-  this.Configurable = O.Configurable;
+  everyFieldIsAbsent() {
+    return this.Value === undefined
+          && this.Get === undefined
+          && this.Set === undefined
+          && this.Writable === undefined
+          && this.Enumerable === undefined
+          && this.Configurable === undefined;
+  }
+
+  // NON-SPEC
+  mark(m: GCMarker) {
+    m(this.Value);
+    m(this.Get);
+    m(this.Set);
+  }
 }
 
-Descriptor.prototype.everyFieldIsAbsent = function everyFieldIsAbsent() {
-  return this.Value === undefined
-    && this.Get === undefined
-    && this.Set === undefined
-    && this.Writable === undefined
-    && this.Enumerable === undefined
-    && this.Configurable === undefined;
-};
-
-// NON-SPEC
-Descriptor.prototype.mark = function mark(m) {
-  m(this.Value);
-  m(this.Get);
-  m(this.Set);
-};
-
 export class DataBlock extends Uint8Array {
-  constructor(sizeOrBuffer, ...restArgs) {
+  constructor(sizeOrBuffer: number | ArrayBuffer, byteOffset?: number, length?: number) {
     if (sizeOrBuffer instanceof ArrayBuffer) {
-      // fine.
-      super(sizeOrBuffer, ...restArgs);
+      super(sizeOrBuffer, byteOffset, length);
     } else {
       Assert(typeof sizeOrBuffer === 'number');
       super(sizeOrBuffer);
@@ -791,7 +832,7 @@ export class DataBlock extends Uint8Array {
   }
 }
 
-export function Type(val) {
+export function Type(val: Value) {
   if (val instanceof UndefinedValue) {
     return 'Undefined';
   }
@@ -848,7 +889,7 @@ export function Type(val) {
 }
 
 // Used for Type(x)::y
-export function TypeForMethod(val) {
+export function TypeForMethod(val: Value) {
   if (val instanceof Value) {
     return val.constructor;
   }


### PR DESCRIPTION
I added the type for `Completion` and `Value`.

### Breaking API changes

#### Deprecates `new Value(val)` in flavor of `Value(val)`

TypeScript does not allow overload for class constructors so I cannot type this usage.