### PR TITLE
Improve type safety of the parser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run lint
+      - run: npm run check
 
       # upload build artifacts
       - uses: actions/upload-artifact@v3

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}\\bin\\engine262.js",
+            "args": ["d:/dev/scratch/dispose.js"],
+            "outFiles": [
+                "${workspaceFolder}/dist/*.js"
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "typescript.preferences.quoteStyle": "single",
+    "editor.tabSize": 2,
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "lint:fix": "eslint rollup.config.js test/ src/ bin/ inspector/ scripts/ --cache --ext=js,mjs,mts --fix",
     "build": "run-s build:*",
     "build:regex_data": "node scripts/gen_regex_sets.js",
+    "check": "tsc -p . --noEmit --emitDeclarationOnly false",
+    "check:watch": "tsc -p . --noEmit --emitDeclarationOnly false --watch",
     "build:engine": "rollup -c",
     "test": "bash test/test_root.sh",
     "test:test262": "node --enable-source-maps test/test262/test262.js",

--- a/src/evaluator.mts
+++ b/src/evaluator.mts
@@ -240,7 +240,7 @@ export function* Evaluate(node) {
       return yield* Evaluate_ConditionalExpression(node);
     case 'RegularExpressionLiteral':
       return Evaluate_RegularExpressionLiteral(node);
-    case 'AsyncFunctionBody':
+    case 'AsyncBody':
     case 'GeneratorBody':
     case 'AsyncGeneratorBody':
       return yield* Evaluate_AnyFunctionBody(node);

--- a/src/helpers.mts
+++ b/src/helpers.mts
@@ -394,3 +394,6 @@ export type Mutable<T> = {
 }
 
 export const isArray: (arg: unknown) => arg is readonly unknown[] = Array.isArray;
+export function unreachable(_: never): never {
+  throw new Error('Unreachable');
+}

--- a/src/helpers.mts
+++ b/src/helpers.mts
@@ -199,7 +199,7 @@ export class CallSite {
   isAsync() {
     if (!(this.context.Function instanceof NullValue) && this.context.Function.ECMAScriptCode) {
       const code = this.context.Function.ECMAScriptCode;
-      return code.type === 'AsyncFunctionBody' || code.type === 'AsyncGeneratorBody';
+      return code.type === 'AsyncBody' || code.type === 'AsyncGeneratorBody';
     }
     return false;
   }

--- a/src/parser/BaseParser.mts
+++ b/src/parser/BaseParser.mts
@@ -1,19 +1,35 @@
 import { Lexer } from './Lexer.mjs';
-import type { ParseNode } from './ParseNode.mjs';
+import type { ParseNode, ParseNodesByType } from './ParseNode.mjs';
 import type { Scope } from './Scope.mjs';
 
 export abstract class BaseParser extends Lexer {
   abstract scope: Scope;
-  abstract startNode(inheritStart?: ParseNode): ParseNode;
+
   abstract startNode<T extends ParseNode>(inheritStart?: ParseNode): ParseNode.Unfinished<T>;
-  abstract finishNode<T extends ParseNode.Unfinished<ParseNode>, K extends T['type']>(node: T, type: K): ParseNode.Finished<T, K>;
-  abstract finishNode<T extends ParseNode>(node: T, type: string): T;
+  abstract finishNode<T extends ParseNode.Unfinished, K extends T['type'] & ParseNode['type']>(node: T, type: K): ParseNodesByType[K];
 
   /**
-   * Repurpose a ParseNode of one type as a ParseNode of another type.
+   * Repurpose a {@link ParseNode} of one type as a {@link ParseNode} of another type.
+   * @param node The node to repurpose.
+   * @param type The name of the new node type.
+   * @param update an optional callback that can be used to mutate {@link node} to match the new node type.
    */
-  protected repurpose<K extends string>(node: ParseNode, type: K): ParseNode & { type: K } {
-    node.type = type;
-    return node as ParseNode & { type: K };
+  protected repurpose<T extends ParseNode, K extends ParseNode['type']>(
+    node: T,
+    type: K,
+    update?: (
+      /** The same value as {@link node}, but cast to an unfinished node of the provided type */
+      asNewNode: ParseNode.Unfinished<ParseNodesByType[K]>,
+      /** The same value as {@link node} */
+      asOldNode: T,
+      /** The same value as {@link node}, but cast to a partial, mutable type so that excess properties can be removed. */
+      asPartialNode: { -readonly [P in keyof T]?: T[P] },
+    ) => void,
+  ): ParseNodesByType[K] {
+    // NOTE: must down-cast to `ParseNode` before up-casting to `Unfinished<T>` due to the incompatbile `type` discriminant.
+    const unfinished = node as ParseNode as ParseNode.Unfinished<ParseNodesByType[K]>;
+    unfinished.type = type;
+    update?.(unfinished, node, node);
+    return unfinished as ParseNode as ParseNodesByType[K];
   }
 }

--- a/src/parser/BaseParser.mts
+++ b/src/parser/BaseParser.mts
@@ -1,3 +1,19 @@
 import { Lexer } from './Lexer.mjs';
+import type { ParseNode } from './ParseNode.mjs';
+import type { Scope } from './Scope.mjs';
 
-export class BaseParser extends Lexer {}
+export abstract class BaseParser extends Lexer {
+  abstract scope: Scope;
+  abstract startNode(inheritStart?: ParseNode): ParseNode;
+  abstract startNode<T extends ParseNode>(inheritStart?: ParseNode): ParseNode.Unfinished<T>;
+  abstract finishNode<T extends ParseNode.Unfinished<ParseNode>, K extends T['type']>(node: T, type: K): ParseNode.Finished<T, K>;
+  abstract finishNode<T extends ParseNode>(node: T, type: string): T;
+
+  /**
+   * Repurpose a ParseNode of one type as a ParseNode of another type.
+   */
+  protected repurpose<K extends string>(node: ParseNode, type: K): ParseNode & { type: K } {
+    node.type = type;
+    return node as ParseNode & { type: K };
+  }
+}

--- a/src/parser/BaseParser.mts
+++ b/src/parser/BaseParser.mts
@@ -3,7 +3,7 @@ import type { ParseNode, ParseNodesByType } from './ParseNode.mjs';
 import type { Scope } from './Scope.mjs';
 
 export abstract class BaseParser extends Lexer {
-  abstract scope: Scope;
+  protected abstract scope: Scope;
 
   abstract startNode<T extends ParseNode>(inheritStart?: ParseNode): ParseNode.Unfinished<T>;
   abstract finishNode<T extends ParseNode.Unfinished, K extends T['type'] & ParseNode['type']>(node: T, type: K): ParseNodesByType[K];

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   TV,
   PropName,
@@ -10,26 +9,37 @@ import {
   Token, TokenPrecedence,
   isPropertyOrCall,
   isMember,
-  isKeyword,
+  isKeywordRaw,
   isAutomaticSemicolon,
 } from './tokens.mjs';
-import { isLineTerminator } from './Lexer.mjs';
+import { isLineTerminator, type TokenData } from './Lexer.mjs';
 import { FunctionParser, FunctionKind } from './FunctionParser.mjs';
 import { RegExpParser } from './RegExpParser.mjs';
+import type { ParseNode } from './ParseNode.mjs';
 
-export class ExpressionParser extends FunctionParser {
+export abstract class ExpressionParser extends FunctionParser {
+  abstract state: {
+    hasTopLevelAwait: boolean;
+    strict: boolean;
+    json: boolean;
+  };
+  abstract parseBindingPattern(): ParseNode.BindingPattern;
+  abstract markNodeStart(node: ParseNode | ParseNode.Unfinished<ParseNode>): void;
+  abstract parseInitializerOpt(): ParseNode.Initializer | null;
+  abstract semicolon(): void;
+
   // Expression :
   //   AssignmentExpression
   //   Expression `,` AssignmentExpression
-  parseExpression() {
-    const node = this.startNode();
+  parseExpression(): ParseNode.Expression {
     const AssignmentExpression = this.parseAssignmentExpression();
     if (this.eat(Token.COMMA)) {
-      node.ExpressionList = [AssignmentExpression];
+      const CommaOperator = this.startNode<ParseNode.CommaOperator>(AssignmentExpression);
+      CommaOperator.ExpressionList = [AssignmentExpression];
       do {
-        node.ExpressionList.push(this.parseAssignmentExpression());
+        CommaOperator.ExpressionList.push(this.parseAssignmentExpression());
       } while (this.eat(Token.COMMA));
-      return this.finishNode(node, 'CommaOperator');
+      return this.finishNode(CommaOperator, 'CommaOperator');
     }
     return AssignmentExpression;
   }
@@ -48,11 +58,10 @@ export class ExpressionParser extends FunctionParser {
   //
   // LogicalAssignmentOperator : one of
   //   &&= ||= ??=
-  parseAssignmentExpression() {
+  parseAssignmentExpression(): ParseNode.AssignmentExpressionOrHigher {
     if (this.test(Token.YIELD) && this.scope.hasYield()) {
       return this.parseYieldExpression();
     }
-    const node = this.startNode();
 
     this.scope.pushAssignmentInfo('assign');
     const left = this.parseConditionalExpression();
@@ -66,6 +75,7 @@ export class ExpressionParser extends FunctionParser {
           && this.testAhead(Token.ARROW)
           && !this.peekAhead().hadLineTerminatorBefore) {
         assignmentInfo.clear();
+        const node = this.startNode<ParseNode.AsyncArrowFunction>(left);
         return this.parseArrowFunction(node, {
           Arguments: [this.parseIdentifierReference()],
         }, FunctionKind.ASYNC);
@@ -73,6 +83,7 @@ export class ExpressionParser extends FunctionParser {
       // IdentifierReference [no LineTerminator here] `=>`
       if (this.test(Token.ARROW) && !this.peek().hadLineTerminatorBefore) {
         assignmentInfo.clear();
+        const node = this.startNode<ParseNode.ArrowFunction>(left);
         return this.parseArrowFunction(node, { Arguments: [left] }, FunctionKind.NORMAL);
       }
     }
@@ -81,14 +92,16 @@ export class ExpressionParser extends FunctionParser {
     if (left.type === 'CallExpression' && left.arrowInfo && this.test(Token.ARROW)
         && !this.peek().hadLineTerminatorBefore) {
       const last = left.Arguments[left.Arguments.length - 1];
-      if (!left.arrowInfo.trailingComma || (last && last.type !== 'AssignmentRestElement')) {
+      if (!left.arrowInfo.hasTrailingComma || (last && last.type !== 'AssignmentRestElement')) {
         assignmentInfo.clear();
+        const node = this.startNode<ParseNode.AsyncArrowFunction>(left);
         return this.parseArrowFunction(node, left, FunctionKind.ASYNC);
       }
     }
 
     if (left.type === 'CoverParenthesizedExpressionAndArrowParameterList') {
       assignmentInfo.clear();
+      const node = this.startNode<ParseNode.ArrowFunction>(left);
       return this.parseArrowFunction(node, left, FunctionKind.NORMAL);
     }
 
@@ -108,41 +121,45 @@ export class ExpressionParser extends FunctionParser {
       case Token.ASSIGN_EXP:
       case Token.ASSIGN_AND:
       case Token.ASSIGN_OR:
-      case Token.ASSIGN_NULLISH:
+      case Token.ASSIGN_NULLISH: {
         assignmentInfo.clear();
+        const node = this.startNode<ParseNode.AssignmentExpression>(left);
         this.validateAssignmentTarget(left);
         node.LeftHandSideExpression = left;
-        node.AssignmentOperator = this.next().value;
+        // NOTE: This cast isn't strictly sound as it depends on an expectation that `this.next.value` is correlated
+        //       to `this.peek().type` which cannot be verified by the type system.
+        node.AssignmentOperator = this.next().value as ParseNode.AssignmentExpression['AssignmentOperator'];
         node.AssignmentExpression = this.parseAssignmentExpression();
         return this.finishNode(node, 'AssignmentExpression');
+      }
       default:
         return left;
     }
   }
 
-  validateAssignmentTarget(node) {
+  validateAssignmentTarget(node: ParseNode) {
     switch (node.type) {
       case 'IdentifierReference':
-        if (this.isStrictMode() && (node.name === 'eval' || node.name === 'arguments')) {
+        if (this.isStrictMode() && ((node as ParseNode.IdentifierReference).name === 'eval' || (node as ParseNode.IdentifierReference).name === 'arguments')) {
           break;
         }
         return;
       case 'CoverInitializedName':
-        this.validateAssignmentTarget(node.IdentifierReference);
+        this.validateAssignmentTarget((node as ParseNode.CoverInitializedName).IdentifierReference);
         return;
       case 'MemberExpression':
         return;
       case 'SuperProperty':
         return;
       case 'ParenthesizedExpression':
-        if (node.Expression.type === 'ObjectLiteral' || node.Expression.type === 'ArrayLiteral') {
+        if ((node as ParseNode.ParenthesizedExpression).Expression.type === 'ObjectLiteral' || (node as ParseNode.ParenthesizedExpression).Expression.type === 'ArrayLiteral') {
           break;
         }
-        this.validateAssignmentTarget(node.Expression);
+        this.validateAssignmentTarget((node as ParseNode.ParenthesizedExpression).Expression);
         return;
       case 'ArrayLiteral':
-        node.ElementList.forEach((p, i) => {
-          if (p.type === 'SpreadElement' && (i !== node.ElementList.length - 1 || node.hasTrailingComma)) {
+        (node as ParseNode.ArrayLiteral).ElementList.forEach((p, i) => {
+          if (p.type === 'SpreadElement' && (i !== (node as ParseNode.ArrayLiteral).ElementList.length - 1 || (node as ParseNode.ArrayLiteral).hasTrailingComma)) {
             this.raiseEarly('InvalidAssignmentTarget', p);
           }
           if (p.type === 'AssignmentExpression') {
@@ -153,29 +170,33 @@ export class ExpressionParser extends FunctionParser {
         });
         return;
       case 'ObjectLiteral':
-        node.PropertyDefinitionList.forEach((p, i) => {
+        (node as ParseNode.ObjectLiteral).PropertyDefinitionList.forEach((p, i) => {
           if (p.type === 'PropertyDefinition' && !p.PropertyName
-              && i !== node.PropertyDefinitionList.length - 1) {
+              && i !== (node as ParseNode.ObjectLiteral).PropertyDefinitionList.length - 1) {
             this.raiseEarly('InvalidAssignmentTarget', p);
           }
           this.validateAssignmentTarget(p);
         });
         return;
-      case 'PropertyDefinition':
-        if (node.AssignmentExpression.type === 'AssignmentExpression') {
-          this.validateAssignmentTarget(node.AssignmentExpression.LeftHandSideExpression);
+      case 'PropertyDefinition': {
+        const PropertyDefinition = node as ParseNode.PropertyDefinition;
+        if (PropertyDefinition.AssignmentExpression.type === 'AssignmentExpression') {
+          this.validateAssignmentTarget(PropertyDefinition.AssignmentExpression.LeftHandSideExpression);
         } else {
-          this.validateAssignmentTarget(node.AssignmentExpression);
+          this.validateAssignmentTarget(PropertyDefinition.AssignmentExpression);
         }
         return;
+      }
       case 'Elision':
         return;
-      case 'SpreadElement':
-        if (node.AssignmentExpression.type === 'AssignmentExpression') {
+      case 'SpreadElement': {
+        const SpreadElement = node as ParseNode.SpreadElement;
+        if (SpreadElement.AssignmentExpression.type === 'AssignmentExpression') {
           break;
         }
-        this.validateAssignmentTarget(node.AssignmentExpression);
+        this.validateAssignmentTarget(SpreadElement.AssignmentExpression);
         return;
+      }
       default:
         break;
     }
@@ -186,11 +207,11 @@ export class ExpressionParser extends FunctionParser {
   //   `yield`
   //   `yield` [no LineTerminator here] AssignmentExpression
   //   `yield` [no LineTerminator here] `*` AssignmentExpression
-  parseYieldExpression() {
+  parseYieldExpression(): ParseNode.YieldExpression {
     if (this.scope.inParameters()) {
       this.raiseEarly('YieldInFormalParameters');
     }
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.YieldExpression>();
     this.expect(Token.YIELD);
     if (this.peek().hadLineTerminatorBefore) {
       node.hasStar = false;
@@ -216,17 +237,17 @@ export class ExpressionParser extends FunctionParser {
         }
       }
     }
-    this.scope.arrowInfo?.yieldExpressions.push(node);
+    this.scope.arrowInfo?.yieldExpressions.push(node as ParseNode.YieldExpression);
     return this.finishNode(node, 'YieldExpression');
   }
 
   // ConditionalExpression :
   //   ShortCircuitExpression
   //   ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
-  parseConditionalExpression() {
-    const node = this.startNode();
+  parseConditionalExpression(): ParseNode.ConditionalExpressionOrHigher {
     const ShortCircuitExpression = this.parseShortCircuitExpression();
     if (this.eat(Token.CONDITIONAL)) {
+      const node = this.startNode<ParseNode.ConditionalExpression>(ShortCircuitExpression);
       node.ShortCircuitExpression = ShortCircuitExpression;
       this.scope.with({ in: true }, () => {
         node.AssignmentExpression_a = this.parseAssignmentExpression();
@@ -248,20 +269,20 @@ export class ExpressionParser extends FunctionParser {
   // CoalesceExpressionHead :
   //   CoalesceExpression
   //   BitwiseORExpression
-  parseShortCircuitExpression() {
+  parseShortCircuitExpression(): ParseNode.ShortCircuitExpressionOrHigher {
     // Start parse at BIT_OR, right above AND/OR/NULLISH
-    const expression = this.parseBinaryExpression(TokenPrecedence[Token.BIT_OR]);
+    const expression = this.parseBinaryExpression(TokenPrecedence[Token.BIT_OR]) as ParseNode.BitwiseORExpressionOrHigher;
     switch (this.peek().type) {
       case Token.AND:
       case Token.OR:
         // Drop into normal binary chain starting at OR
-        return this.parseBinaryExpression(TokenPrecedence[Token.OR], expression);
+        return this.parseBinaryExpression(TokenPrecedence[Token.OR], expression) as ParseNode.LogicalORExpressionOrHigher;
       case Token.NULLISH: {
-        let x = expression;
+        let x: ParseNode.CoalesceExpressionHead = expression;
         while (this.eat(Token.NULLISH)) {
-          const node = this.startNode();
+          const node = this.startNode<ParseNode.CoalesceExpression>();
           node.CoalesceExpressionHead = x;
-          node.BitwiseORExpression = this.parseBinaryExpression(TokenPrecedence[Token.BIT_OR]);
+          node.BitwiseORExpression = this.parseBinaryExpression(TokenPrecedence[Token.BIT_OR]) as ParseNode.BitwiseORExpressionOrHigher;
           x = this.finishNode(node, 'CoalesceExpression');
         }
         return x;
@@ -271,7 +292,7 @@ export class ExpressionParser extends FunctionParser {
     }
   }
 
-  parseBinaryExpression(precedence, x) {
+  parseBinaryExpression(precedence: number, x?: ParseNode.BinaryExpressionOrHigher | ParseNode.PrivateIdentifier): ParseNode.BinaryExpressionOrHigher | ParseNode.PrivateIdentifier {
     if (!x) {
       if (this.test(Token.PRIVATE_IDENTIFIER)) {
         x = this.parsePrivateIdentifier();
@@ -286,6 +307,8 @@ export class ExpressionParser extends FunctionParser {
       }
     }
 
+    // NOTE: While the algorithm may be efficient, many casts below are inherently unsound as they depend on assumptions
+    //       that cannot be proven in the type system without runtime assertions.
     let p = TokenPrecedence[this.peek().type];
     if (p >= precedence) {
       do {
@@ -294,41 +317,55 @@ export class ExpressionParser extends FunctionParser {
           if (p === TokenPrecedence[Token.EXP] && (left.type === 'UnaryExpression' || left.type === 'AwaitExpression')) {
             return left;
           }
-          const node = this.startNode(left);
+          let node: ParseNode.Unfinished<ParseNode.BinaryExpression>;
           if (this.peek().type === Token.IN && !this.scope.hasIn()) {
             return left;
           }
           const op = this.next();
           const right = this.parseBinaryExpression(op.type === Token.EXP ? p : p + 1);
-          let name;
+          let name: 'ExponentiationExpression'
+                  | 'MultiplicativeExpression'
+                  | 'AdditiveExpression'
+                  | 'ShiftExpression'
+                  | 'RelationalExpression'
+                  | 'EqualityExpression'
+                  | 'BitwiseANDExpression'
+                  | 'BitwiseXORExpression'
+                  | 'BitwiseORExpression'
+                  | 'LogicalANDExpression'
+                  | 'LogicalORExpression';
           switch (op.type) {
             case Token.EXP:
               name = 'ExponentiationExpression';
-              node.UpdateExpression = left;
-              node.ExponentiationExpression = right;
+              node = this.startNode<ParseNode.ExponentiationExpression>(left);
+              node.UpdateExpression = left as ParseNode.UpdateExpressionOrHigher; // NOTE: unsound cast
+              node.ExponentiationExpression = right as ParseNode.ExponentiationExpressionOrHigher; // NOTE: unsound cast
               break;
             case Token.MUL:
             case Token.DIV:
             case Token.MOD:
               name = 'MultiplicativeExpression';
-              node.MultiplicativeExpression = left;
-              node.MultiplicativeOperator = op.value;
-              node.ExponentiationExpression = right;
+              node = this.startNode<ParseNode.MultiplicativeExpression>(left);
+              node.MultiplicativeExpression = left as ParseNode.MultiplicativeExpressionOrHigher; // NOTE: unsound cast
+              node.MultiplicativeOperator = op.value as ParseNode.MultiplicativeOperator; // NOTE: unsound cast
+              node.ExponentiationExpression = right as ParseNode.ExponentiationExpressionOrHigher; // NOTE: unsound cast
               break;
             case Token.ADD:
             case Token.SUB:
               name = 'AdditiveExpression';
-              node.AdditiveExpression = left;
-              node.MultiplicativeExpression = right;
-              node.operator = op.value;
+              node = this.startNode<ParseNode.AdditiveExpression>(left);
+              node.AdditiveExpression = left as ParseNode.AdditiveExpressionOrHigher; // NOTE: unsound cast
+              node.MultiplicativeExpression = right as ParseNode.MultiplicativeExpressionOrHigher; // NOTE: unsound cast
+              node.operator = op.value as ParseNode.AdditiveExpression['operator']; // NOTE: unsound cast
               break;
             case Token.SHL:
             case Token.SAR:
             case Token.SHR:
               name = 'ShiftExpression';
-              node.ShiftExpression = left;
-              node.AdditiveExpression = right;
-              node.operator = op.value;
+              node = this.startNode<ParseNode.ShiftExpression>(left);
+              node.ShiftExpression = left as ParseNode.ShiftExpressionOrHigher; // NOTE: unsound cast
+              node.AdditiveExpression = right as ParseNode.AdditiveExpressionOrHigher; // NOTE: unsound cast
+              node.operator = op.value as ParseNode.ShiftExpression['operator']; // NOTE: unsound cast
               break;
             case Token.LT:
             case Token.GT:
@@ -337,50 +374,57 @@ export class ExpressionParser extends FunctionParser {
             case Token.INSTANCEOF:
             case Token.IN:
               name = 'RelationalExpression';
+              node = this.startNode<ParseNode.RelationalExpression>(left);
               if (left.type === 'PrivateIdentifier') {
                 node.PrivateIdentifier = left;
               } else {
-                node.RelationalExpression = left;
+                node.RelationalExpression = left as ParseNode.RelationalExpressionOrHigher; // NOTE: unsound cast
               }
-              node.ShiftExpression = right;
-              node.operator = op.value;
+              node.ShiftExpression = right as ParseNode.ShiftExpressionOrHigher; // NOTE: unsound cast
+              node.operator = op.value as ParseNode.RelationalExpression['operator']; // NOTE: unsound cast
               break;
             case Token.EQ:
             case Token.NE:
             case Token.EQ_STRICT:
             case Token.NE_STRICT:
               name = 'EqualityExpression';
-              node.EqualityExpression = left;
-              node.RelationalExpression = right;
-              node.operator = op.value;
+              node = this.startNode<ParseNode.EqualityExpression>(left);
+              node.EqualityExpression = left as ParseNode.EqualityExpressionOrHigher; // NOTE: unsound cast
+              node.RelationalExpression = right as ParseNode.RelationalExpressionOrHigher; // NOTE: unsound cast
+              node.operator = op.value as ParseNode.EqualityExpression['operator']; // NOTE: unsound cast
               break;
             case Token.BIT_AND:
               name = 'BitwiseANDExpression';
-              node.A = left;
-              node.operator = op.value;
-              node.B = right;
+              node = this.startNode<ParseNode.BitwiseANDExpression>(left);
+              node.A = left as ParseNode.BitwiseANDExpressionOrHigher; // NOTE: unsound cast
+              node.operator = op.value as ParseNode.BitwiseANDExpression['operator']; // NOTE: unsound cast
+              node.B = right as ParseNode.EqualityExpressionOrHigher; // NOTE: unsound cast
               break;
             case Token.BIT_XOR:
               name = 'BitwiseXORExpression';
-              node.A = left;
-              node.operator = op.value;
-              node.B = right;
+              node = this.startNode<ParseNode.BitwiseXORExpression>(left);
+              node.A = left as ParseNode.BitwiseXORExpressionOrHigher; // NOTE: unsound cast
+              node.operator = op.value as ParseNode.BitwiseXORExpression['operator']; // NOTE: unsound cast
+              node.B = right as ParseNode.BitwiseANDExpressionOrHigher; // NOTE: unsound cast
               break;
             case Token.BIT_OR:
               name = 'BitwiseORExpression';
-              node.A = left;
-              node.operator = op.value;
-              node.B = right;
+              node = this.startNode<ParseNode.BitwiseORExpression>(left);
+              node.A = left as ParseNode.BitwiseORExpressionOrHigher; // NOTE: unsound cast
+              node.operator = op.value as ParseNode.BitwiseORExpression['operator']; // NOTE: unsound cast
+              node.B = right as ParseNode.BitwiseXORExpressionOrHigher; // NOTE: unsound cast
               break;
             case Token.AND:
               name = 'LogicalANDExpression';
-              node.LogicalANDExpression = left;
-              node.BitwiseORExpression = right;
+              node = this.startNode<ParseNode.LogicalANDExpression>(left);
+              node.LogicalANDExpression = left as ParseNode.LogicalANDExpressionOrHigher; // NOTE: unsound cast
+              node.BitwiseORExpression = right as ParseNode.BitwiseORExpressionOrHigher; // NOTE: unsound cast
               break;
             case Token.OR:
               name = 'LogicalORExpression';
-              node.LogicalORExpression = left;
-              node.LogicalANDExpression = right;
+              node = this.startNode<ParseNode.LogicalORExpression>(left);
+              node.LogicalORExpression = left as ParseNode.LogicalORExpressionOrHigher; // NOTE: unsound cast
+              node.LogicalANDExpression = right as ParseNode.LogicalANDExpressionOrHigher; // NOTE: unsound cast
               break;
             default:
               this.unexpected(op);
@@ -403,12 +447,11 @@ export class ExpressionParser extends FunctionParser {
   //   `~` UnaryExpression
   //   `!` UnaryExpression
   //   [+Await] AwaitExpression
-  parseUnaryExpression() {
+  parseUnaryExpression(): ParseNode.UnaryExpressionOrHigher {
     return this.scope.with({ in: true }, () => {
       if (this.test(Token.AWAIT) && this.scope.hasAwait()) {
         return this.parseAwaitExpression();
       }
-      const node = this.startNode();
       switch (this.peek().type) {
         case Token.DELETE:
         case Token.VOID:
@@ -416,11 +459,12 @@ export class ExpressionParser extends FunctionParser {
         case Token.ADD:
         case Token.SUB:
         case Token.BIT_NOT:
-        case Token.NOT:
-          node.operator = this.next().value;
+        case Token.NOT: {
+          const node = this.startNode<ParseNode.UnaryExpression>();
+          node.operator = this.next().value as ParseNode.UnaryExpression['operator']; // NOTE: unsound cast
           node.UnaryExpression = this.parseUnaryExpression();
           if (node.operator === 'delete') {
-            let target = node.UnaryExpression;
+            let target: ParseNode.Expression = node.UnaryExpression;
             while (target.type === 'ParenthesizedExpression') {
               target = target.Expression;
             }
@@ -432,6 +476,7 @@ export class ExpressionParser extends FunctionParser {
             }
           }
           return this.finishNode(node, 'UnaryExpression');
+        }
         default:
           return this.parseUpdateExpression();
       }
@@ -439,16 +484,16 @@ export class ExpressionParser extends FunctionParser {
   }
 
   // AwaitExpression : `await` UnaryExpression
-  parseAwaitExpression() {
+  parseAwaitExpression(): ParseNode.AwaitExpression {
     if (this.scope.inParameters()) {
       this.raiseEarly('AwaitInFormalParameters');
     } else if (this.scope.inClassStaticBlock()) {
       this.raiseEarly('AwaitInClassStaticBlock');
     }
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.AwaitExpression>();
     this.expect(Token.AWAIT);
     node.UnaryExpression = this.parseUnaryExpression();
-    this.scope.arrowInfo?.awaitExpressions.push(node);
+    this.scope.arrowInfo?.awaitExpressions.push(node as ParseNode.AwaitExpression);
     if (!this.scope.hasReturn()) {
       this.state.hasTopLevelAwait = true;
     }
@@ -461,10 +506,10 @@ export class ExpressionParser extends FunctionParser {
   //   LeftHandSideExpression [no LineTerminator here] `--`
   //   `++` UnaryExpression
   //   `--` UnaryExpression
-  parseUpdateExpression() {
+  parseUpdateExpression(): ParseNode.UpdateExpressionOrHigher {
     if (this.test(Token.INC) || this.test(Token.DEC)) {
-      const node = this.startNode();
-      node.operator = this.next().value;
+      const node = this.startNode<ParseNode.UpdateExpression>();
+      node.operator = this.next().value as ParseNode.UpdateExpression['operator']; // NOTE: unsound cast
       node.LeftHandSideExpression = null;
       node.UnaryExpression = this.parseUnaryExpression();
       this.validateAssignmentTarget(node.UnaryExpression);
@@ -474,8 +519,8 @@ export class ExpressionParser extends FunctionParser {
     if (!this.peek().hadLineTerminatorBefore) {
       if (this.test(Token.INC) || this.test(Token.DEC)) {
         this.validateAssignmentTarget(argument);
-        const node = this.startNode();
-        node.operator = this.next().value;
+        const node = this.startNode(argument) as ParseNode.UpdateExpression;
+        node.operator = this.next().value as ParseNode.UpdateExpression['operator']; // NOTE: unsound cast
         node.LeftHandSideExpression = argument;
         node.UnaryExpression = null;
         return this.finishNode(node, 'UpdateExpression');
@@ -485,14 +530,14 @@ export class ExpressionParser extends FunctionParser {
   }
 
   // LeftHandSideExpression
-  parseLeftHandSideExpression(allowCalls = true) {
-    let result;
+  parseLeftHandSideExpression(allowCalls = true): ParseNode.LeftHandSideExpression {
+    let result: ParseNode.LeftHandSideExpression;
     switch (this.peek().type) {
       case Token.NEW:
         result = this.parseNewExpression();
         break;
       case Token.SUPER: {
-        const node = this.startNode();
+        const node = this.startNode<ParseNode.SuperCall | ParseNode.SuperProperty>();
         this.next();
         if (this.test(Token.LPAREN)) {
           if (!this.scope.hasSuperCall()) {
@@ -518,7 +563,7 @@ export class ExpressionParser extends FunctionParser {
         break;
       }
       case Token.IMPORT: {
-        const node = this.startNode();
+        const node = this.startNode<ParseNode.ImportMeta | ParseNode.ImportCall>();
         this.next();
         if (this.scope.hasImportMeta() && this.eat(Token.PERIOD)) {
           this.expect('meta');
@@ -541,18 +586,20 @@ export class ExpressionParser extends FunctionParser {
 
     const check = allowCalls ? isPropertyOrCall : isMember;
     while (check(this.peek().type)) {
-      const node = this.startNode(result);
+      let finished: ParseNode.LeftHandSideExpression;
       switch (this.peek().type) {
         case Token.LBRACK: {
+          const node = this.startNode<ParseNode.MemberExpression>(result);
           this.next();
           node.MemberExpression = result;
           node.IdentifierName = null;
           node.Expression = this.parseExpression();
           this.expect(Token.RBRACK);
-          result = this.finishNode(node, 'MemberExpression');
+          finished = this.finishNode(node, 'MemberExpression');
           break;
         }
-        case Token.PERIOD:
+        case Token.PERIOD: {
+          const node = this.startNode<ParseNode.MemberExpression>(result);
           this.next();
           node.MemberExpression = result;
           if (this.test(Token.PRIVATE_IDENTIFIER)) {
@@ -564,11 +611,13 @@ export class ExpressionParser extends FunctionParser {
             node.PrivateIdentifier = null;
           }
           node.Expression = null;
-          result = this.finishNode(node, 'MemberExpression');
+          finished = this.finishNode(node, 'MemberExpression');
           break;
+        }
         case Token.LPAREN: {
+          const node = this.startNode<ParseNode.CallExpression>(result);
           // `async` [no LineTerminator here] `(`
-          const couldBeArrow = this.matches('async', this.currentToken)
+          const couldBeArrow = this.matches('async', this.currentToken!)
             && result.type === 'IdentifierReference'
             && !this.peek().hadLineTerminatorBefore;
           if (couldBeArrow) {
@@ -579,32 +628,38 @@ export class ExpressionParser extends FunctionParser {
           node.Arguments = Arguments;
           if (couldBeArrow) {
             node.arrowInfo = this.scope.popArrowInfo();
-            node.arrowInfo.trailingComma = trailingComma;
+            node.arrowInfo.hasTrailingComma = trailingComma;
           }
-          result = this.finishNode(node, 'CallExpression');
+          finished = this.finishNode(node, 'CallExpression');
           break;
         }
-        case Token.OPTIONAL:
+        case Token.OPTIONAL: {
+          const node = this.startNode<ParseNode.OptionalExpression>(result);
           node.MemberExpression = result;
           node.OptionalChain = this.parseOptionalChain();
-          result = this.finishNode(node, 'OptionalExpression');
+          finished = this.finishNode(node, 'OptionalExpression');
           break;
-        case Token.TEMPLATE:
+        }
+        case Token.TEMPLATE: {
+          const node = this.startNode<ParseNode.TaggedTemplateExpression>(result);
           node.MemberExpression = result;
           node.TemplateLiteral = this.parseTemplateLiteral(true);
-          result = this.finishNode(node, 'TaggedTemplateExpression');
+          finished = this.finishNode(node, 'TaggedTemplateExpression');
           break;
+        }
         default:
           this.unexpected();
       }
+      // NOTE: unwinds ParseNode.Finish type alias to avoid circularity issues in type checker
+      result = finished as ParseNode.LeftHandSideExpression;
     }
     return result;
   }
 
   // OptionalChain
-  parseOptionalChain() {
+  parseOptionalChain(): ParseNode.OptionalChain {
     this.expect(Token.OPTIONAL);
-    let base = this.startNode();
+    const base = this.startNode<ParseNode.OptionalChain>();
     base.OptionalChain = null;
     if (this.test(Token.LPAREN)) {
       base.Arguments = this.parseArguments().Arguments;
@@ -619,43 +674,43 @@ export class ExpressionParser extends FunctionParser {
     } else {
       base.IdentifierName = this.parseIdentifierName();
     }
-    base = this.finishNode(base, 'OptionalChain');
 
+    let chain = this.finishNode(base, 'OptionalChain');
     while (true) {
-      const node = this.startNode();
+      const node = this.startNode<ParseNode.OptionalChain>();
       if (this.test(Token.LPAREN)) {
-        node.OptionalChain = base;
+        node.OptionalChain = chain;
         node.Arguments = this.parseArguments().Arguments;
-        base = this.finishNode(node, 'OptionalChain');
+        chain = this.finishNode(node, 'OptionalChain');
       } else if (this.eat(Token.LBRACK)) {
-        node.OptionalChain = base;
+        node.OptionalChain = chain;
         node.Expression = this.parseExpression();
         this.expect(Token.RBRACK);
-        base = this.finishNode(node, 'OptionalChain');
+        chain = this.finishNode(node, 'OptionalChain');
       } else if (this.test(Token.TEMPLATE)) {
         this.raise('TemplateInOptionalChain');
       } else if (this.eat(Token.PERIOD)) {
-        node.OptionalChain = base;
+        node.OptionalChain = chain;
         if (this.test(Token.PRIVATE_IDENTIFIER)) {
           node.PrivateIdentifier = this.parsePrivateIdentifier();
           this.scope.checkUndefinedPrivate(node.PrivateIdentifier);
         } else {
           node.IdentifierName = this.parseIdentifierName();
         }
-        base = this.finishNode(node, 'OptionalChain');
+        chain = this.finishNode(node, 'OptionalChain');
       } else {
-        return base;
+        return chain;
       }
     }
   }
 
   // NewExpression
-  parseNewExpression() {
-    const node = this.startNode();
+  parseNewExpression(): ParseNode.NewExpressionOrHigher {
+    const node = this.startNode<ParseNode.NewTarget | ParseNode.NewExpression>();
     this.expect(Token.NEW);
     if (this.scope.hasNewTarget() && this.eat(Token.PERIOD)) {
       this.expect('target');
-      return this.finishNode(node, 'NewTarget');
+      return this.finishNode(node as ParseNode.NewTarget, 'NewTarget');
     }
     node.MemberExpression = this.parseLeftHandSideExpression(false);
     if (this.test(Token.LPAREN)) {
@@ -663,12 +718,12 @@ export class ExpressionParser extends FunctionParser {
     } else {
       node.Arguments = null;
     }
-    return this.finishNode(node, 'NewExpression');
+    return this.finishNode(node as ParseNode.NewExpression, 'NewExpression');
   }
 
   // PrimaryExpression :
   //   ...
-  parsePrimaryExpression() {
+  parsePrimaryExpression(): ParseNode.PrimaryExpression {
     switch (this.peek().type) {
       case Token.IDENTIFIER:
       case Token.ESCAPED_KEYWORD:
@@ -681,7 +736,7 @@ export class ExpressionParser extends FunctionParser {
         }
         return this.parseIdentifierReference();
       case Token.THIS: {
-        const node = this.startNode();
+        const node = this.startNode<ParseNode.ThisExpression>();
         this.next();
         return this.finishNode(node, 'ThisExpression');
       }
@@ -691,7 +746,7 @@ export class ExpressionParser extends FunctionParser {
       case Token.STRING:
         return this.parseStringLiteral();
       case Token.NULL: {
-        const node = this.startNode();
+        const node = this.startNode<ParseNode.NullLiteral>();
         this.next();
         return this.finishNode(node, 'NullLiteral');
       }
@@ -719,30 +774,30 @@ export class ExpressionParser extends FunctionParser {
   }
 
   // NumericLiteral
-  parseNumericLiteral() {
-    const node = this.startNode();
+  parseNumericLiteral(): ParseNode.NumericLiteral {
+    const node = this.startNode<ParseNode.NumericLiteral>();
     if (!this.test(Token.NUMBER) && !this.test(Token.BIGINT)) {
       this.unexpected();
     }
-    node.value = this.next().value;
+    node.value = this.next().valueAsNumeric();
     return this.finishNode(node, 'NumericLiteral');
   }
 
   // StringLiteral
-  parseStringLiteral() {
-    const node = this.startNode();
+  parseStringLiteral(): ParseNode.StringLiteral {
+    const node = this.startNode<ParseNode.StringLiteral>();
     if (!this.test(Token.STRING)) {
       this.unexpected();
     }
-    node.value = this.next().value;
+    node.value = this.next().valueAsString();
     return this.finishNode(node, 'StringLiteral');
   }
 
   // BooleanLiteral :
   //   `true`
   //   `false`
-  parseBooleanLiteral() {
-    const node = this.startNode();
+  parseBooleanLiteral(): ParseNode.BooleanLiteral {
+    const node = this.startNode<ParseNode.BooleanLiteral>();
     switch (this.peek().type) {
       case Token.TRUE:
         this.next();
@@ -764,14 +819,14 @@ export class ExpressionParser extends FunctionParser {
   //   `[` ElementList `]`
   //   `[` ElementList `,` `]`
   //   `[` ElementList `,` Elision `]`
-  parseArrayLiteral() {
-    const node = this.startNode();
+  parseArrayLiteral(): ParseNode.ArrayLiteral {
+    const node = this.startNode<ParseNode.ArrayLiteral>();
     this.expect(Token.LBRACK);
     node.ElementList = [];
     node.hasTrailingComma = false;
     while (true) {
       while (this.test(Token.COMMA)) {
-        const elision = this.startNode();
+        const elision = this.startNode<ParseNode.Elision>();
         this.next();
         node.ElementList.push(this.finishNode(elision, 'Elision'));
       }
@@ -779,7 +834,7 @@ export class ExpressionParser extends FunctionParser {
         break;
       }
       if (this.test(Token.ELLIPSIS)) {
-        const spread = this.startNode();
+        const spread = this.startNode<ParseNode.SpreadElement>();
         this.next();
         spread.AssignmentExpression = this.parseAssignmentExpression();
         node.ElementList.push(this.finishNode(spread, 'SpreadElement'));
@@ -800,8 +855,8 @@ export class ExpressionParser extends FunctionParser {
   //   `{` `}`
   //   `{` PropertyDefinitionList `}`
   //   `{` PropertyDefinitionList `,` `}`
-  parseObjectLiteral() {
-    const node = this.startNode();
+  parseObjectLiteral(): ParseNode.ObjectLiteral {
+    const node = this.startNode<ParseNode.ObjectLiteral>();
     this.expect(Token.LBRACE);
     node.PropertyDefinitionList = [];
     let hasProto = false;
@@ -831,23 +886,23 @@ export class ExpressionParser extends FunctionParser {
     return this.finishNode(node, 'ObjectLiteral');
   }
 
-  parsePropertyDefinition() {
+  parsePropertyDefinition(): ParseNode.PropertyDefinitionListElement {
     return this.parseBracketedDefinition('property');
   }
 
-  parseFunctionExpression(kind) {
-    return this.parseFunction(true, kind);
+  parseFunctionExpression(kind: FunctionKind): ParseNode.FunctionExpressionLike {
+    return this.parseFunction(true, kind) as ParseNode.FunctionExpressionLike;
   }
 
-  parseArguments() {
+  parseArguments(): { Arguments: ParseNode.Arguments, trailingComma: boolean } {
     this.expect(Token.LPAREN);
     if (this.eat(Token.RPAREN)) {
       return { Arguments: [], trailingComma: false };
     }
-    const Arguments = [];
+    const Arguments: ParseNode.Arguments = [];
     let trailingComma = false;
     while (true) {
-      const node = this.startNode();
+      const node = this.startNode<ParseNode.AssignmentRestElement>();
       if (this.eat(Token.ELLIPSIS)) {
         node.AssignmentExpression = this.parseAssignmentExpression();
         Arguments.push(this.finishNode(node, 'AssignmentRestElement'));
@@ -873,8 +928,8 @@ export class ExpressionParser extends FunctionParser {
   //
   // ClassExpression :
   //   `class` BindingIdentifier? ClassTail
-  parseClass(isExpression) {
-    const node = this.startNode();
+  parseClass(isExpression: boolean): ParseNode.ClassLike {
+    const node = this.startNode<ParseNode.ClassLike>();
 
     this.expect(Token.CLASS);
 
@@ -898,8 +953,8 @@ export class ExpressionParser extends FunctionParser {
   // ClassTail : ClassHeritage? `{` ClassBody? `}`
   // ClassHeritage : `extends` LeftHandSideExpression
   // ClassBody : ClassElementList
-  parseClassTail() {
-    const node = this.startNode();
+  parseClassTail(): ParseNode.ClassTail {
+    const node = this.startNode<ParseNode.ClassTail>();
 
     if (this.eat(Token.EXTENDS)) {
       node.ClassHeritage = this.parseLeftHandSideExpression();
@@ -933,7 +988,7 @@ export class ExpressionParser extends FunctionParser {
           }
 
           if (m.ClassElementName?.type === 'PrivateIdentifier') {
-            let type;
+            let type: 'field' | 'method' | 'set' | 'get';
             if (m.type === 'FieldDefinition') {
               type = 'field';
             } else if (m.UniqueFormalParameters) {
@@ -966,8 +1021,8 @@ export class ExpressionParser extends FunctionParser {
 
           const name = PropName(m);
           const isActualConstructor = !m.static
-            && !!m.UniqueFormalParameters
             && m.type === 'MethodDefinition'
+            && !!m.UniqueFormalParameters
             && name === 'constructor';
           if (isActualConstructor) {
             if (hasConstructor) {
@@ -990,15 +1045,15 @@ export class ExpressionParser extends FunctionParser {
     return this.finishNode(node, 'ClassTail');
   }
 
-  parseClassElement() {
+  parseClassElement(): ParseNode.ClassElement {
     let element;
     if (this.test('static') && this.testAhead(Token.LBRACE)) {
-      const node = this.startNode();
+      const node = this.startNode<ParseNode.ClassStaticBlock>();
       this.expect('static');
       node.static = true;
       this.expect(Token.LBRACE);
-      node.ClassStaticBlockBody = this.startNode();
-      node.ClassStaticBlockBody.ClassStaticBlockStatementList = this.scope.with(
+      const ClassStaticBlockBody = this.startNode<ParseNode.ClassStaticBlockBody>();
+      ClassStaticBlockBody.ClassStaticBlockStatementList = this.scope.with(
         {
           lexical: true,
           yield: false,
@@ -1012,7 +1067,7 @@ export class ExpressionParser extends FunctionParser {
         },
         () => this.parseStatementList(Token.RBRACE),
       );
-      this.finishNode(node.ClassStaticBlockBody, 'ClassStaticBlockBody');
+      node.ClassStaticBlockBody = this.finishNode(ClassStaticBlockBody, 'ClassStaticBlockBody');
       element = this.finishNode(node, 'ClassStaticBlock');
     } else {
       element = this.parseBracketedDefinition('class element');
@@ -1020,12 +1075,12 @@ export class ExpressionParser extends FunctionParser {
     return element;
   }
 
-  parseClassExpression() {
-    return this.parseClass(true);
+  parseClassExpression(): ParseNode.ClassExpression {
+    return this.parseClass(true) as ParseNode.ClassExpression;
   }
 
-  parseTemplateLiteral(tagged = false) {
-    const node = this.startNode();
+  parseTemplateLiteral(tagged = false): ParseNode.TemplateLiteral {
+    const node = this.startNode<ParseNode.TemplateLiteral>();
     node.TemplateSpanList = [];
     node.ExpressionList = [];
     let buffer = '';
@@ -1088,14 +1143,14 @@ export class ExpressionParser extends FunctionParser {
 
   // RegularExpressionLiteral :
   //   `/` RegularExpressionBody `/` RegularExpressionFlags
-  parseRegularExpressionLiteral() {
-    const node = this.startNode();
+  parseRegularExpressionLiteral(): ParseNode.RegularExpressionLiteral {
+    const node = this.startNode<ParseNode.RegularExpressionLiteral>();
     this.scanRegularExpressionBody();
-    node.RegularExpressionBody = this.scannedValue;
+    node.RegularExpressionBody = this.scannedValue as string; // NOTE: unsound cast
     this.scanRegularExpressionFlags();
-    node.RegularExpressionFlags = this.scannedValue;
+    node.RegularExpressionFlags = this.scannedValue as string; // NOTE: unsound cast
     try {
-      const parse = (flags) => {
+      const parse = (flags: { U: boolean; N: boolean; }) => {
         const p = new RegExpParser(node.RegularExpressionBody);
         return p.scope(flags, () => p.parsePattern());
       };
@@ -1109,6 +1164,7 @@ export class ExpressionParser extends FunctionParser {
       }
     } catch (e) {
       if (e instanceof SyntaxError) {
+        // @ts-expect-error
         this.raise('Raw', node.location.startIndex + e.position + 1, e.message);
       } else {
         throw e;
@@ -1118,7 +1174,7 @@ export class ExpressionParser extends FunctionParser {
       endIndex: this.position - 1,
       line: this.line - 1,
       column: this.position - this.columnOffset,
-    };
+    } as TokenData; // NOTE: unsound cast
     this.next();
     this.currentToken = fakeToken;
     return this.finishNode(node, 'RegularExpressionLiteral');
@@ -1132,9 +1188,9 @@ export class ExpressionParser extends FunctionParser {
   //   `(` `...` BindingPattern `)`
   //   `(` Expression `,` `...` BindingIdentifier `)`
   //   `(` Expression `.` `...` BindingPattern `)`
-  parseCoverParenthesizedExpressionAndArrowParameterList() {
-    const node = this.startNode();
-    const commaOp = this.startNode();
+  parseCoverParenthesizedExpressionAndArrowParameterList(): ParseNode.CoverParenthesizedExpressionAndArrowParameterList | ParseNode.ParenthesizedExpression {
+    const node = this.startNode<ParseNode.CoverParenthesizedExpressionAndArrowParameterList | ParseNode.ParenthesizedExpression>();
+    const commaOp = this.startNode<ParseNode.CommaOperator>();
     this.expect(Token.LPAREN);
     if (this.test(Token.RPAREN)) {
       if (!this.testAhead(Token.ARROW) || this.peekAhead().hadLineTerminatorBefore) {
@@ -1152,7 +1208,7 @@ export class ExpressionParser extends FunctionParser {
     let rparenAfterComma;
     while (true) {
       if (this.test(Token.ELLIPSIS)) {
-        const inner = this.startNode();
+        const inner = this.startNode<ParseNode.BindingRestElement>();
         this.next();
         switch (this.peek().type) {
           case Token.LBRACE:
@@ -1202,9 +1258,9 @@ export class ExpressionParser extends FunctionParser {
       this.unexpected(rparenAfterComma);
     }
     if (expressions.length === 1) {
-      node.Expression = expressions[0];
+      node.Expression = expressions[0] as ParseNode.Expression; // NOTE: unsound cast due to potential BindingRestElement
     } else {
-      commaOp.ExpressionList = expressions;
+      commaOp.ExpressionList = expressions as ParseNode.AssignmentExpressionOrHigher[]; // NOTE: unsound cast
       node.Expression = this.finishNode(commaOp, 'CommaOperator');
     }
     return this.finishNode(node, 'ParenthesizedExpression');
@@ -1219,9 +1275,9 @@ export class ExpressionParser extends FunctionParser {
   //   NumericLiteral
   // ComputedPropertyName :
   //   `[` AssignmentExpression `]`
-  parsePropertyName() {
+  parsePropertyName(): ParseNode.PropertyNameLike {
     if (this.test(Token.LBRACK)) {
-      const node = this.startNode();
+      const node = this.startNode<ParseNode.PropertyName>();
       this.next();
       node.ComputedPropertyName = this.parseAssignmentExpression();
       this.expect(Token.RBRACK);
@@ -1239,7 +1295,7 @@ export class ExpressionParser extends FunctionParser {
   // ClassElementName :
   //   PropertyName
   //   PrivateIdentifier
-  parseClassElementName() {
+  parseClassElementName(): ParseNode.ClassElementName {
     if (this.test(Token.PRIVATE_IDENTIFIER)) {
       return this.parsePrivateIdentifier();
     }
@@ -1265,8 +1321,11 @@ export class ExpressionParser extends FunctionParser {
   //   `async` [no LineTerminator here] ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
   // AsyncGeneratorMethod :
   //   `async` [no LineTerminator here] `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
-  parseBracketedDefinition(type) {
-    const node = this.startNode();
+  parseBracketedDefinition(type: 'class element'): ParseNode.ClassElement;
+  parseBracketedDefinition(type: 'property'): ParseNode.PropertyDefinitionListElement;
+  parseBracketedDefinition(type: 'property' | 'class element'): ParseNode.PropertyDefinitionListElement | ParseNode.ClassElement;
+  parseBracketedDefinition(type: 'property' | 'class element'): ParseNode.PropertyDefinitionListElement | ParseNode.ClassElement {
+    const node = this.startNode<ParseNode.PropertyDefinitionListElement | ParseNode.ClassElement>();
 
     if (type === 'property' && this.eat(Token.ELLIPSIS)) {
       node.PropertyName = null;
@@ -1316,7 +1375,7 @@ export class ExpressionParser extends FunctionParser {
 
     if (!isGenerator) {
       if (type === 'property' && this.eat(Token.COLON)) {
-        node.PropertyName = firstName;
+        node.PropertyName = firstName as ParseNode.PropertyName; // NOTE: unsound cast
         node.AssignmentExpression = this.parseAssignmentExpression();
         return this.finishNode(node, 'PropertyDefinition');
       }
@@ -1333,28 +1392,27 @@ export class ExpressionParser extends FunctionParser {
         if (argumentNode) {
           this.raiseEarly('UnexpectedToken', argumentNode);
         }
-        this.finishNode(node, 'FieldDefinition');
+        const finished = this.finishNode(node, 'FieldDefinition');
         this.semicolon();
-        return node;
+        return finished;
       }
 
       if (type === 'property' && this.scope.assignmentInfoStack.length > 0 && this.test(Token.ASSIGN)) {
-        node.IdentifierReference = firstName;
-        node.IdentifierReference.type = 'IdentifierReference';
+        node.IdentifierReference = this.repurpose(firstName, 'IdentifierReference') as ParseNode.IdentifierReference;
         node.Initializer = this.parseInitializerOpt();
-        this.finishNode(node, 'CoverInitializedName');
-        this.scope.registerObjectLiteralEarlyError(this.raiseEarly('UnexpectedToken', node));
-        return node;
+        const finished = this.finishNode(node, 'CoverInitializedName');
+        this.scope.registerObjectLiteralEarlyError(this.raiseEarly('UnexpectedToken', finished));
+        return finished;
       }
 
       if (type === 'property'
           && !isSpecialMethod
           && firstName.type === 'IdentifierName'
           && !this.test(Token.LPAREN)
-          && !isKeyword(firstName.name)) {
-        firstName.type = 'IdentifierReference';
+          && !isKeywordRaw(firstName.name)) {
+        const IdentifierReference = this.repurpose(firstName, 'IdentifierReference') as ParseNode.IdentifierReference;
         this.validateIdentifierReference(firstName.name, firstName);
-        return firstName;
+        return IdentifierReference;
       }
     }
 
@@ -1394,18 +1452,22 @@ export class ExpressionParser extends FunctionParser {
       this.scope.with({
         superCall: !isSpecialMethod
                    && !node.static
-                   && (node.ClassElementName.name === 'constructor' || node.ClassElementName.value === 'constructor')
+                   && node.ClassElementName
+                   && ((node.ClassElementName.type === 'IdentifierName' && node.ClassElementName.name === 'constructor')
+                    || (node.ClassElementName.type === 'StringLiteral' && node.ClassElementName.value === 'constructor'))
                    && this.scope.hasSuperCall(),
       }, () => {
         const body = this.parseFunctionBody(isAsync, isGenerator, false);
+        // NOTE: since the property name below is a union, it is unsound to write to `node` in this fashion
+        // @ts-expect-error
         node[`${isAsync ? 'Async' : ''}${isGenerator ? 'Generator' : 'Function'}Body`] = body;
         if (node.UniqueFormalParameters || node.PropertySetParameterList) {
-          this.validateFormalParameters(node.UniqueFormalParameters || node.PropertySetParameterList, body, true);
+          this.validateFormalParameters(node.UniqueFormalParameters || node.PropertySetParameterList!, body, true);
         }
       });
     });
 
-    const name = `${isAsync ? 'Async' : ''}${isGenerator ? 'Generator' : ''}Method${isAsync || isGenerator ? '' : 'Definition'}`;
+    const name = `${isAsync ? 'Async' : ''}${isGenerator ? 'Generator' : ''}Method${isAsync || isGenerator ? '' : 'Definition'}` as ParseNode.MethodLike['type'];
     return this.finishNode(node, name);
   }
 }

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -1480,7 +1480,12 @@ export abstract class ExpressionParser extends FunctionParser {
       });
     });
 
-    const name: ParseNode.MethodDefinitionLike['type'] = isAsync ? isGenerator ? 'AsyncGeneratorMethod' : 'AsyncMethod' : isGenerator ? 'GeneratorMethod' : 'MethodDefinition';
+    let name: ParseNode.MethodDefinitionLike['type'];
+    if (isAsync) {
+      name = isGenerator ? 'AsyncGeneratorMethod' : 'AsyncMethod';
+    } else {
+      name = isGenerator ? 'GeneratorMethod' : 'MethodDefinition';
+    }
     return this.finishNode(node, name);
   }
 }

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -1415,8 +1415,8 @@ export abstract class ExpressionParser extends FunctionParser {
           && firstName.type === 'IdentifierName'
           && !this.test(Token.LPAREN)
           && (!isKeywordRaw(firstName.name)
-            || (firstName.name === 'yield' && !this.scope.hasYield)
-            || (firstName.name === 'await' && !this.scope.hasAwait))) {
+            || (firstName.name === 'yield' && !this.scope.hasYield())
+            || (firstName.name === 'await' && !this.scope.hasAwait()))) {
         const IdentifierReference = this.repurpose(firstName, 'IdentifierReference');
         this.validateIdentifierReference(firstName.name, firstName);
         return IdentifierReference;

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -530,7 +530,7 @@ export abstract class ExpressionParser extends FunctionParser {
 
   // LeftHandSideExpression
   parseLeftHandSideExpression(allowCalls = true): ParseNode.LeftHandSideExpression {
-    let result: ParseNode.CallExpressionOrHigher | ParseNode.MemberExpressionOrHigher;
+    let result: ParseNode.LeftHandSideExpression;
     switch (this.peek().type) {
       case Token.NEW:
         result = this.parseNewExpression();
@@ -585,7 +585,7 @@ export abstract class ExpressionParser extends FunctionParser {
 
     const check = allowCalls ? isPropertyOrCall : isMember;
     while (check(this.peek().type)) {
-      let finished: ParseNode.CallExpressionOrHigher | ParseNode.MemberExpressionOrHigher;
+      let finished: ParseNode.LeftHandSideExpression;
       switch (this.peek().type) {
         case Token.LBRACK: {
           const node = this.startNode<ParseNode.MemberExpression>(result);
@@ -636,7 +636,8 @@ export abstract class ExpressionParser extends FunctionParser {
           const node = this.startNode<ParseNode.OptionalExpression>(result);
           node.MemberExpression = result;
           node.OptionalChain = this.parseOptionalChain();
-          return this.finishNode(node, 'OptionalExpression');
+          finished = this.finishNode(node, 'OptionalExpression');
+          break;
         }
         case Token.TEMPLATE: {
           const node = this.startNode<ParseNode.TaggedTemplateExpression>(result);

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -1321,7 +1321,7 @@ export abstract class ExpressionParser extends FunctionParser {
   // GeneratorMethod :
   //   `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`
   // AsyncMethod :
-  //   `async` [no LineTerminator here] ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
+  //   `async` [no LineTerminator here] ClassElementName `(` UniqueFormalParameters `)` `{` AsyncBody `}`
   // AsyncGeneratorMethod :
   //   `async` [no LineTerminator here] `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
   parseBracketedDefinition(type: 'class element'): ParseNode.ClassElement;
@@ -1468,7 +1468,7 @@ export abstract class ExpressionParser extends FunctionParser {
         if (!isAsync && !isGenerator) {
           (node as ParseNode.Unfinished<ParseNode.MethodDefinition>).FunctionBody = body as ParseNode.FunctionBody;
         } else if (isAsync && !isGenerator) {
-          (node as ParseNode.Unfinished<ParseNode.AsyncMethod>).AsyncBody = body as ParseNode.AsyncFunctionBody;
+          (node as ParseNode.Unfinished<ParseNode.AsyncMethod>).AsyncBody = body as ParseNode.AsyncBody;
         } else if (!isAsync && isGenerator) {
           (node as ParseNode.Unfinished<ParseNode.GeneratorMethod>).GeneratorBody = body as ParseNode.GeneratorBody;
         } else if (isAsync && isGenerator) {

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -1394,6 +1394,7 @@ export abstract class ExpressionParser extends FunctionParser {
       }
 
       if (type === 'property' && this.scope.assignmentInfoStack.length > 0 && this.test(Token.ASSIGN)) {
+        // NOTE: The next line is unsafe because firstName could be something other than IdentifierName
         node.IdentifierReference = this.repurpose(firstName, 'IdentifierReference');
         node.Initializer = this.parseInitializerOpt();
         const finished = this.finishNode(node, 'CoverInitializedName');
@@ -1405,7 +1406,9 @@ export abstract class ExpressionParser extends FunctionParser {
           && !isSpecialMethod
           && firstName.type === 'IdentifierName'
           && !this.test(Token.LPAREN)
-          && !isKeywordRaw(firstName.name)) {
+          && (!isKeywordRaw(firstName.name)
+            || (firstName.name === "yield" && !this.scope.hasYield)
+            || (firstName.name === "await" && !this.scope.hasAwait))) {
         const IdentifierReference = this.repurpose(firstName, 'IdentifierReference');
         this.validateIdentifierReference(firstName.name, firstName);
         return IdentifierReference;

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -19,7 +19,7 @@ import { RegExpParser } from './RegExpParser.mjs';
 import type { ParseNode } from './ParseNode.mjs';
 
 export abstract class ExpressionParser extends FunctionParser {
-  abstract readonly state: {
+  protected abstract readonly state: {
     hasTopLevelAwait: boolean;
     strict: boolean;
     json: boolean;

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -19,7 +19,7 @@ import { RegExpParser } from './RegExpParser.mjs';
 import type { ParseNode } from './ParseNode.mjs';
 
 export abstract class ExpressionParser extends FunctionParser {
-  abstract state: {
+  abstract readonly state: {
     hasTopLevelAwait: boolean;
     strict: boolean;
     json: boolean;

--- a/src/parser/FunctionParser.mts
+++ b/src/parser/FunctionParser.mts
@@ -290,7 +290,14 @@ export abstract class FunctionParser extends IdentifierParser {
       }, () => Arguments.map((p) => this.convertArrowParameter(p)));
       const body = this.parseConciseBody(isAsync);
       this.validateFormalParameters(node.ArrowParameters, body, true);
-      const bodyType = body.type === 'FunctionBody' ? 'ConciseBody' : body.type === 'AsyncBody' ? 'AsyncConciseBody' : body.type;
+      let bodyType: 'ConciseBody' | 'AsyncConciseBody';
+      if (body.type === 'FunctionBody') {
+        bodyType = 'ConciseBody';
+      } else if (body.type === 'AsyncBody') {
+        bodyType = 'AsyncConciseBody';
+      } else {
+        bodyType = body.type;
+      }
       this.setConciseBodyGeneric(node, bodyType, body);
     });
     return this.finishNode(node, `${isAsync ? 'Async' : ''}ArrowFunction`);
@@ -367,11 +374,12 @@ export abstract class FunctionParser extends IdentifierParser {
       node.FunctionStatementList = this.parseStatementList(Token.RBRACE, node.directives);
       node.strict = node.strict || node.directives.includes('use strict');
     });
-    const name =
-      isAsync && isGenerator ? 'AsyncGeneratorBody' :
-      isAsync ? 'AsyncBody' :
-      isGenerator ? 'GeneratorBody' :
-      'FunctionBody';
+    let name: ParseNode.FunctionBodyLike['type'];
+    if (isAsync) {
+      name = isGenerator ? 'AsyncGeneratorBody' : 'AsyncBody';
+    } else {
+      name = isGenerator ? 'GeneratorBody' : 'FunctionBody';
+    }
     return this.finishNode(node, name);
   }
 }

--- a/src/parser/FunctionParser.mts
+++ b/src/parser/FunctionParser.mts
@@ -1,15 +1,36 @@
-// @ts-nocheck
 import { IsSimpleParameterList } from '../static-semantics/all.mjs';
-import { getDeclarations } from './Scope.mjs';
+import { getDeclarations, type ArrowInfo } from './Scope.mjs';
 import { Token } from './tokens.mjs';
 import { IdentifierParser } from './IdentifierParser.mjs';
+import type { ParseNode } from './ParseNode.mjs';
 
-export const FunctionKind = {
-  NORMAL: 0,
-  ASYNC: 1,
-};
+export enum FunctionKind {
+  NORMAL = 0,
+  ASYNC = 1,
+}
 
-export class FunctionParser extends IdentifierParser {
+interface ArrowParameterConversions {
+  'IdentifierReference': ParseNode.SingleNameBinding;
+  'BindingRestElement': ParseNode.BindingRestElement;
+  'Elision': ParseNode.Elision;
+  'ArrayLiteral': ParseNode.BindingElement;
+  'ObjectLiteral': ParseNode.BindingElement;
+  'AssignmentExpression': ParseNode.SingleNameBinding | ParseNode.BindingElement;
+  'CoverInitializedName': ParseNode.SingleNameBinding;
+  'PropertyDefinition': ParseNode.BindingRestProperty | ParseNode.BindingProperty;
+  'SpreadElement': ParseNode.BindingRestElement;
+  'AssignmentRestElement': ParseNode.BindingRestElement;
+}
+
+type ConvertArrowParameterResult<T> =
+  T extends keyof ArrowParameterConversions ? ArrowParameterConversions[T] : never;
+
+export abstract class FunctionParser extends IdentifierParser {
+  abstract parseStatementList(token: string | Token, directives?: string[]): ParseNode.StatementList;
+  abstract parseAssignmentExpression(): ParseNode.AssignmentExpressionOrHigher;
+  abstract parseBindingElement(): ParseNode.BindingElementOrHigher;
+  abstract parseBindingRestElement(): ParseNode.BindingRestElement;
+
   // FunctionDeclaration :
   //   `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
   //   [+Default] `function` `(` FormalParameters `)` `{` FunctionBody `}`
@@ -30,21 +51,19 @@ export class FunctionParser extends IdentifierParser {
   //   [+Default] `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
   // Async`FunctionExpression :
   //   `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-  parseFunction(isExpression, kind) {
+  parseFunction(isExpression: boolean, kind: FunctionKind) {
     const isAsync = kind === FunctionKind.ASYNC;
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.FunctionLike>();
     if (isAsync) {
       this.expect('async');
     }
     this.expect(Token.FUNCTION);
     const isGenerator = this.eat(Token.MUL);
     if (!this.test(Token.LPAREN)) {
-      this.scope.with({
+      node.BindingIdentifier = this.scope.with({
         await: isExpression ? false : undefined,
         yield: isExpression ? false : undefined,
-      }, () => {
-        node.BindingIdentifier = this.parseBindingIdentifier();
-      });
+      }, () => this.parseBindingIdentifier());
       if (!isExpression) {
         this.scope.declare(node.BindingIdentifier, 'function');
       }
@@ -69,6 +88,8 @@ export class FunctionParser extends IdentifierParser {
       node.FormalParameters = this.parseFormalParameters();
 
       const body = this.parseFunctionBody(isAsync, isGenerator, false);
+      // NOTE: since `body` is a union, it is unsound to write to `node` in this fashion
+      // @ts-expect-error
       node[body.type] = body;
 
       if (node.BindingIdentifier) {
@@ -90,11 +111,11 @@ export class FunctionParser extends IdentifierParser {
       this.scope.arrowInfoStack.pop();
     });
 
-    const name = `${isAsync ? 'Async' : ''}${isGenerator ? 'Generator' : 'Function'}${isExpression ? 'Expression' : 'Declaration'}`;
+    const name = `${isAsync ? 'Async' : ''}${isGenerator ? 'Generator' : 'Function'}${isExpression ? 'Expression' : 'Declaration'}` as const;
     return this.finishNode(node, name);
   }
 
-  validateFormalParameters(parameters, body, wantsUnique = false) {
+  validateFormalParameters(parameters: ParseNode.FormalParameters, body: ParseNode.FunctionBodyLike | ParseNode.ConciseBodyLike, wantsUnique = false) {
     const isStrict = body.strict;
     const hasStrictDirective = body.directives && body.directives.includes('use strict');
     if (wantsUnique === false && !IsSimpleParameterList(parameters)) {
@@ -127,15 +148,17 @@ export class FunctionParser extends IdentifierParser {
       });
   }
 
-  convertArrowParameter(node) {
+  convertArrowParameter<T extends ParseNode>(node: T): ConvertArrowParameterResult<T['type']>;
+  convertArrowParameter(node: ParseNode) {
     switch (node.type) {
       case 'IdentifierReference': {
-        node.type = 'BindingIdentifier';
-        const container = this.startNode();
-        container.BindingIdentifier = node;
-        container.Initializer = null;
-        this.scope.declare(node, 'parameter');
-        return this.finishNode(container, 'SingleNameBinding');
+        const IdentifierReference = node as ParseNode.IdentifierReference;
+        const BindingIdentifier = this.repurpose(IdentifierReference, 'BindingIdentifier') as ParseNode.BindingIdentifier;
+        const SingleNameBinding = this.startNode<ParseNode.SingleNameBinding>(IdentifierReference);
+        SingleNameBinding.BindingIdentifier = BindingIdentifier;
+        SingleNameBinding.Initializer = null;
+        this.scope.declare(IdentifierReference, 'parameter');
+        return this.finishNode(SingleNameBinding, 'SingleNameBinding');
       }
       case 'BindingRestElement':
         this.scope.declare(node, 'parameter');
@@ -143,87 +166,98 @@ export class FunctionParser extends IdentifierParser {
       case 'Elision':
         return node;
       case 'ArrayLiteral': {
-        const wrap = this.startNode();
-        node.BindingElementList = [];
-        node.ElementList.forEach((p, i) => {
+        const ArrayLiteral = node as ParseNode.ArrayLiteral;
+        const BindingPattern = this.repurpose(ArrayLiteral, 'ArrayBindingPattern') as ParseNode.ArrayBindingPattern;
+        BindingPattern.BindingElementList = [];
+        ArrayLiteral.ElementList.forEach((p, i) => {
           const c = this.convertArrowParameter(p);
           if (c.type === 'BindingRestElement') {
-            if (i !== node.ElementList.length - 1) {
+            if (i !== ArrayLiteral.ElementList.length - 1) {
               this.raiseEarly('UnexpectedToken', c);
             }
-            node.BindingRestElement = c;
+            BindingPattern.BindingRestElement = c;
           } else {
-            node.BindingElementList.push(c);
+            BindingPattern.BindingElementList.push(c);
           }
         });
-        delete node.ElementList;
-        node.type = 'ArrayBindingPattern';
-        wrap.BindingPattern = node;
-        wrap.Initializer = null;
-        return this.finishNode(wrap, 'BindingElement');
+        delete (ArrayLiteral as Partial<ParseNode.ArrayLiteral>).ElementList;
+        const BindingElement = this.startNode<ParseNode.BindingElement>(ArrayLiteral);
+        BindingElement.BindingPattern = BindingPattern;
+        BindingElement.Initializer = null;
+        return this.finishNode(BindingElement, 'BindingElement');
       }
       case 'ObjectLiteral': {
-        const wrap = this.startNode();
-        node.BindingPropertyList = [];
-        node.PropertyDefinitionList.forEach((p) => {
+        const ObjectLiteral = node as ParseNode.ObjectLiteral;
+        const BindingPattern = this.repurpose(ObjectLiteral, 'ObjectBindingPattern') as ParseNode.ObjectBindingPattern;
+        BindingPattern.BindingPropertyList = [];
+        ObjectLiteral.PropertyDefinitionList.forEach((p) => {
           const c = this.convertArrowParameter(p);
           if (c.type === 'BindingRestProperty') {
-            node.BindingRestProperty = c;
+            BindingPattern.BindingRestProperty = c;
           } else {
-            node.BindingPropertyList.push(c);
+            BindingPattern.BindingPropertyList.push(c);
           }
         });
-        delete node.PropertyDefinitionList;
-        node.type = 'ObjectBindingPattern';
-        wrap.BindingPattern = node;
-        wrap.Initializer = null;
-        return this.finishNode(wrap, 'BindingElement');
+        delete (ObjectLiteral as Partial<ParseNode.ObjectLiteral>).PropertyDefinitionList;
+        const BindingElement = this.startNode<ParseNode.BindingElement>(ObjectLiteral);
+        BindingElement.BindingPattern = BindingPattern;
+        BindingElement.Initializer = null;
+        return this.finishNode(BindingElement, 'BindingElement');
       }
       case 'AssignmentExpression': {
-        const result = this.convertArrowParameter(node.LeftHandSideExpression);
-        result.Initializer = node.AssignmentExpression;
+        const AssignmentExpression = node as ParseNode.AssignmentExpression;
+        const result = this.convertArrowParameter(AssignmentExpression.LeftHandSideExpression);
+        result.Initializer = AssignmentExpression.AssignmentExpression;
         return result;
       }
-      case 'CoverInitializedName':
-        node.type = 'SingleNameBinding';
-        node.BindingIdentifier = node.IdentifierReference;
-        node.BindingIdentifier.type = 'BindingIdentifier';
-        delete node.IdentifierReference;
-        this.scope.declare(node, 'parameter');
-        return node;
-      case 'PropertyDefinition':
-        if (node.PropertyName === null) {
-          node.type = 'BindingRestProperty';
-          node.BindingIdentifier = node.AssignmentExpression;
-          node.BindingIdentifier.type = 'BindingIdentifier';
+      case 'CoverInitializedName': {
+        const CoverInitializedName = node as ParseNode.CoverInitializedName;
+        const { IdentifierReference } = CoverInitializedName;
+        const BindingIdentifier = this.repurpose(IdentifierReference, 'BindingIdentifier') as ParseNode.BindingIdentifier;
+        const SingleNameBinding = this.repurpose(CoverInitializedName, 'SingleNameBinding') as ParseNode.SingleNameBinding;
+        SingleNameBinding.BindingIdentifier = BindingIdentifier;
+        delete (CoverInitializedName as Partial<ParseNode.CoverInitializedName>).IdentifierReference;
+        this.scope.declare(SingleNameBinding, 'parameter');
+        return SingleNameBinding;
+      }
+      case 'PropertyDefinition': {
+        const PropertyDefinition = node as ParseNode.PropertyDefinition;
+        const { AssignmentExpression } = PropertyDefinition;
+        let BindingProperty: ParseNode.BindingProperty | ParseNode.BindingRestProperty;
+        if (PropertyDefinition.PropertyName === null) {
+          BindingProperty = this.repurpose(PropertyDefinition, 'BindingRestProperty') as ParseNode.BindingRestProperty;
+          BindingProperty.BindingIdentifier = this.repurpose(AssignmentExpression, 'BindingIdentifier') as ParseNode.BindingIdentifier;
         } else {
-          node.type = 'BindingProperty';
-          node.BindingElement = this.convertArrowParameter(node.AssignmentExpression);
+          BindingProperty = this.repurpose(PropertyDefinition, 'BindingProperty') as ParseNode.BindingProperty;
+          BindingProperty.BindingElement = this.convertArrowParameter(AssignmentExpression);
         }
-        this.scope.declare(node, 'parameter');
-        delete node.AssignmentExpression;
-        return node;
+        this.scope.declare(PropertyDefinition, 'parameter');
+        delete (PropertyDefinition as Partial<ParseNode.PropertyDefinition>).AssignmentExpression;
+        return BindingProperty;
+      }
       case 'SpreadElement':
-      case 'AssignmentRestElement':
-        node.type = 'BindingRestElement';
-        if (node.AssignmentExpression.type === 'AssignmentExpression') {
-          this.raiseEarly('UnexpectedToken', node);
-        } else if (node.AssignmentExpression.type === 'IdentifierReference') {
-          node.BindingIdentifier = node.AssignmentExpression;
-          node.BindingIdentifier.type = 'BindingIdentifier';
+      case 'AssignmentRestElement': {
+        const SpreadElementOrAssignmentRestElement = node as ParseNode.SpreadElement | ParseNode.AssignmentRestElement;
+        const { AssignmentExpression } = SpreadElementOrAssignmentRestElement;
+        const BindingRestElement = this.repurpose(SpreadElementOrAssignmentRestElement, 'BindingRestElement') as ParseNode.BindingRestElement;
+        if (AssignmentExpression.type === 'AssignmentExpression') {
+          this.raiseEarly('UnexpectedToken', SpreadElementOrAssignmentRestElement);
+        } else if (AssignmentExpression.type === 'IdentifierReference') {
+          BindingRestElement.BindingIdentifier = this.repurpose(AssignmentExpression, 'BindingIdentifier') as ParseNode.BindingIdentifier;
         } else {
-          node.BindingPattern = this.convertArrowParameter(node.AssignmentExpression).BindingPattern;
+          BindingRestElement.BindingPattern = this.convertArrowParameter(AssignmentExpression).BindingPattern;
         }
-        this.scope.declare(node, 'parameter');
-        delete node.AssignmentExpression;
-        return node;
+        this.scope.declare(BindingRestElement, 'parameter');
+        delete (SpreadElementOrAssignmentRestElement as Partial<ParseNode.SpreadElement | ParseNode.AssignmentRestElement>).AssignmentExpression;
+        return BindingRestElement;
+      }
       default:
         this.raiseEarly('UnexpectedToken', node);
         return node;
     }
   }
 
-  parseArrowFunction(node, { arrowInfo, Arguments }, kind) {
+  parseArrowFunction(node: ParseNode.Unfinished<ParseNode.ArrowFunctionLike>, { arrowInfo, Arguments }: { arrowInfo?: ArrowInfo, Arguments: ParseNode.CoverParenthesizedExpressionAndArrowParameterList['Arguments'] }, kind: FunctionKind): ParseNode.ArrowFunctionLike {
     const isAsync = kind === FunctionKind.ASYNC;
     this.expect(Token.ARROW);
     if (arrowInfo) {
@@ -244,24 +278,24 @@ export class FunctionParser extends IdentifierParser {
       lexical: true,
       variable: true,
     }, () => {
-      this.scope.with({
+      node.ArrowParameters = this.scope.with({
         parameters: true,
-      }, () => {
-        node.ArrowParameters = Arguments.map((p) => this.convertArrowParameter(p));
-      });
+      }, () => Arguments.map((p) => this.convertArrowParameter(p)));
       const body = this.parseConciseBody(isAsync);
       this.validateFormalParameters(node.ArrowParameters, body, true);
+      // NOTE: since `body` is a union, it is unsound to write to `node` in this fashion
+      // @ts-expect-error
       node[`${isAsync ? 'Async' : ''}ConciseBody`] = body;
     });
     return this.finishNode(node, `${isAsync ? 'Async' : ''}ArrowFunction`);
   }
 
-  parseConciseBody(isAsync) {
+  parseConciseBody(isAsync: boolean): ParseNode.ConciseBodyLikeOrHigher {
     if (this.test(Token.LBRACE)) {
-      return this.parseFunctionBody(isAsync, false, true);
+      return this.parseFunctionBody(isAsync, false, true) as ParseNode.FunctionBody | ParseNode.AsyncFunctionBody;
     }
-    const asyncBody = this.startNode();
-    const exprBody = this.startNode();
+    const asyncBody = this.startNode<ParseNode.ConciseBodyLike>();
+    const exprBody = this.startNode<ParseNode.ExpressionBody>();
     this.scope.with({ await: isAsync }, () => {
       exprBody.AssignmentExpression = this.parseAssignmentExpression();
     });
@@ -271,7 +305,7 @@ export class FunctionParser extends IdentifierParser {
 
   // FormalParameter : BindingElement
   parseFormalParameter() {
-    return this.parseBindingElement();
+    return this.parseBindingElement() as ParseNode.FormalParameter;
   }
 
   parseFormalParameters() {
@@ -279,7 +313,7 @@ export class FunctionParser extends IdentifierParser {
     if (this.eat(Token.RPAREN)) {
       return [];
     }
-    const params = [];
+    const params: ParseNode.FormalParameters = [];
     this.scope.with({ parameters: true }, () => {
       while (true) {
         if (this.test(Token.ELLIPSIS)) {
@@ -306,11 +340,11 @@ export class FunctionParser extends IdentifierParser {
   }
 
   parseUniqueFormalParameters() {
-    return this.parseFormalParameters();
+    return this.parseFormalParameters() as ParseNode.UniqueFormalParameters;
   }
 
-  parseFunctionBody(isAsync, isGenerator, isArrow) {
-    const node = this.startNode();
+  parseFunctionBody(isAsync: boolean, isGenerator: boolean, isArrow: boolean): ParseNode.FunctionBodyLike {
+    const node = this.startNode<ParseNode.FunctionBodyLike>();
     this.expect(Token.LBRACE);
     this.scope.with({
       newTarget: isArrow ? undefined : true,
@@ -323,7 +357,7 @@ export class FunctionParser extends IdentifierParser {
       node.FunctionStatementList = this.parseStatementList(Token.RBRACE, node.directives);
       node.strict = node.strict || node.directives.includes('use strict');
     });
-    const name = `${isAsync ? 'Async' : ''}${isGenerator ? 'Generator' : 'Function'}Body`;
+    const name = `${isAsync ? 'Async' : ''}${isGenerator ? 'Generator' : 'Function'}Body` as const;
     return this.finishNode(node, name);
   }
 }

--- a/src/parser/FunctionParser.mts
+++ b/src/parser/FunctionParser.mts
@@ -89,11 +89,17 @@ export abstract class FunctionParser extends IdentifierParser {
       node.FormalParameters = this.parseFormalParameters();
 
       const body = this.parseFunctionBody(isAsync, isGenerator, false);
-      if (body.type === 'AsyncFunctionBody') node.AsyncBody = body;
-      else if (body.type === 'AsyncGeneratorBody') node.AsyncGeneratorBody = body;
-      else if (body.type === 'FunctionBody') node.FunctionBody = body;
-      else if (body.type === 'GeneratorBody') node.GeneratorBody = body;
-      else unreachable(body);
+      if (body.type === 'AsyncFunctionBody') {
+        node.AsyncBody = body;
+      } else if (body.type === 'AsyncGeneratorBody') {
+        node.AsyncGeneratorBody = body;
+      } else if (body.type === 'FunctionBody') {
+        node.FunctionBody = body;
+      } else if (body.type === 'GeneratorBody') {
+        node.GeneratorBody = body;
+      } else {
+        unreachable(body);
+      }
 
       if (node.BindingIdentifier) {
         if (body.strict && (node.BindingIdentifier.name === 'eval' || node.BindingIdentifier.name === 'arguments')) {
@@ -286,8 +292,11 @@ export abstract class FunctionParser extends IdentifierParser {
       const body = this.parseConciseBody(isAsync);
       this.validateFormalParameters(node.ArrowParameters, body, true);
       // Unsafe cast
-      if (isAsync) node.AsyncConciseBody = body as ParseNode.AsyncConciseBody;
-      else node.ConciseBody = body as ParseNode.ConciseBody;
+      if (isAsync) {
+        node.AsyncConciseBody = body as ParseNode.AsyncConciseBody;
+      } else {
+        node.ConciseBody = body as ParseNode.ConciseBody;
+      }
     });
     return this.finishNode(node, `${isAsync ? 'Async' : ''}ArrowFunction`);
   }

--- a/src/parser/IdentifierParser.mts
+++ b/src/parser/IdentifierParser.mts
@@ -131,7 +131,7 @@ export abstract class IdentifierParser extends BaseParser {
   //   [~Await] `await`
   parseLabelIdentifier() {
     const node = this.parseIdentifierReference();
-    return this.repurpose(node, 'LabelIdentifier') as ParseNode.LabelIdentifier;
+    return this.repurpose(node, 'LabelIdentifier');
   }
 
   // PrivateIdentifier ::

--- a/src/parser/IdentifierParser.mts
+++ b/src/parser/IdentifierParser.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Token,
   isKeyword,
@@ -6,16 +5,18 @@ import {
   isKeywordRaw,
 } from './tokens.mjs';
 import { BaseParser } from './BaseParser.mjs';
+import type { ParseNode } from './ParseNode.mjs';
+import { type Locatable } from './Lexer.mjs';
 
-export class IdentifierParser extends BaseParser {
+export abstract class IdentifierParser extends BaseParser {
   // IdentifierName
   parseIdentifierName() {
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.IdentifierName>();
     const p = this.peek();
     if (p.type === Token.IDENTIFIER
         || p.type === Token.ESCAPED_KEYWORD
         || isKeyword(p.type)) {
-      node.name = this.next().value;
+      node.name = this.next().valueAsString();
     } else {
       this.unexpected();
     }
@@ -27,14 +28,14 @@ export class IdentifierParser extends BaseParser {
   //   `yield`
   //   `await`
   parseBindingIdentifier() {
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.BindingIdentifier>();
     const token = this.next();
     switch (token.type) {
       case Token.IDENTIFIER:
-        node.name = token.value;
+        node.name = token.valueAsString();
         break;
       case Token.ESCAPED_KEYWORD:
-        node.name = token.value;
+        node.name = token.valueAsString();
         break;
       case Token.YIELD:
         node.name = 'yield';
@@ -47,7 +48,7 @@ export class IdentifierParser extends BaseParser {
             break;
           }
           if (arrowInfo.isAsync) {
-            arrowInfo.awaitIdentifiers.push(node);
+            arrowInfo.awaitIdentifiers.push(node as ParseNode.BindingIdentifier);
             break;
           }
         }
@@ -67,15 +68,15 @@ export class IdentifierParser extends BaseParser {
   //   [~Yield] `yield`
   //   [~Await] `await`
   parseIdentifierReference() {
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.IdentifierReference>();
     const token = this.next();
     node.escaped = token.escaped;
     switch (token.type) {
       case Token.IDENTIFIER:
-        node.name = token.value;
+        node.name = token.valueAsString();
         break;
       case Token.ESCAPED_KEYWORD:
-        node.name = token.value;
+        node.name = token.valueAsString();
         break;
       case Token.YIELD:
         if (this.scope.hasYield()) {
@@ -93,7 +94,7 @@ export class IdentifierParser extends BaseParser {
             break;
           }
           if (arrowInfo.isAsync) {
-            arrowInfo.awaitIdentifiers.push(node);
+            arrowInfo.awaitIdentifiers.push(node as ParseNode.IdentifierReference);
             break;
           }
         }
@@ -106,7 +107,7 @@ export class IdentifierParser extends BaseParser {
     return this.finishNode(node, 'IdentifierReference');
   }
 
-  validateIdentifierReference(name, token) {
+  validateIdentifierReference(name: string, token: Locatable) {
     if (name === 'yield' && (this.scope.hasYield() || this.scope.isModule())) {
       this.raiseEarly('UnexpectedReservedWordStrict', token);
     }
@@ -130,15 +131,14 @@ export class IdentifierParser extends BaseParser {
   //   [~Await] `await`
   parseLabelIdentifier() {
     const node = this.parseIdentifierReference();
-    node.type = 'LabelIdentifier';
-    return node;
+    return this.repurpose(node, 'LabelIdentifier') as ParseNode.LabelIdentifier;
   }
 
   // PrivateIdentifier ::
   //   `#` IdentifierName
   parsePrivateIdentifier() {
-    const node = this.startNode();
-    node.name = this.expect(Token.PRIVATE_IDENTIFIER).value;
+    const node = this.startNode<ParseNode.PrivateIdentifier>();
+    node.name = this.expect(Token.PRIVATE_IDENTIFIER).valueAsString();
     return this.finishNode(node, 'PrivateIdentifier');
   }
 }

--- a/src/parser/LanguageParser.mts
+++ b/src/parser/LanguageParser.mts
@@ -1,3 +1,4 @@
+import type { Mutable } from '../helpers.mjs';
 import { ModuleParser } from './ModuleParser.mjs';
 import type { ParseNode } from './ParseNode.mjs';
 import { Token } from './tokens.mjs';
@@ -74,7 +75,7 @@ export abstract class LanguageParser extends ModuleParser {
   //   ExportDeclaration
   //   StatementListItem
   parseModuleItemList(): ParseNode.ModuleItemList {
-    const moduleItemList: ParseNode.ModuleItemList = [];
+    const moduleItemList: Mutable<ParseNode.ModuleItemList> = [];
     while (!this.eat(Token.EOS)) {
       switch (this.peek().type) {
         case Token.IMPORT:

--- a/src/parser/LanguageParser.mts
+++ b/src/parser/LanguageParser.mts
@@ -1,12 +1,12 @@
-// @ts-nocheck
 import { ModuleParser } from './ModuleParser.mjs';
+import type { ParseNode } from './ParseNode.mjs';
 import { Token } from './tokens.mjs';
 
-export class LanguageParser extends ModuleParser {
+export abstract class LanguageParser extends ModuleParser {
   // Script : ScriptBody?
-  parseScript() {
+  parseScript(): ParseNode.Script {
     this.skipHashbangComment();
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.Script>();
     if (this.eat(Token.EOS)) {
       node.ScriptBody = null;
     } else {
@@ -16,15 +16,15 @@ export class LanguageParser extends ModuleParser {
   }
 
   // ScriptBody : StatementList
-  parseScriptBody() {
-    const node = this.startNode();
+  parseScriptBody(): ParseNode.ScriptBody {
+    const node = this.startNode<ParseNode.ScriptBody>();
     this.scope.with({
       in: true,
       lexical: true,
       variable: true,
       variableFunctions: true,
     }, () => {
-      const directives = [];
+      const directives: string[] = [];
       node.StatementList = this.parseStatementList(Token.EOS, directives);
       node.strict = directives.includes('use strict');
     });
@@ -32,7 +32,7 @@ export class LanguageParser extends ModuleParser {
   }
 
   // Module : ModuleBody?
-  parseModule() {
+  parseModule(): ParseNode.Module {
     this.skipHashbangComment();
     return this.scope.with({
       module: true,
@@ -43,7 +43,7 @@ export class LanguageParser extends ModuleParser {
       lexical: true,
       variable: true,
     }, () => {
-      const node = this.startNode();
+      const node = this.startNode<ParseNode.Module>();
       if (this.eat(Token.EOS)) {
         node.ModuleBody = null;
       } else {
@@ -59,8 +59,8 @@ export class LanguageParser extends ModuleParser {
 
   // ModuleBody :
   //   ModuleItemList
-  parseModuleBody() {
-    const node = this.startNode();
+  parseModuleBody(): ParseNode.ModuleBody {
+    const node = this.startNode<ParseNode.ModuleBody>();
     node.ModuleItemList = this.parseModuleItemList();
     return this.finishNode(node, 'ModuleBody');
   }
@@ -73,8 +73,8 @@ export class LanguageParser extends ModuleParser {
   //   ImportDeclaration
   //   ExportDeclaration
   //   StatementListItem
-  parseModuleItemList() {
-    const moduleItemList = [];
+  parseModuleItemList(): ParseNode.ModuleItemList {
+    const moduleItemList: ParseNode.ModuleItemList = [];
     while (!this.eat(Token.EOS)) {
       switch (this.peek().type) {
         case Token.IMPORT:

--- a/src/parser/Lexer.mts
+++ b/src/parser/Lexer.mts
@@ -10,14 +10,14 @@ import {
   KeywordLookup,
   isKeywordRaw,
 } from './tokens.mjs';
-import type { Location, ParseNode, Position } from './ParseNode.mjs';
+import type { Location, Position } from './ParseNode.mjs';
 
 export type Locatable =
   | TokenData
   | Position
   | Location
-  | ParseNode
-  | ParseNode.Unfinished<ParseNode>;
+  | { readonly location: Location };
+
 const isUnicodeIDStart = (c: string) => c && isUnicodeIDStartRegex.test(c);
 const isUnicodeIDContinue = (c: string) => c && isUnicodeIDContinueRegex.test(c);
 export const isDecimalDigit = (c: string) => c && /\d/u.test(c);

--- a/src/parser/Lexer.mts
+++ b/src/parser/Lexer.mts
@@ -130,15 +130,15 @@ const SingleCharTokens: { [key: string]: number } = {
 };
 
 export class TokenData {
-  type: Token;
-  startIndex: number;
-  endIndex: number;
-  line: number;
-  column: number;
-  hadLineTerminatorBefore: boolean;
-  name: string;
-  value: string | number | bigint | boolean | null;
-  escaped: boolean;
+  readonly type: Token;
+  readonly startIndex: number;
+  readonly endIndex: number;
+  readonly line: number;
+  readonly column: number;
+  readonly hadLineTerminatorBefore: boolean;
+  readonly name: string;
+  readonly value: string | number | bigint | boolean | null;
+  readonly escaped: boolean;
 
   constructor({
     type,
@@ -179,21 +179,21 @@ export class TokenData {
 }
 
 export abstract class Lexer {
-  abstract source: string;
+  protected abstract readonly source: string;
 
-  currentToken!: TokenData; // NOTE: unsound definite assignment operator (`!`)
-  peekToken!: TokenData; // NOTE: unsound definite assignment operator (`!`)
-  peekAheadToken: TokenData | undefined;
+  protected currentToken!: TokenData; // NOTE: unsound definite assignment operator (`!`)
+  protected peekToken!: TokenData; // NOTE: unsound definite assignment operator (`!`)
+  protected peekAheadToken: TokenData | undefined;
 
-  position = 0;
-  line = 1;
-  columnOffset = 0;
-  scannedValue!: string | number | Token | bigint | boolean; // NOTE: unsound definite assignment operator (`!`)
-  lineTerminatorBeforeNextToken = false;
-  positionForNextToken = 0;
-  lineForNextToken = 0;
-  columnForNextToken = 0;
-  escapeIndex = -1;
+  protected position = 0;
+  protected line = 1;
+  protected columnOffset = 0;
+  protected scannedValue!: string | number | Token | bigint | boolean; // NOTE: unsound definite assignment operator (`!`)
+  protected lineTerminatorBeforeNextToken = false;
+  protected positionForNextToken = 0;
+  protected lineForNextToken = 0;
+  protected columnForNextToken = 0;
+  protected escapeIndex = -1;
 
   abstract isStrictMode(): boolean;
   abstract createSyntaxError<K extends keyof typeof import('../messages.mjs')>(context: number | Locatable | undefined, template: K, templateArgs: Parameters<typeof import('../messages.mjs')[K]>): SyntaxError;

--- a/src/parser/Lexer.mts
+++ b/src/parser/Lexer.mts
@@ -1,8 +1,8 @@
-// @ts-nocheck
 import isUnicodeIDStartRegex from '@unicode/unicode-15.0.0/Binary_Property/ID_Start/regex.js';
 import isUnicodeIDContinueRegex from '@unicode/unicode-15.0.0/Binary_Property/ID_Continue/regex.js';
 import isSpaceSeparatorRegex from '@unicode/unicode-15.0.0/General_Category/Space_Separator/regex.js';
 import { UTF16SurrogatePairToCodePoint } from '../static-semantics/all.mjs';
+import { Assert } from '../api.mjs';
 import {
   Token,
   TokenNames,
@@ -10,23 +10,30 @@ import {
   KeywordLookup,
   isKeywordRaw,
 } from './tokens.mjs';
+import type { Location, ParseNode, Position } from './ParseNode.mjs';
 
-const isUnicodeIDStart = (c) => c && isUnicodeIDStartRegex.test(c);
-const isUnicodeIDContinue = (c) => c && isUnicodeIDContinueRegex.test(c);
-export const isDecimalDigit = (c) => c && /\d/u.test(c);
-export const isHexDigit = (c) => c && /[\da-f]/ui.test(c);
-const isOctalDigit = (c) => c && /[0-7]/u.test(c);
-const isBinaryDigit = (c) => (c === '0' || c === '1');
-export const isWhitespace = (c) => c && (/[\u0009\u000B\u000C\u0020\u00A0\uFEFF]/u.test(c) || isSpaceSeparatorRegex.test(c)); // eslint-disable-line no-control-regex
-export const isLineTerminator = (c) => c && /[\r\n\u2028\u2029]/u.test(c);
-const isRegularExpressionFlagPart = (c) => c && (isUnicodeIDContinue(c) || c === '$');
-export const isIdentifierStart = (c) => SingleCharTokens[c] === Token.IDENTIFIER || isUnicodeIDStart(c);
-export const isIdentifierPart = (c) => SingleCharTokens[c] === Token.IDENTIFIER || c === '\u{200C}' || c === '\u{200D}' || isUnicodeIDContinue(c);
-export const isLeadingSurrogate = (cp) => cp >= 0xD800 && cp <= 0xDBFF;
-export const isTrailingSurrogate = (cp) => cp >= 0xDC00 && cp <= 0xDFFF;
+export type Locatable =
+  | TokenData
+  | Position
+  | Location
+  | ParseNode
+  | ParseNode.Unfinished<ParseNode>;
+const isUnicodeIDStart = (c: string) => c && isUnicodeIDStartRegex.test(c);
+const isUnicodeIDContinue = (c: string) => c && isUnicodeIDContinueRegex.test(c);
+export const isDecimalDigit = (c: string) => c && /\d/u.test(c);
+export const isHexDigit = (c: string) => c && /[\da-f]/ui.test(c);
+const isOctalDigit = (c: string) => c && /[0-7]/u.test(c);
+const isBinaryDigit = (c: string) => (c === '0' || c === '1');
+export const isWhitespace = (c: string) => c && (/[\u0009\u000B\u000C\u0020\u00A0\uFEFF]/u.test(c) || isSpaceSeparatorRegex.test(c)); // eslint-disable-line no-control-regex
+export const isLineTerminator = (c: string) => c && /[\r\n\u2028\u2029]/u.test(c);
+const isRegularExpressionFlagPart = (c: string) => c && (isUnicodeIDContinue(c) || c === '$');
+export const isIdentifierStart = (c: string) => SingleCharTokens[c] === Token.IDENTIFIER || isUnicodeIDStart(c);
+export const isIdentifierPart = (c: string) => SingleCharTokens[c] === Token.IDENTIFIER || c === '\u{200C}' || c === '\u{200D}' || isUnicodeIDContinue(c);
+export const isLeadingSurrogate = (cp: number) => cp >= 0xD800 && cp <= 0xDBFF;
+export const isTrailingSurrogate = (cp: number) => cp >= 0xDC00 && cp <= 0xDFFF;
 
-const SingleCharTokens = {
-  '__proto__': null,
+const SingleCharTokens: { [key: string]: number } = {
+  '__proto__': null!,
   '0': Token.NUMBER,
   '1': Token.NUMBER,
   '2': Token.NUMBER,
@@ -122,26 +129,83 @@ const SingleCharTokens = {
   '#': Token.PRIVATE_IDENTIFIER,
 };
 
-export class Lexer {
-  currentToken;
-  peekToken;
-  peekAheadToken;
+export class TokenData {
+  type: Token;
+  startIndex: number;
+  endIndex: number;
+  line: number;
+  column: number;
+  hadLineTerminatorBefore: boolean;
+  name: string;
+  value: string | number | bigint | boolean | null;
+  escaped: boolean;
+
+  constructor({
+    type,
+    startIndex,
+    endIndex,
+    line,
+    column,
+    hadLineTerminatorBefore,
+    name,
+    value,
+    escaped,
+  }: Pick<TokenData, 'type' | 'startIndex' | 'endIndex' | 'line' | 'column' | 'hadLineTerminatorBefore' | 'name' | 'value' | 'escaped'>) {
+    this.type = type;
+    this.startIndex = startIndex;
+    this.endIndex = endIndex;
+    this.line = line;
+    this.column = column;
+    this.hadLineTerminatorBefore = hadLineTerminatorBefore;
+    this.name = name;
+    this.value = value;
+    this.escaped = escaped;
+  }
+
+  valueAsString() {
+    Assert(typeof this.value === 'string');
+    return this.value;
+  }
+
+  valueAsNumeric() {
+    Assert(typeof this.value === 'number' || typeof this.value === 'bigint');
+    return this.value;
+  }
+
+  valueAsBoolean() {
+    Assert(typeof this.value === 'boolean');
+    return this.value;
+  }
+}
+
+export abstract class Lexer {
+  abstract source: string;
+
+  currentToken!: TokenData; // NOTE: unsound definite assignment operator (`!`)
+  peekToken!: TokenData; // NOTE: unsound definite assignment operator (`!`)
+  peekAheadToken: TokenData | undefined;
 
   position = 0;
   line = 1;
   columnOffset = 0;
-  scannedValue;
+  scannedValue!: string | number | Token | bigint | boolean; // NOTE: unsound definite assignment operator (`!`)
   lineTerminatorBeforeNextToken = false;
   positionForNextToken = 0;
   lineForNextToken = 0;
   columnForNextToken = 0;
   escapeIndex = -1;
 
-  advance() {
+  abstract isStrictMode(): boolean;
+  abstract createSyntaxError<K extends keyof typeof import('../messages.mjs')>(context: number | Locatable | undefined, template: K, templateArgs: Parameters<typeof import('../messages.mjs')[K]>): SyntaxError;
+  abstract raiseEarly<K extends keyof typeof import('../messages.mjs')>(template: K, context?: number | Locatable, ...templateArgs: Parameters<typeof import('../messages.mjs')[K]>): SyntaxError;
+  abstract raise<K extends keyof typeof import('../messages.mjs')>(template: K, context?: number | Locatable, ...templateArgs: Parameters<typeof import('../messages.mjs')[K]>): never;
+  abstract unexpected(...args: [(number | Locatable)?, ...Parameters<typeof import('../messages.mjs')['UnexpectedToken']>]): never;
+
+  advance(): TokenData {
     this.lineTerminatorBeforeNextToken = false;
     this.escapeIndex = -1;
-    const type = this.nextToken();
-    return {
+    const type = this.nextToken()!;
+    return new TokenData({
       type,
       startIndex: this.positionForNextToken,
       endIndex: this.position,
@@ -151,7 +215,7 @@ export class Lexer {
       name: TokenNames[type],
       value: TokenValues[type] ?? this.scannedValue,
       escaped: this.escapeIndex !== -1,
-    };
+    });
   }
 
   next() {
@@ -180,7 +244,7 @@ export class Lexer {
     return this.peekAheadToken;
   }
 
-  matches(token, peek) {
+  matches(token: string | Token, peek: TokenData) {
     if (typeof token === 'string') {
       if (peek.type === Token.IDENTIFIER && peek.value === token) {
         const escapeIndex = this.source.slice(peek.startIndex, peek.endIndex).indexOf('\\');
@@ -195,15 +259,15 @@ export class Lexer {
     return peek.type === token;
   }
 
-  test(token) {
+  test(token: string | Token) {
     return this.matches(token, this.peek());
   }
 
-  testAhead(token) {
+  testAhead(token: string | Token) {
     return this.matches(token, this.peekAhead());
   }
 
-  eat(token) {
+  eat(token: string | Token) {
     if (this.test(token)) {
       this.next();
       return true;
@@ -211,7 +275,7 @@ export class Lexer {
     return false;
   }
 
-  expect(token) {
+  expect(token: string | Token) {
     if (this.test(token)) {
       return this.next();
     }
@@ -290,7 +354,7 @@ export class Lexer {
     }
     this.position += 2;
     for (const match of this.source.slice(this.position, end).matchAll(/\r\n?|[\n\u2028\u2029]/ug)) {
-      this.position = match.index;
+      this.position = match.index!;
       this.line += 1;
       this.columnOffset = this.position;
       this.lineTerminatorBeforeNextToken = true;
@@ -553,7 +617,7 @@ export class Lexer {
 
   scanNumber() {
     const start = this.position;
-    let base = 10;
+    let base: 2 | 8 | 10 | 16 = 10;
     let check = isDecimalDigit;
     if (this.source[this.position] === '0') {
       this.scannedValue = 0;
@@ -665,12 +729,12 @@ export class Lexer {
       .slice(base === 10 ? start : start + 2, this.position)
       .replace(/_/g, '');
     this.scannedValue = base === 10
-      ? Number.parseFloat(buffer, base)
+      ? Number.parseFloat(buffer)
       : Number.parseInt(buffer, base);
     return Token.NUMBER;
   }
 
-  scanString(char) {
+  scanString(char: string) {
     let buffer = '';
     while (true) {
       if (this.position >= this.source.length) {
@@ -758,7 +822,7 @@ export class Lexer {
     return this.scanHex(4);
   }
 
-  scanHex(length) {
+  scanHex(length: number) {
     if (length === 0) {
       this.raise('InvalidCodePoint', this.position);
     }

--- a/src/parser/ModuleParser.mts
+++ b/src/parser/ModuleParser.mts
@@ -1,4 +1,5 @@
 import { IsStringWellFormedUnicode, StringValue } from '../static-semantics/all.mjs';
+import type { Mutable } from '../helpers.mjs';
 import { Token, isKeywordRaw } from './tokens.mjs';
 import { StatementParser } from './StatementParser.mjs';
 import { FunctionKind } from './FunctionParser.mjs';
@@ -78,9 +79,10 @@ export abstract class ModuleParser extends StatementParser {
   //   `{` ImportsList `,` `}`
   parseNamedImports(): ParseNode.NamedImports {
     const node = this.startNode<ParseNode.NamedImports>();
-    node.ImportsList = [];
+    const ImportsList: Mutable<ParseNode.ImportsList> = [];
+    node.ImportsList = ImportsList;
     while (!this.eat(Token.RBRACE)) {
-      node.ImportsList.push(this.parseImportSpecifier());
+      ImportsList.push(this.parseImportSpecifier());
       if (this.eat(Token.RBRACE)) {
         break;
       }
@@ -219,9 +221,10 @@ export abstract class ModuleParser extends StatementParser {
   parseNamedExports(): ParseNode.NamedExports {
     const node = this.startNode<ParseNode.NamedExports>();
     this.expect(Token.LBRACE);
-    node.ExportsList = [];
+    const ExportsList: Mutable<ParseNode.ExportsList> = [];
+    node.ExportsList = ExportsList;
     while (!this.eat(Token.RBRACE)) {
-      node.ExportsList.push(this.parseExportSpecifier());
+      ExportsList.push(this.parseExportSpecifier());
       if (this.eat(Token.RBRACE)) {
         break;
       }

--- a/src/parser/ModuleParser.mts
+++ b/src/parser/ModuleParser.mts
@@ -100,7 +100,7 @@ export abstract class ModuleParser extends StatementParser {
       node.ModuleExportName = name;
       node.ImportedBinding = this.parseBindingIdentifier();
     } else {
-      node.ImportedBinding = this.repurpose(name, 'BindingIdentifier') as ParseNode.BindingIdentifier;
+      node.ImportedBinding = this.repurpose(name, 'BindingIdentifier');
       if (isKeywordRaw(node.ImportedBinding.name)) {
         this.raiseEarly('UnexpectedToken', node.ImportedBinding);
       }

--- a/src/parser/ModuleParser.mts
+++ b/src/parser/ModuleParser.mts
@@ -1,20 +1,20 @@
-// @ts-nocheck
 import { IsStringWellFormedUnicode, StringValue } from '../static-semantics/all.mjs';
 import { Token, isKeywordRaw } from './tokens.mjs';
 import { StatementParser } from './StatementParser.mjs';
 import { FunctionKind } from './FunctionParser.mjs';
+import type { ParseNode } from './ParseNode.mjs';
 
-export class ModuleParser extends StatementParser {
+export abstract class ModuleParser extends StatementParser {
   // ImportDeclaration :
   //   `import` ImportClause FromClause `;`
   //   `import` ModuleSpecifier `;`
-  parseImportDeclaration() {
+  parseImportDeclaration(): ParseNode.ImportDeclaration | ParseNode.ExpressionStatement | ParseNode.LabelledStatement {
     if (this.testAhead(Token.PERIOD) || this.testAhead(Token.LPAREN)) {
       // `import` `(`
       // `import` `.`
       return this.parseExpressionStatement();
     }
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.ImportDeclaration>();
     this.next();
     if (this.test(Token.STRING)) {
       node.ModuleSpecifier = this.parsePrimaryExpression();
@@ -36,8 +36,8 @@ export class ModuleParser extends StatementParser {
   //
   // ImportedBinding :
   //   BindingIdentifier
-  parseImportClause() {
-    const node = this.startNode();
+  parseImportClause(): ParseNode.ImportClause {
+    const node = this.startNode<ParseNode.ImportClause>();
     if (this.test(Token.IDENTIFIER)) {
       node.ImportedDefaultBinding = this.parseImportedDefaultBinding();
       if (!this.eat(Token.COMMA)) {
@@ -56,16 +56,16 @@ export class ModuleParser extends StatementParser {
 
   // ImportedDefaultBinding :
   //   ImportedBinding
-  parseImportedDefaultBinding() {
-    const node = this.startNode();
+  parseImportedDefaultBinding(): ParseNode.ImportedDefaultBinding {
+    const node = this.startNode<ParseNode.ImportedDefaultBinding>();
     node.ImportedBinding = this.parseBindingIdentifier();
     return this.finishNode(node, 'ImportedDefaultBinding');
   }
 
   // NameSpaceImport :
   //   `*` `as` ImportedBinding
-  parseNameSpaceImport() {
-    const node = this.startNode();
+  parseNameSpaceImport(): ParseNode.NameSpaceImport {
+    const node = this.startNode<ParseNode.NameSpaceImport>();
     this.expect(Token.MUL);
     this.expect('as');
     node.ImportedBinding = this.parseBindingIdentifier();
@@ -76,8 +76,8 @@ export class ModuleParser extends StatementParser {
   //   `{` `}`
   //   `{` ImportsList `}`
   //   `{` ImportsList `,` `}`
-  parseNamedImports() {
-    const node = this.startNode();
+  parseNamedImports(): ParseNode.NamedImports {
+    const node = this.startNode<ParseNode.NamedImports>();
     node.ImportsList = [];
     while (!this.eat(Token.RBRACE)) {
       node.ImportsList.push(this.parseImportSpecifier());
@@ -92,16 +92,15 @@ export class ModuleParser extends StatementParser {
   // ImportSpecifier :
   //   ImportedBinding
   //   ModuleExportName `as` ImportedBinding
-  parseImportSpecifier() {
-    const node = this.startNode();
+  parseImportSpecifier(): ParseNode.ImportSpecifier {
+    const node = this.startNode<ParseNode.ImportSpecifier>();
     const name = this.parseModuleExportName();
     if (name.type === 'StringLiteral' || this.test('as')) {
       this.expect('as');
       node.ModuleExportName = name;
       node.ImportedBinding = this.parseBindingIdentifier();
     } else {
-      node.ImportedBinding = name;
-      node.ImportedBinding.type = 'BindingIdentifier';
+      node.ImportedBinding = this.repurpose(name, 'BindingIdentifier') as ParseNode.BindingIdentifier;
       if (isKeywordRaw(node.ImportedBinding.name)) {
         this.raiseEarly('UnexpectedToken', node.ImportedBinding);
       }
@@ -125,8 +124,8 @@ export class ModuleParser extends StatementParser {
   //   `*`
   //   `*` as ModuleExportName
   //   NamedExports
-  parseExportDeclaration() {
-    const node = this.startNode();
+  parseExportDeclaration(): ParseNode.ExportDeclaration {
+    const node = this.startNode<ParseNode.ExportDeclaration>();
     this.expect(Token.EXPORT);
     node.default = this.eat(Token.DEFAULT);
     if (node.default) {
@@ -187,7 +186,7 @@ export class ModuleParser extends StatementParser {
           break;
         }
         case Token.MUL: {
-          const inner = this.startNode();
+          const inner = this.startNode<ParseNode.ExportFromClause>();
           this.next();
           if (this.eat('as')) {
             inner.ModuleExportName = this.parseModuleExportName();
@@ -217,8 +216,8 @@ export class ModuleParser extends StatementParser {
   //   `{` `}`
   //   `{` ExportsList `}`
   //   `{` ExportsList `,` `}`
-  parseNamedExports() {
-    const node = this.startNode();
+  parseNamedExports(): ParseNode.NamedExports {
+    const node = this.startNode<ParseNode.NamedExports>();
     this.expect(Token.LBRACE);
     node.ExportsList = [];
     while (!this.eat(Token.RBRACE)) {
@@ -234,8 +233,8 @@ export class ModuleParser extends StatementParser {
   // ExportSpecifier :
   //   ModuleExportName
   //   ModuleExportName `as` ModuleExportName
-  parseExportSpecifier() {
-    const node = this.startNode();
+  parseExportSpecifier(): ParseNode.ExportSpecifier {
+    const node = this.startNode<ParseNode.ExportSpecifier>();
     node.localName = this.parseModuleExportName();
     if (this.eat('as')) {
       node.exportName = this.parseModuleExportName();
@@ -249,7 +248,7 @@ export class ModuleParser extends StatementParser {
   // ModuleExportName :
   //   IdentifierName
   //   StringLiteral
-  parseModuleExportName() {
+  parseModuleExportName(): ParseNode.ModuleExportName {
     if (this.test(Token.STRING)) {
       const literal = this.parseStringLiteral();
       if (!IsStringWellFormedUnicode(StringValue(literal))) {
@@ -262,7 +261,7 @@ export class ModuleParser extends StatementParser {
 
   // FromClause :
   //   `from` ModuleSpecifier
-  parseFromClause() {
+  parseFromClause(): ParseNode.FromClause {
     this.expect('from');
     return this.parseStringLiteral();
   }

--- a/src/parser/ParseNode.mts
+++ b/src/parser/ParseNode.mts
@@ -1,650 +1,125 @@
 import type { ArrowInfo } from './Scope.mjs';
 
 export interface Position {
-  line: number;
-  column: number;
+  readonly line: number;
+  readonly column: number;
 }
 
 export interface Location {
-  startIndex: number;
-  endIndex: number;
-  start: Position;
-  end: Position;
-}
-
-export interface ParseNode {
-  type: string;
-  location: Location;
-  strict: boolean;
-  sourceText: () => string;
+  readonly startIndex: number;
+  readonly endIndex: number;
+  readonly start: Position;
+  readonly end: Position;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace ParseNode {
-  export interface PrivateIdentifier extends ParseNode {
-    type: 'PrivateIdentifier';
-    name: string;
+  export interface BaseParseNode {
+    // NOTE: while we could use `string` here, by limiting `type` to only those types defined in the `ParseNode`
+    //       union we can ensure that new subtypes of `BaseParseNode` are correctly added to the union.
+    readonly type: ParseNode['type'];
+    readonly location: Location;
+    readonly strict: boolean;
+    readonly sourceText: () => string;
   }
 
-  export interface IdentifierName extends ParseNode {
-    type: 'IdentifierName';
-    name: string;
+  // A.1 Lexical Grammar
+  // https://tc39.es/ecma262/#sec-lexical-grammar
+
+  // PrivateIdentifier ::
+  //   `#` IdentifierName
+  export interface PrivateIdentifier extends BaseParseNode {
+    readonly type: 'PrivateIdentifier';
+    readonly name: string;
   }
 
-  export interface IdentifierReference extends ParseNode {
-    type: 'IdentifierReference';
-    escaped: boolean;
-    name: string;
+  // IdentifierName ::
+  //   IdentifierStart
+  //   IdentifierName IdentifierPart
+  export interface IdentifierName extends BaseParseNode {
+    readonly type: 'IdentifierName';
+    readonly name: string;
   }
 
-  export interface BindingIdentifier extends ParseNode {
-    type: 'BindingIdentifier';
-    name: string;
-  }
-
-  export interface LabelIdentifier extends ParseNode {
-    type: 'LabelIdentifier';
-    name: string;
-  }
-
-  // PropertyName : ComputedPropertyName
-  // ComputedPropertyName : `[` AssignmentExpression `]`
-  export interface PropertyName extends ParseNode {
-    type: 'PropertyName';
-    ComputedPropertyName: AssignmentExpressionOrHigher;
-  }
-
-  // PropertyName :
-  //   LiteralPropertyName
-  //   ComputedPropertyName
-  // LiteralPropertyName :
-  //   IdentifierName
-  //   StringLiteral
-  //   NumericLiteral
-  // ComputedPropertyName :
-  //   `[` AssignmentExpression `]`
-  export type PropertyNameLike =
-    | PropertyName
-    | StringLiteral
-    | NumericLiteral
-    | IdentifierName;
-
-  // ClassElementName :
-  //   PropertyName
-  //   PrivateIdentifier
-  export type ClassElementName =
-    | PropertyNameLike
-    | PrivateIdentifier;
-
-  // PrimaryExpression (partial) :
-  //   `this`
-  export interface ThisExpression extends ParseNode {
-    type: 'ThisExpression';
-  }
-
-  // NullLiteral :
+  // NullLiteral ::
   //   `null`
-  export interface NullLiteral extends ParseNode {
-    type: 'NullLiteral';
+  export interface NullLiteral extends BaseParseNode {
+    readonly type: 'NullLiteral';
   }
 
-  // BooleanLiteral :
+  // BooleanLiteral ::
   //   `true`
   //   `false`
-  export interface BooleanLiteral extends ParseNode {
-    type: 'BooleanLiteral';
-    value: boolean;
+  export interface BooleanLiteral extends BaseParseNode {
+    readonly type: 'BooleanLiteral';
+    readonly value: boolean;
   }
 
-  export interface NumericLiteral extends ParseNode {
-    type: 'NumericLiteral';
-    value: number | bigint;
+  // NumericLiteral ::
+  //   DecimalLiteral
+  //   DecimalBigIntegerLiteral
+  //   NonDecimalIntegerLiteral
+  //   NonDecimalIntegerLiteral BigIntLiteralSuffix
+  //   LegacyOctalIntegerLiteral
+  export interface NumericLiteral extends BaseParseNode {
+    readonly type: 'NumericLiteral';
+    readonly value: number | bigint;
   }
 
-  export interface StringLiteral extends ParseNode {
-    type: 'StringLiteral';
-    value: string;
+  // StringLiteral ::
+  //   `"` DoubleStringCharacters? `"`
+  //   `'` SingleStringCharacters? `'`
+  export interface StringLiteral extends BaseParseNode {
+    readonly type: 'StringLiteral';
+    readonly value: string;
   }
 
-  // Literal :
-  //   NullLiteral
-  //   BooleanLiteral
-  //   NumericLiteral
-  //   StringLiteral
-  export type Literal =
-    | NullLiteral
-    | BooleanLiteral
-    | NumericLiteral
-    | StringLiteral;
-
-  // Elision :
-  //   `,`
-  //   Elision `,`
-  export interface Elision extends ParseNode {
-    type: 'Elision';
+  // RegularExpressionLiteral ::
+  //   `/` RegularExpressionBody `/` RegularExpressionFlags
+  export interface RegularExpressionLiteral extends BaseParseNode {
+    readonly type: 'RegularExpressionLiteral';
+    readonly RegularExpressionBody: string;
+    readonly RegularExpressionFlags: string;
   }
 
-  // ArrayLiteral :
-  //   `[` `]`
-  //   `[` Elision `]`
-  //   `[` ElementList `]`
-  //   `[` ElementList `,` `]`
-  //   `[` ElementList `,` Elision `]`
-  export interface ArrayLiteral extends ParseNode {
-    type: 'ArrayLiteral';
-    ElementList: ElementList;
-    hasTrailingComma: boolean;
-  }
+  // A.2 Expressions
+  // https://tc39.es/ecma262/#sec-expressions
 
-  // SpreadElement :
-  // `...` AssignmentExpression
-  export interface SpreadElement extends ParseNode {
-    type: 'SpreadElement';
-    AssignmentExpression: AssignmentExpressionOrHigher;
-  }
-
-  // ElementList :
-  //   Elision? AssignmentExpression
-  //   Elision? SpreadElement
-  //   ElementList `,` Elision? AssignmentExpression
-  //   ElementList `,` Elision? SpreadElement
-  export type ElementList = ElementListElement[];
-
-  // ElementList :
-  //   Elision? AssignmentExpression
-  //   Elision? SpreadElement
-  //   ElementList `,` Elision? AssignmentExpression
-  //   ElementList `,` Elision? SpreadElement
-  export type ElementListElement =
-    | AssignmentExpressionOrHigher
-    | SpreadElement
-    | Elision;
-
-  // ObjectLiteral :
-  //   `{` `}`
-  //   `{` PropertyDefinitionList `}`
-  //   `{` PropertyDefinitionList `,` `}`
-  export interface ObjectLiteral extends ParseNode {
-    type: 'ObjectLiteral';
-    PropertyDefinitionList: PropertyDefinitionList;
-  }
-
-  // PropertyDefinition (partial) :
-  //   PropertyName `:` AssignmentExpression
-  //   `...` AssignmentExpression
-  export interface PropertyDefinition extends ParseNode {
-    type: 'PropertyDefinition';
-    PropertyName: PropertyNameLike | null;
-    AssignmentExpression: AssignmentExpressionOrHigher;
-  }
-
-  // CoverInitializedName :
-  //   IdentifierReference Initializer
-  export interface CoverInitializedName extends ParseNode {
-    type: 'CoverInitializedName';
-    IdentifierReference: IdentifierReference;
-    Initializer: Initializer | null; // opt
-  }
-
-  // MethodDefinition (partial) :
-  //   ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
-  //   `get` ClassElementName `(` `)` `{` FunctionBody `}`
-  //   `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
-  export interface MethodDefinition extends ParseNode {
-    type: 'MethodDefinition';
-    static?: boolean;
-    ClassElementName: ClassElementName;
-    PropertySetParameterList: [FormalParameter] | null;
-    UniqueFormalParameters: UniqueFormalParameters | null;
-    FunctionBody: FunctionBody;
-  }
-
-  // NON-SPEC
-  export type MethodLike =
-    | MethodDefinition
-    | AsyncMethod
-    | GeneratorMethod
-    | AsyncGeneratorMethod;
-
-  // UniqueFormalParameters :
-  //   FormalParameters
-  export type UniqueFormalParameters =
-    | FormalParameters;
-
-  // FormalParameters :
-  //   [empty]
-  //   FunctionRestParameter
-  //   FormalParameterList
-  //   FormalParameterList `,`
-  //   FormalParameterList `,` FunctionRestParameter
-  export type FormalParameters = FormalParametersElement[];
-
-  // NON-SPEC
-  export type FormalParametersElement = FunctionRestParameter | FormalParameter;
-
-  // FunctionRestParameter :
-  //   BindingRestElement
-  export type FunctionRestParameter =
-    | BindingRestElement;
-
-  // FormalParameter :
-  //   BindingElement
-  export type FormalParameter =
-    | BindingElementOrHigher;
-
-  // MethodDefinition :
-  //   ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
-  //   GeneratorMethod
-  //   AsyncMethod
-  //   AsyncGeneratorMethod
-  //   `get` ClassElementName `(` `)` `{` FunctionBody `}`
-  //   `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
-  export type MethodDefinitionOrHigher =
-    | MethodDefinition
-    | GeneratorMethod
-    | AsyncMethod
-    | AsyncGeneratorMethod;
-
-  // PropertyDefinitionList :
-  //   PropertyDefinition
-  //   PropertyDefinitionList `,` PropertyDefinition
-  export type PropertyDefinitionList = PropertyDefinitionListElement[];
-
-  // PropertyDefinition :
-  //   IdentifierReference
-  //   CoverInitializedName
-  //   PropertyName `:` AssignmentExpression
-  //   MethodDefinition
-  //   `...` AssignmentExpression
-  export type PropertyDefinitionListElement =
-    | IdentifierReference
-    | CoverInitializedName
-    | PropertyDefinition
-    | MethodDefinitionOrHigher;
-
-  // FunctionDeclaration :
-  //   `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
-  //   [+Default] `function` `(` FormalParameters `)` `{` FunctionBody `}`
-  export interface FunctionDeclaration extends ParseNode {
-    type: 'FunctionDeclaration';
-    BindingIdentifier: BindingIdentifier | null;
-    FormalParameters: FormalParameters;
-    FunctionBody: FunctionBody;
-  }
-
-  // FunctionExpression :
-  //   `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
-  export interface FunctionExpression extends ParseNode {
-    type: 'FunctionExpression';
-    BindingIdentifier: BindingIdentifier | null;
-    FormalParameters: FormalParameters;
-    FunctionBody: FunctionBody;
-  }
-
-  // FunctionBody :
-  //   FunctionStatementList
-  export interface FunctionBody extends ParseNode {
-    type: 'FunctionBody';
-    directives: string[];
-    strict: boolean;
-    FunctionStatementList: FunctionStatementList;
-  }
-
-  // FunctionStatementList :
-  //   StatementList
-  export type FunctionStatementList = StatementList;
-
-  // ArrowFunction :
-  //  ArrowParameters `=>` ConciseBody
-  export interface ArrowFunction extends ParseNode {
-    type: 'ArrowFunction';
-    ArrowParameters: ArrowParameters;
-    ConciseBody: ConciseBodyOrHigher;
-  }
-
-  // ArrowParameters :
-  //   BindingIdentifier
-  //   CoverParenthesizedExpressionAndArrowParameterList
+  // IdentifierReference :
+  //   Identifier
+  //   [~Yield] `yield`
+  //   [~Await] `await`
   //
-  //   ArrowFormalParameters (refined) :
-  //    `(` UniqueFormalParameters `)`
-  export type ArrowParameters = ArrowFormalParameters;
-
-  //   ArrowFormalParameters :
-  //    `(` UniqueFormalParameters `)`
-  export type ArrowFormalParameters = UniqueFormalParameters;
-
-  // ExpressionBody :
-  //   AssignmentExpression
-  export interface ExpressionBody extends ParseNode {
-    type: 'ExpressionBody';
-    AssignmentExpression: AssignmentExpressionOrHigher;
+  // Identifier :
+  //   IdentifierName but not ReservedWord
+  export interface IdentifierReference extends BaseParseNode {
+    readonly type: 'IdentifierReference';
+    readonly escaped: boolean;
+    readonly name: string;
   }
 
-  // ConciseBody (partial) :
-  //   ExpressionBody
-  export interface ConciseBody extends ParseNode {
-    type: 'ConciseBody';
-    directives?: undefined;
-    ExpressionBody: ExpressionBody;
-  }
-
-  // ConciseBody :
-  //   ExpressionBody
-  //   `{` FunctionBody `}`
-  export type ConciseBodyOrHigher =
-    | FunctionBody
-    | ConciseBody;
-
-  // GeneratorDeclaration :
-  //   `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
-  //   [+Default] `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
-  export interface GeneratorDeclaration extends ParseNode {
-    type: 'GeneratorDeclaration';
-    BindingIdentifier: BindingIdentifier | null;
-    FormalParameters: FormalParameters;
-    GeneratorBody: GeneratorBody;
-  }
-
-  // GeneratorExpression :
-  //   `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
-  export interface GeneratorExpression extends ParseNode {
-    type: 'GeneratorExpression';
-    BindingIdentifier: BindingIdentifier | null;
-    FormalParameters: FormalParameters;
-    GeneratorBody: GeneratorBody;
-  }
-
-  // GeneratorMethod :
-  //   `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`
-  export interface GeneratorMethod extends ParseNode {
-    type: 'GeneratorMethod';
-    static?: boolean;
-    ClassElementName: ClassElementName;
-    PropertySetParameterList: null;
-    UniqueFormalParameters: UniqueFormalParameters;
-    GeneratorBody: GeneratorBody;
-  }
-
-  // GeneratorBody :
-  //   FunctionBody
-  export interface GeneratorBody extends ParseNode {
-    type: 'GeneratorBody';
-    directives: string[];
-    strict: boolean;
-    FunctionStatementList: FunctionStatementList;
-  }
-
-  // YieldExpression :
-  //   `yield`
-  //   `yield` [no LineTerminator here] AssignmentExpression
-  //   `yield` [no LineTerminator here] `*` AssignmentExpression
-  export interface YieldExpression extends ParseNode {
-    type: 'YieldExpression';
-    hasStar: boolean;
-    AssignmentExpression: AssignmentExpressionOrHigher | null;
-  }
-
-  // AsyncGeneratorDeclaration :
-  //   `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-  //   [+Default] `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-  export interface AsyncGeneratorDeclaration extends ParseNode {
-    type: 'AsyncGeneratorDeclaration';
-    BindingIdentifier: BindingIdentifier | null;
-    FormalParameters: FormalParameters;
-    AsyncGeneratorBody: AsyncGeneratorBody;
-  }
-
-  // AsyncGeneratorExpression :
-  //   `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-  export interface AsyncGeneratorExpression extends ParseNode {
-    type: 'AsyncGeneratorExpression';
-    BindingIdentifier: BindingIdentifier | null;
-    FormalParameters: FormalParameters;
-    AsyncGeneratorBody: AsyncGeneratorBody;
-  }
-
-  // AsyncGeneratorMethod :
-  //   `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
-  export interface AsyncGeneratorMethod extends ParseNode {
-    type: 'AsyncGeneratorMethod';
-    static?: boolean;
-    ClassElementName: ClassElementName;
-    PropertySetParameterList: null;
-    UniqueFormalParameters: UniqueFormalParameters;
-    AsyncGeneratorBody: AsyncGeneratorBody;
-  }
-
-  // AsyncGeneratorBody :
-  //   FunctionBody
-  export interface AsyncGeneratorBody extends ParseNode {
-    type: 'AsyncGeneratorBody';
-    directives: string[];
-    strict: boolean;
-    FunctionStatementList: FunctionStatementList;
-  }
-
-  // NON-SPEC
-  export type FunctionLike =
-    | FunctionDeclaration
-    | GeneratorDeclaration
-    | AsyncFunctionDeclaration
-    | AsyncGeneratorDeclaration
-    | FunctionExpression
-    | GeneratorExpression
-    | AsyncFunctionExpression
-    | AsyncGeneratorExpression;
-
-  // NON-SPEC
-  export type FunctionDeclarationLike =
-    | FunctionDeclaration
-    | GeneratorDeclaration
-    | AsyncFunctionDeclaration
-    | AsyncGeneratorDeclaration;
-
-  // NON-SPEC
-  export type FunctionExpressionLike =
-    | FunctionExpression
-    | GeneratorExpression
-    | AsyncFunctionExpression
-    | AsyncGeneratorExpression;
-
-  // NON-SPEC
-  export type FunctionBodyLike =
-    | FunctionBody
-    | GeneratorBody
-    | AsyncFunctionBody
-    | AsyncGeneratorBody;
-
-  // ClassDeclaration :
-  //   `class` BindingIdentifier ClassTail
-  //   [+Default] `class` ClassTail
-  export interface ClassDeclaration extends ParseNode {
-    type: 'ClassDeclaration';
-    BindingIdentifier: BindingIdentifier | null;
-    ClassTail: ClassTail;
-  }
-
-  // ClassExpression :
-  //   `class` BindingIdentifier? ClassTail
-  export interface ClassExpression extends ParseNode {
-    type: 'ClassExpression';
-    BindingIdentifier: BindingIdentifier | null;
-    ClassTail: ClassTail;
-  }
-
-  // NON-SPEC
-  export type ClassLike =
-    | ClassDeclaration
-    | ClassExpression;
-
-  // ClassTail :
-  //   ClassHeritage? `{` ClassBody? `}`
-  export interface ClassTail extends ParseNode {
-    type: 'ClassTail';
-    ClassHeritage: ClassHeritage | null;
-    ClassBody: ClassBody | null;
-  }
-
-  // ClassHeritage :
-  //   `extends` LeftHandSideExpression
-  export type ClassHeritage = LeftHandSideExpression;
-
-  // ClassBody :
-  //   ClassElementList
-  export type ClassBody = ClassElementList;
-
-  // ClassElementList :
-  //   ClassElement
-  //   ClassElementList ClassElement
-  export type ClassElementList = ClassElement[];
-
-  // ClassElement :
-  //   MethodDefinition
-  //   `static` MethodDefinition
-  //   FieldDefinition `;`
-  //   `static` FieldDefinition `;`
-  //   ClassStaticBlock
-  //   `;`
-  export type ClassElement =
-    | MethodDefinitionOrHigher
-    | FieldDefinition
-    | ClassStaticBlock;
-
-  // FieldDefinition :
-  //   ClassElementName Initializer?
-  export interface FieldDefinition extends ParseNode {
-    type: 'FieldDefinition';
-    static?: boolean;
-    ClassElementName: ClassElementName;
-    Initializer: Initializer | null; // opt
-  }
-
-  // ClassStaticBlock :
-  //   `static` `{` ClassStaticBlockBody `}`
-  export interface ClassStaticBlock extends ParseNode {
-    type: 'ClassStaticBlock';
-    static: true;
-    ClassStaticBlockBody: ClassStaticBlockBody;
-  }
-
-  // ClassStaticBlockBody :
-  //   ClassStaticBlockStatementList
-  export interface ClassStaticBlockBody extends ParseNode {
-    type: 'ClassStaticBlockBody';
-    ClassStaticBlockStatementList: ClassStaticBlockStatementList;
-  }
-
-  // ClassStaticBlockStatementList :
-  //   StatementList?
-  export type ClassStaticBlockStatementList = StatementList;
-
-  // AsyncFunctionDeclaration :
-  //   `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncBody `}`
-  //   [+Default] `async` `function` `*` `(` FormalParameters `)` `{` AsyncBody `}`
-  export interface AsyncFunctionDeclaration extends ParseNode {
-    type: 'AsyncFunctionDeclaration';
-    BindingIdentifier: BindingIdentifier | null;
-    FormalParameters: FormalParameters;
-    AsyncBody: AsyncFunctionBody;
-  }
-
-  // AsyncFunctionExpression :
-  //   `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncBody `}`
-  export interface AsyncFunctionExpression extends ParseNode {
-    type: 'AsyncFunctionExpression';
-    BindingIdentifier: BindingIdentifier | null;
-    FormalParameters: FormalParameters;
-    AsyncBody: AsyncFunctionBody;
-  }
-
-  // AsyncMethod :
-  //   `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncBody `}`
-  export interface AsyncMethod extends ParseNode {
-    type: 'AsyncMethod';
-    static?: boolean;
-    ClassElementName: ClassElementName;
-    PropertySetParameterList: null;
-    UniqueFormalParameters: UniqueFormalParameters;
-    AsyncBody: AsyncFunctionBody;
-  }
-
-  // AsyncBody :
-  //   FunctionBody
-  export interface AsyncFunctionBody extends ParseNode {
-    type: 'AsyncFunctionBody';
-    directives: string[];
-    strict: boolean;
-    FunctionStatementList: FunctionStatementList;
-  }
-
-  // AsyncArrowFunction :
-  //   `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
-  //   CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
+  // BindingIdentifier :
+  //   Identifier
+  //   [~Yield] `yield`
+  //   [~Await] `await`
   //
-  // CoverCallExpressionAndAsyncArrowHead :
-  //   MemberExpression Arguments
+  // Identifier :
+  //   IdentifierName but not ReservedWord
+  export interface BindingIdentifier extends BaseParseNode {
+    readonly type: 'BindingIdentifier';
+    readonly name: string;
+  }
+
+  // LabelIdentifier :
+  //   Identifier
+  //   [~Yield] `yield`
+  //   [~Await] `await`
   //
-  // AsyncArrowHead (refined) :
-  //   `async` ArrowFormalParameters
-  export interface AsyncArrowFunction extends ParseNode {
-    type: 'AsyncArrowFunction';
-    ArrowParameters: ArrowParameters;
-    AsyncConciseBody: AsyncConciseBodyOrHigher;
-  }
-
-  // AsyncConciseBody (partial) :
-  //   ExpressionBody
-  export interface AsyncConciseBody extends ParseNode {
-    type: 'AsyncConciseBody';
-    directives?: undefined;
-    ExpressionBody: ExpressionBody;
-  }
-
-  // AsyncConciseBody :
-  //   ExpressionBody
-  //   `{` AsyncFunctionBody `}`
-  export type AsyncConciseBodyOrHigher =
-    | AsyncFunctionBody
-    | AsyncConciseBody;
-
-  // NON-SPEC
-  export type ArrowFunctionLike = ArrowFunction | AsyncArrowFunction;
-
-  // NON-SPEC
-  export type ConciseBodyLike = ConciseBody | AsyncConciseBody;
-
-  // NON-SPEC
-  export type ConciseBodyLikeOrHigher = ConciseBodyOrHigher | AsyncConciseBodyOrHigher;
-
-  export interface RegularExpressionLiteral extends ParseNode {
-    type: 'RegularExpressionLiteral';
-    RegularExpressionBody: string;
-    RegularExpressionFlags: string;
-  }
-
-  // CoverParenthesizedExpressionAndArrowParameterList :
-  //   `(` Expression `)`
-  //   `(` Expression `,` `)`
-  //   `(` `)`
-  //   `(` `...` BindingIdentifier `)`
-  //   `(` `...` BindingPattern `)`
-  //   `(` Expression `,` `...` BindingIdentifier `)`
-  //   `(` Expression `.` `...` BindingPattern `)`
-  export interface CoverParenthesizedExpressionAndArrowParameterList extends ParseNode {
-    type: 'CoverParenthesizedExpressionAndArrowParameterList';
-    Arguments: (ArgumentListElement | BindingRestElement)[];
-    arrowInfo?: ArrowInfo;
-  }
-
-  // CoverParenthesizedExpressionAndArrowParameterList (partial) :
-  //   `(` Expression `)`
-  //
-  // ParenthesizedExpression (refined) :
-  //   `(` Expression `)`
-  export interface ParenthesizedExpression extends ParseNode {
-    type: 'ParenthesizedExpression';
-    Expression: Expression;
+  // Identifier :
+  //   IdentifierName but not ReservedWord
+  export interface LabelIdentifier extends BaseParseNode {
+    readonly type: 'LabelIdentifier';
+    readonly name: string;
   }
 
   // PrimaryExpression :
@@ -677,64 +152,178 @@ export namespace ParseNode {
     | CoverParenthesizedExpressionAndArrowParameterList
     | ParenthesizedExpression;
 
-  // SuperProperty (partial) :
-  //   super `[` Expression `]`
-  export interface SuperProperty extends ParseNode {
-    type: 'SuperProperty';
-    Expression: Expression | null;
+  // PrimaryExpression (partial) :
+  //   `this`
+  export interface ThisExpression extends BaseParseNode {
+    readonly type: 'ThisExpression';
   }
 
-  // SuperProperty (partial) :
-  //   super `.` IdentifierName
-  export interface SuperProperty extends ParseNode {
-    type: 'SuperProperty';
-    IdentifierName: IdentifierName | null;
+  // CoverParenthesizedExpressionAndArrowParameterList :
+  //   `(` Expression `)`
+  //   `(` Expression `,` `)`
+  //   `(` `)`
+  //   `(` `...` BindingIdentifier `)`
+  //   `(` `...` BindingPattern `)`
+  //   `(` Expression `,` `...` BindingIdentifier `)`
+  //   `(` Expression `.` `...` BindingPattern `)`
+  export interface CoverParenthesizedExpressionAndArrowParameterList extends BaseParseNode {
+    readonly type: 'CoverParenthesizedExpressionAndArrowParameterList';
+    readonly Arguments: (ArgumentListElement | BindingRestElement)[];
+    readonly arrowInfo?: ArrowInfo;
   }
 
-  // NewTarget :
-  //   `new` `.` `target`
-  export interface NewTarget extends ParseNode {
-    type: 'NewTarget';
+  // CoverParenthesizedExpressionAndArrowParameterList (partial) :
+  //   `(` Expression `)`
+  //
+  // ParenthesizedExpression (refined) :
+  //   `(` Expression `)`
+  export interface ParenthesizedExpression extends BaseParseNode {
+    readonly type: 'ParenthesizedExpression';
+    readonly Expression: Expression;
   }
 
-  // ImportMeta :
-  //   `import` `.` `meta`
-  export interface ImportMeta extends ParseNode {
-    type: 'ImportMeta';
+  // Literal :
+  //   NullLiteral
+  //   BooleanLiteral
+  //   NumericLiteral
+  //   StringLiteral
+  export type Literal =
+    | NullLiteral
+    | BooleanLiteral
+    | NumericLiteral
+    | StringLiteral;
+
+  // ArrayLiteral :
+  //   `[` `]`
+  //   `[` Elision `]`
+  //   `[` ElementList `]`
+  //   `[` ElementList `,` `]`
+  //   `[` ElementList `,` Elision `]`
+  export interface ArrayLiteral extends BaseParseNode {
+    readonly type: 'ArrayLiteral';
+    readonly ElementList: ElementList;
+    readonly hasTrailingComma: boolean;
   }
 
-  // MetaProperty :
-  //   NewTarget
-  //   ImportMeta
-  export type MetaProperty =
-    | NewTarget
-    | ImportMeta;
+  // ElementList :
+  //   Elision? AssignmentExpression
+  //   Elision? SpreadElement
+  //   ElementList `,` Elision? AssignmentExpression
+  //   ElementList `,` Elision? SpreadElement
+  export type ElementList = ElementListElement[];
 
-  // MemberExpression (partial) :
-  //   MemberExpression `[` Expression `]`
-  export interface MemberExpression extends ParseNode {
-    type: 'MemberExpression';
-    // NOTE: Should be MemberExpressionOrHigher
-    MemberExpression: LeftHandSideExpression;
-    Expression: Expression | null;
+  // NON-SPEC
+  export type ElementListElement =
+    | AssignmentExpressionOrHigher
+    | SpreadElement
+    | Elision;
+
+  // Elision :
+  //   `,`
+  //   Elision `,`
+  export interface Elision extends BaseParseNode {
+    readonly type: 'Elision';
   }
 
-  // MemberExpression (partial) :
-  //   MemberExpression `.` IdentifierName
-  export interface MemberExpression extends ParseNode {
-    type: 'MemberExpression';
-    // NOTE: Should be MemberExpressionOrHigher
-    MemberExpression: LeftHandSideExpression;
-    IdentifierName: IdentifierName | null;
+  // SpreadElement :
+  // `...` AssignmentExpression
+  export interface SpreadElement extends BaseParseNode {
+    readonly type: 'SpreadElement';
+    readonly AssignmentExpression: AssignmentExpressionOrHigher;
   }
 
-  // MemberExpression (partial) :
-  //   MemberExpression `.` PrivateIdentifier
-  export interface MemberExpression extends ParseNode {
-    type: 'MemberExpression';
-    // NOTE: Should be MemberExpressionOrHigher
-    MemberExpression: LeftHandSideExpression;
-    PrivateIdentifier: PrivateIdentifier | null;
+  // ObjectLiteral :
+  //   `{` `}`
+  //   `{` PropertyDefinitionList `}`
+  //   `{` PropertyDefinitionList `,` `}`
+  export interface ObjectLiteral extends BaseParseNode {
+    readonly type: 'ObjectLiteral';
+    readonly PropertyDefinitionList: PropertyDefinitionList;
+  }
+
+  // PropertyDefinitionList :
+  //   PropertyDefinition
+  //   PropertyDefinitionList `,` PropertyDefinition
+  export type PropertyDefinitionList = PropertyDefinitionLike[];
+
+  // PropertyDefinition :
+  //   IdentifierReference
+  //   CoverInitializedName
+  //   PropertyName `:` AssignmentExpression
+  //   MethodDefinition
+  //   `...` AssignmentExpression
+  export type PropertyDefinitionLike =
+    | IdentifierReference
+    | CoverInitializedName
+    | PropertyDefinition
+    | MethodDefinitionLike;
+
+  // PropertyDefinition (partial) :
+  //   PropertyName `:` AssignmentExpression
+  //   `...` AssignmentExpression
+  export interface PropertyDefinition extends BaseParseNode {
+    readonly type: 'PropertyDefinition';
+    readonly PropertyName: PropertyNameLike | null;
+    readonly AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // PropertyName :
+  //   LiteralPropertyName
+  //   ComputedPropertyName
+  //
+  // LiteralPropertyName :
+  //   IdentifierName
+  //   StringLiteral
+  //   NumericLiteral
+  //
+  // ComputedPropertyName :
+  //   `[` AssignmentExpression `]`
+  export type PropertyNameLike =
+    | PropertyName
+    | StringLiteral
+    | NumericLiteral
+    | IdentifierName;
+
+  // PropertyName (partial) :
+  //   ComputedPropertyName
+  //
+  // ComputedPropertyName :
+  //   `[` AssignmentExpression `]`
+  export interface PropertyName extends BaseParseNode {
+    readonly type: 'PropertyName';
+    readonly ComputedPropertyName: AssignmentExpressionOrHigher;
+  }
+
+  // CoverInitializedName :
+  //   IdentifierReference Initializer
+  export interface CoverInitializedName extends BaseParseNode {
+    readonly type: 'CoverInitializedName';
+    readonly IdentifierReference: IdentifierReference;
+    readonly Initializer: Initializer | null;
+  }
+
+  // Initializer :
+  //   `=` AssignmentExpression
+  export type Initializer = AssignmentExpressionOrHigher;
+
+  // TemplateLiteral :
+  //   NoSubstitutionTemplate
+  //   SubstitutionTemplate
+  //
+  // SubstitutionTemplate :
+  //   TemplateHead Expression TemplateSpans
+  //
+  // TemplateSpans :
+  //   TemplateTail
+  //   TemplateMiddleList TemplateTail
+  //
+  // TemplateMiddleList :
+  //   TemplateMiddle Expression
+  //   TemplateMiddleList TemplateMiddle Expression
+  export interface TemplateLiteral extends BaseParseNode {
+    readonly type: 'TemplateLiteral';
+    readonly TemplateSpanList: string[];
+    readonly ExpressionList: Expression[];
   }
 
   // MemberExpression :
@@ -753,16 +342,64 @@ export namespace ParseNode {
     | MetaProperty
     | NewExpression;
 
-  // NewExpression (partial) :
-  //   `new` NewExpression
-  //
-  // MemberExpression (partial) :
-  //   `new` MemberExpression Arguments
-  export interface NewExpression extends ParseNode {
-    type: 'NewExpression';
-    // NOTE: Should be NewExpressionOrHigher | MemberExpressionOrHigher
-    MemberExpression: LeftHandSideExpression;
-    Arguments: Arguments | null;
+  // MemberExpression :
+  //   MemberExpression `[` Expression `]`
+  //   MemberExpression `.` IdentifierName
+  //   MemberExpression `.` PrivateIdentifier
+  export interface MemberExpression extends BaseParseNode {
+    readonly type: 'MemberExpression';
+
+    /// MemberExpression : MemberExpression `[` Expression `]`
+    // readonly MemberExpression: LeftHandSideExpression; // NOTE: Should be MemberExpressionOrHigher
+    // readonly Expression: Expression | null;
+
+    /// MemberExpression : MemberExpression `.` IdentifierName
+    // readonly MemberExpression: LeftHandSideExpression; // NOTE: Should be MemberExpressionOrHigher
+    // readonly IdentifierName: IdentifierName | null;
+
+    /// MemberExpression : MemberExpression `.` PrivateIdentifier
+    // readonly MemberExpression: LeftHandSideExpression; // NOTE: Should be MemberExpressionOrHigher
+    // readonly PrivateIdentifier: PrivateIdentifier | null;
+
+    readonly MemberExpression: LeftHandSideExpression; // NOTE: Should be MemberExpressionOrHigher
+    readonly Expression: Expression | null;
+    readonly IdentifierName: IdentifierName | null;
+    readonly PrivateIdentifier: PrivateIdentifier | null;
+  }
+
+  // SuperProperty :
+  //   super `[` Expression `]`
+  //   super `.` IdentifierName
+  export interface SuperProperty extends BaseParseNode {
+    readonly type: 'SuperProperty';
+
+    /// SuperProperty : super `[` Expression `]`
+    // readonly Expression: Expression | null;
+
+    /// SuperProperty : super `.` IdentifierName
+    // readonly IdentifierName: IdentifierName | null;
+
+    readonly Expression: Expression | null;
+    readonly IdentifierName: IdentifierName | null;
+  }
+
+  // MetaProperty :
+  //   NewTarget
+  //   ImportMeta
+  export type MetaProperty =
+    | NewTarget
+    | ImportMeta;
+
+  // NewTarget :
+  //   `new` `.` `target`
+  export interface NewTarget extends BaseParseNode {
+    readonly type: 'NewTarget';
+  }
+
+  // ImportMeta :
+  //   `import` `.` `meta`
+  export interface ImportMeta extends BaseParseNode {
+    readonly type: 'ImportMeta';
   }
 
   // NewExpression :
@@ -772,61 +409,16 @@ export namespace ParseNode {
     | MemberExpressionOrHigher
     | NewExpression;
 
-  // SuperCall :
-  //   `super` Arguments
-  export interface SuperCall extends ParseNode {
-    type: 'SuperCall';
-    Arguments: Arguments;
-  }
-
-  // ImportCall :
-  //   `import` `(` AssignmentExpression `)`
-  export interface ImportCall extends ParseNode {
-    type: 'ImportCall';
-    AssignmentExpression: AssignmentExpressionOrHigher;
-  }
-
-  // CallExpression (partial) :
-  //   CallExpression Arguments
-  export interface CallExpression extends ParseNode {
-    type: 'CallExpression';
-    // NOTE: Should be CallExpressionOrHigher
-    CallExpression: LeftHandSideExpression;
-    Arguments: Arguments;
-    arrowInfo?: ArrowInfo;
-  }
-
-  // TemplateLiteral :
-  //   NoSubstitutionTemplate
-  //   SubstitutionTemplate
-  //
-  // SubstitutionTemplate :
-  //   TemplateHead Expression TemplateSpans
-  //
-  // TemplateSpans :
-  //   TemplateTail
-  //   TemplateMiddleList TemplateTail
-  //
-  // TemplateMiddleList :
-  //   TemplateMiddle Expression
-  //   TemplateMiddleList TemplateMiddle Expression
-  export interface TemplateLiteral extends ParseNode {
-    type: 'TemplateLiteral';
-    TemplateSpanList: string[];
-    ExpressionList: Expression[];
-  }
-
-  // CallExpression (partial) :
-  //   CallExpression TemplateLiteral
+  // NewExpression (partial) :
+  //   `new` NewExpression
   //
   // MemberExpression (partial) :
-  //   MemberExpression TemplateLiteral
-  export interface TaggedTemplateExpression extends ParseNode {
-    type: 'TaggedTemplateExpression';
-    // NOTE: Should be CallExpressionOrHigher
-    MemberExpression: LeftHandSideExpression;
-    TemplateLiteral: TemplateLiteral;
-    arrowInfo?: ArrowInfo;
+  //   `new` MemberExpression Arguments
+  export interface NewExpression extends BaseParseNode {
+    readonly type: 'NewExpression';
+    // NOTE: Should be NewExpressionOrHigher | MemberExpressionOrHigher
+    readonly MemberExpression: LeftHandSideExpression;
+    readonly Arguments: Arguments | null;
   }
 
   // CallExpression :
@@ -839,98 +431,51 @@ export namespace ParseNode {
   //   CallExpression TemplateLiteral
   //   CallExpression `.` PrivateIdentifier
   export type CallExpressionOrHigher =
-    | MemberExpressionOrHigher
+    // CoverCallExpressionAndAsyncArrowHead
     | SuperCall
     | ImportCall
     | CallExpression
+    | MemberExpression
     | TaggedTemplateExpression;
 
-  // OptionalExpression :
-  //   MemberExpression OptionalChain
-  //   CallExpression OptionalChain
-  //   OptionalExpression OptionalChain
-  export interface OptionalExpression extends ParseNode {
-    type: 'OptionalExpression';
-    MemberExpression: MemberExpressionOrHigher | CallExpressionOrHigher | OptionalExpression;
-    OptionalChain: OptionalChain;
+  // CallExpression (partial) :
+  //   CoverCallExpressionAndAsyncArrowHead
+  //   CallExpression Arguments
+  //
+  // CallMemberExpression (refined) :
+  //   MemberExpression Arguments
+  export interface CallExpression extends BaseParseNode {
+    readonly type: 'CallExpression';
+    readonly CallExpression: CallExpressionOrHigher | MemberExpressionOrHigher;
+    readonly Arguments: Arguments;
+    readonly arrowInfo?: ArrowInfo;
   }
 
-  // OptionalChain (partial) :
-  //   `?.` Arguments
-  export interface OptionalChain extends ParseNode {
-    type: 'OptionalChain';
-    Arguments?: Arguments;
+  // CallExpression (partial) :
+  //   CallExpression TemplateLiteral
+  //
+  // MemberExpression (partial) :
+  //   MemberExpression TemplateLiteral
+  export interface TaggedTemplateExpression extends BaseParseNode {
+    readonly type: 'TaggedTemplateExpression';
+    readonly MemberExpression: CallExpressionOrHigher | MemberExpressionOrHigher;
+    readonly TemplateLiteral: TemplateLiteral;
+    readonly arrowInfo?: ArrowInfo;
   }
 
-  // OptionalChain (partial) :
-  //   `?.` `[` Expression `]`
-  export interface OptionalChain extends ParseNode {
-    type: 'OptionalChain';
-    Expression?: Expression;
+  // SuperCall :
+  //   `super` Arguments
+  export interface SuperCall extends BaseParseNode {
+    readonly type: 'SuperCall';
+    readonly Arguments: Arguments;
   }
 
-  // OptionalChain (partial) :
-  //   `?.` IdentifierName
-  export interface OptionalChain extends ParseNode {
-    type: 'OptionalChain';
-    IdentifierName?: IdentifierName;
+  // ImportCall :
+  //   `import` `(` AssignmentExpression `)`
+  export interface ImportCall extends BaseParseNode {
+    readonly type: 'ImportCall';
+    readonly AssignmentExpression: AssignmentExpressionOrHigher;
   }
-
-  // OptionalChain (partial) :
-  //   `?.` PrivateIdentifier
-  export interface OptionalChain extends ParseNode {
-    type: 'OptionalChain';
-    PrivateIdentifier?: PrivateIdentifier;
-  }
-
-  // OptionalChain (partial) :
-  //   OptionalChain `?.` Arguments
-  export interface OptionalChain extends ParseNode {
-    type: 'OptionalChain';
-    OptionalChain: OptionalChain | null;
-    Arguments?: Arguments;
-  }
-
-  // OptionalChain (partial) :
-  //   OptionalChain `?.` `[` Expression `]`
-  export interface OptionalChain extends ParseNode {
-    type: 'OptionalChain';
-    OptionalChain: OptionalChain | null;
-    Expression?: Expression;
-  }
-
-  // OptionalChain (partial) :
-  //   OptionalChain `?.` IdentifierName
-  export interface OptionalChain extends ParseNode {
-    type: 'OptionalChain';
-    OptionalChain: OptionalChain | null;
-    IdentifierName?: IdentifierName;
-  }
-
-  // OptionalChain (partial) :
-  //   OptionalChain `?.` PrivateIdentifier
-  export interface OptionalChain extends ParseNode {
-    type: 'OptionalChain';
-    OptionalChain: OptionalChain | null;
-    PrivateIdentifier?: PrivateIdentifier;
-  }
-
-  // ArgumentList (partial) :
-  //   `...` AssignmentExpression
-  //   ArgumentList `,` `...` AssignmentExpression
-  export interface AssignmentRestElement extends ParseNode {
-    type: 'AssignmentRestElement';
-    AssignmentExpression: AssignmentExpressionOrHigher;
-  }
-
-  // ArgumentList :
-  //   AssignmentExpression
-  //   `...` AssignmentExpression
-  //   ArgumentList `,` AssignmentExpression
-  //   ArgumentList `,` `...` AssignmentExpression
-  export type ArgumentListElement =
-    | AssignmentExpressionOrHigher
-    | AssignmentRestElement;
 
   // Arguments :
   //   `(` `)`
@@ -943,6 +488,69 @@ export namespace ParseNode {
   //   ArgumentList `,` AssignmentExpression
   //   ArgumentList `,` `...` AssignmentExpression
   export type Arguments = ArgumentListElement[];
+
+  // NON-SPEC
+  export type ArgumentListElement =
+    | AssignmentExpressionOrHigher
+    | AssignmentRestElement;
+
+  // OptionalExpression :
+  //   MemberExpression OptionalChain
+  //   CallExpression OptionalChain
+  //   OptionalExpression OptionalChain
+  export interface OptionalExpression extends BaseParseNode {
+    readonly type: 'OptionalExpression';
+    // NOTE: The following doesn't match how this is handled in other nodes.
+    readonly MemberExpression: MemberExpressionOrHigher | CallExpressionOrHigher | OptionalExpression;
+    readonly OptionalChain: OptionalChain;
+  }
+
+  // OptionalChain :
+  //   `?.` Arguments
+  //   `?.` `[` Expression `]`
+  //   `?.` IdentifierName
+  //   `?.` PrivateIdentifier
+  //   OptionalChain `?.` Arguments
+  //   OptionalChain `?.` `[` Expression `]`
+  //   OptionalChain `?.` IdentifierName
+  //   OptionalChain `?.` PrivateIdentifier
+  export interface OptionalChain extends BaseParseNode {
+    readonly type: 'OptionalChain';
+
+    /// OptionalChain : `?.` Arguments
+    // readonly Arguments?: Arguments;
+
+    /// OptionalChain : `?.` `[` Expression `]`
+    // readonly Expression?: Expression;
+
+    /// OptionalChain : `?.` IdentifierName
+    // readonly IdentifierName?: IdentifierName;
+
+    /// OptionalChain : `?.` PrivateIdentifier
+    // readonly PrivateIdentifier?: PrivateIdentifier;
+
+    /// OptionalChain : OptionalChain `?.` Arguments
+    // readonly OptionalChain: OptionalChain | null;
+    // readonly Arguments?: Arguments;
+
+    /// OptionalChain : OptionalChain `?.` `[` Expression `]`
+    // readonly OptionalChain: OptionalChain | null;
+    // readonly Expression?: Expression;
+
+    /// OptionalChain : OptionalChain `?.` IdentifierName
+    // readonly OptionalChain: OptionalChain | null;
+    // readonly IdentifierName?: IdentifierName;
+
+    /// OptionalChain : OptionalChain `?.` PrivateIdentifier
+    // readonly OptionalChain: OptionalChain | null;
+    // readonly PrivateIdentifier?: PrivateIdentifier;
+
+    readonly OptionalChain: OptionalChain | null;
+    readonly Arguments?: Arguments;
+    readonly Expression?: Expression;
+    readonly IdentifierName?: IdentifierName;
+    readonly PrivateIdentifier?: PrivateIdentifier;
+  }
 
   // LeftHandSideExpression :
   //   NewExpression
@@ -959,41 +567,33 @@ export namespace ParseNode {
   //   LeftHandSideExpression [no LineTerminator here] `--`
   //   `++` UnaryExpression
   //   `--` UnaryExpression
-  export interface UpdateExpression extends ParseNode {
-    type: 'UpdateExpression';
-    operator: '++' | '--';
-    LeftHandSideExpression: LeftHandSideExpression | null;
-    UnaryExpression: UnaryExpressionOrHigher | null;
-  }
-
-  // UpdateExpression :
-  //   LeftHandSideExpression
-  //   LeftHandSideExpression [no LineTerminator here] `++`
-  //   LeftHandSideExpression [no LineTerminator here] `--`
-  //   `++` UnaryExpression
-  //   `--` UnaryExpression
   export type UpdateExpressionOrHigher =
     | LeftHandSideExpression
     | UpdateExpression;
 
-  // AwaitExpression : `await` UnaryExpression
-  export interface AwaitExpression extends ParseNode {
-    type: 'AwaitExpression';
-    UnaryExpression: UnaryExpressionOrHigher;
-  }
+  // UpdateExpression (partial) :
+  //   LeftHandSideExpression [no LineTerminator here] `++`
+  //   LeftHandSideExpression [no LineTerminator here] `--`
+  //   `++` UnaryExpression
+  //   `--` UnaryExpression
+  export interface UpdateExpression extends BaseParseNode {
+    readonly type: 'UpdateExpression';
 
-  // UnaryExpression (partial) :
-  //   `delete` UnaryExpression
-  //   `void` UnaryExpression
-  //   `typeof` UnaryExpression
-  //   `+` UnaryExpression
-  //   `-` UnaryExpression
-  //   `~` UnaryExpression
-  //   `!` UnaryExpression
-  export interface UnaryExpression extends ParseNode {
-    type: 'UnaryExpression';
-    operator: 'delete' | 'void' | 'typeof' | '+' | '-' | '~' | '!';
-    UnaryExpression: UnaryExpressionOrHigher;
+    /// UpdateExpression :
+    ///   LeftHandSideExpression [no LineTerminator here] `++`
+    ///   LeftHandSideExpression [no LineTerminator here] `--`
+    // readonly LeftHandSideExpression: LeftHandSideExpression | null;
+    // readonly operator: '++' | '--';
+
+    /// UpdateExpression :
+    ///   `++` UnaryExpression
+    ///   `--` UnaryExpression
+    // readonly operator: '++' | '--';
+    // readonly UnaryExpression: UnaryExpressionOrHigher | null;
+
+    readonly operator: '++' | '--';
+    readonly LeftHandSideExpression: LeftHandSideExpression | null;
+    readonly UnaryExpression: UnaryExpressionOrHigher | null;
   }
 
   // UnaryExpression :
@@ -1011,12 +611,18 @@ export namespace ParseNode {
     | UnaryExpression
     | AwaitExpression;
 
-  // ExponentiationExpression (partial) :
-  //   UpdateExpresion `**` ExponentiationExpression
-  export interface ExponentiationExpression extends ParseNode {
-    type: 'ExponentiationExpression';
-    UpdateExpression: UpdateExpressionOrHigher;
-    ExponentiationExpression: ExponentiationExpressionOrHigher;
+  // UnaryExpression (partial) :
+  //   `delete` UnaryExpression
+  //   `void` UnaryExpression
+  //   `typeof` UnaryExpression
+  //   `+` UnaryExpression
+  //   `-` UnaryExpression
+  //   `~` UnaryExpression
+  //   `!` UnaryExpression
+  export interface UnaryExpression extends BaseParseNode {
+    readonly type: 'UnaryExpression';
+    readonly operator: 'delete' | 'void' | 'typeof' | '+' | '-' | '~' | '!';
+    readonly UnaryExpression: UnaryExpressionOrHigher;
   }
 
   // ExponentiationExpression :
@@ -1026,17 +632,12 @@ export namespace ParseNode {
     | UnaryExpressionOrHigher
     | ExponentiationExpression;
 
-  // MultiplicativeOperator : one of
-  //   `*`  `/`  `%`;
-  export type MultiplicativeOperator = '*' | '/' | '%';
-
   // ExponentiationExpression (partial) :
-  //   MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
-  export interface MultiplicativeExpression extends ParseNode {
-    type: 'MultiplicativeExpression';
-    MultiplicativeExpression: MultiplicativeExpressionOrHigher;
-    MultiplicativeOperator: MultiplicativeOperator;
-    ExponentiationExpression: ExponentiationExpressionOrHigher;
+  //   UpdateExpresion `**` ExponentiationExpression
+  export interface ExponentiationExpression extends BaseParseNode {
+    readonly type: 'ExponentiationExpression';
+    readonly UpdateExpression: UpdateExpressionOrHigher;
+    readonly ExponentiationExpression: ExponentiationExpressionOrHigher;
   }
 
   // MultiplicativeExpression :
@@ -1046,15 +647,18 @@ export namespace ParseNode {
     | ExponentiationExpressionOrHigher
     | MultiplicativeExpression;
 
-  // AdditiveExpression (partial) :
-  //   AdditiveExpression `+` MultiplicativeExpression
-  //   AdditiveExpression `-` MultiplicativeExpression
-  export interface AdditiveExpression extends ParseNode {
-    type: 'AdditiveExpression';
-    operator: '+' | '-';
-    AdditiveExpression: AdditiveExpressionOrHigher;
-    MultiplicativeExpression: MultiplicativeExpressionOrHigher;
+  // MultiplicativeExpression (partial) :
+  //   MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
+  export interface MultiplicativeExpression extends BaseParseNode {
+    readonly type: 'MultiplicativeExpression';
+    readonly MultiplicativeExpression: MultiplicativeExpressionOrHigher;
+    readonly MultiplicativeOperator: MultiplicativeOperator;
+    readonly ExponentiationExpression: ExponentiationExpressionOrHigher;
   }
+
+  // MultiplicativeOperator : one of
+  //   `*`  `/`  `%`;
+  export type MultiplicativeOperator = '*' | '/' | '%';
 
   // AdditiveExpression :
   //   MultiplicativeExpression
@@ -1064,15 +668,14 @@ export namespace ParseNode {
     | MultiplicativeExpressionOrHigher
     | AdditiveExpression;
 
-  // ShiftExpression (partial) :
-  //   ShiftExpression `<<` AdditiveExpression
-  //   ShiftExpression `>>` AdditiveExpression
-  //   ShiftExpression `>>>` AdditiveExpression
-  export interface ShiftExpression extends ParseNode {
-    type: 'ShiftExpression';
-    operator: '<<' | '>>' | '>>>';
-    ShiftExpression: ShiftExpressionOrHigher;
-    AdditiveExpression: AdditiveExpressionOrHigher;
+  // AdditiveExpression (partial) :
+  //   AdditiveExpression `+` MultiplicativeExpression
+  //   AdditiveExpression `-` MultiplicativeExpression
+  export interface AdditiveExpression extends BaseParseNode {
+    readonly type: 'AdditiveExpression';
+    readonly operator: '+' | '-';
+    readonly AdditiveExpression: AdditiveExpressionOrHigher;
+    readonly MultiplicativeExpression: MultiplicativeExpressionOrHigher;
   }
 
   // ShiftExpression :
@@ -1084,19 +687,15 @@ export namespace ParseNode {
     | AdditiveExpressionOrHigher
     | ShiftExpression;
 
-  // RelationalExpression (partial) :
-  //   RelationalExpression `<` ShiftExpression
-  //   RelationalExpression `>` ShiftExpression
-  //   RelationalExpression `<=` ShiftExpression
-  //   RelationalExpression `>=` ShiftExpression
-  //   RelationalExpression `instanceof` ShiftExpression
-  //   RelationalExpression `in` ShiftExpression
-  export interface RelationalExpression extends ParseNode {
-    type: 'RelationalExpression';
-    operator: '<' | '>' | '<=' | '>=' | 'instanceof' | 'in';
-    PrivateIdentifier?: PrivateIdentifier;
-    RelationalExpression?: RelationalExpressionOrHigher;
-    ShiftExpression: ShiftExpressionOrHigher;
+  // ShiftExpression (partial) :
+  //   ShiftExpression `<<` AdditiveExpression
+  //   ShiftExpression `>>` AdditiveExpression
+  //   ShiftExpression `>>>` AdditiveExpression
+  export interface ShiftExpression extends BaseParseNode {
+    readonly type: 'ShiftExpression';
+    readonly operator: '<<' | '>>' | '>>>';
+    readonly ShiftExpression: ShiftExpressionOrHigher;
+    readonly AdditiveExpression: AdditiveExpressionOrHigher;
   }
 
   // RelationalExpression :
@@ -1111,16 +710,19 @@ export namespace ParseNode {
     | ShiftExpressionOrHigher
     | RelationalExpression;
 
-  // EqualityExpression (partial) :
-  //   EqualityExpression == RelationalExpression
-  //   EqualityExpression != RelationalExpression
-  //   EqualityExpression === RelationalExpression
-  //   EqualityExpression !== RelationalExpression
-  export interface EqualityExpression extends ParseNode {
-    type: 'EqualityExpression';
-    operator: '==' | '!=' | '===' | '!==';
-    EqualityExpression: EqualityExpressionOrHigher;
-    RelationalExpression: RelationalExpressionOrHigher;
+  // RelationalExpression (partial) :
+  //   RelationalExpression `<` ShiftExpression
+  //   RelationalExpression `>` ShiftExpression
+  //   RelationalExpression `<=` ShiftExpression
+  //   RelationalExpression `>=` ShiftExpression
+  //   RelationalExpression `instanceof` ShiftExpression
+  //   RelationalExpression `in` ShiftExpression
+  export interface RelationalExpression extends BaseParseNode {
+    readonly type: 'RelationalExpression';
+    readonly operator: '<' | '>' | '<=' | '>=' | 'instanceof' | 'in';
+    readonly PrivateIdentifier?: PrivateIdentifier;
+    readonly RelationalExpression?: RelationalExpressionOrHigher;
+    readonly ShiftExpression: ShiftExpressionOrHigher;
   }
 
   // EqualityExpression :
@@ -1133,13 +735,16 @@ export namespace ParseNode {
     | RelationalExpressionOrHigher
     | EqualityExpression;
 
-  // BitwiseANDExpression (partial) :
-  //   BitwiseANDExpression `^&` EqualityExpression
-  export interface BitwiseANDExpression extends ParseNode {
-    type: 'BitwiseANDExpression';
-    operator: '&';
-    A: BitwiseANDExpressionOrHigher;
-    B: EqualityExpressionOrHigher;
+  // EqualityExpression (partial) :
+  //   EqualityExpression == RelationalExpression
+  //   EqualityExpression != RelationalExpression
+  //   EqualityExpression === RelationalExpression
+  //   EqualityExpression !== RelationalExpression
+  export interface EqualityExpression extends BaseParseNode {
+    readonly type: 'EqualityExpression';
+    readonly operator: '==' | '!=' | '===' | '!==';
+    readonly EqualityExpression: EqualityExpressionOrHigher;
+    readonly RelationalExpression: RelationalExpressionOrHigher;
   }
 
   // BitwiseANDExpression :
@@ -1149,13 +754,13 @@ export namespace ParseNode {
     | EqualityExpressionOrHigher
     | BitwiseANDExpression;
 
-  // BitwiseXORExpression (partial) :
-  //   BitwiseXORExpression `^` BitwiseANDExpression
-  export interface BitwiseXORExpression extends ParseNode {
-    type: 'BitwiseXORExpression';
-    operator: '^';
-    A: BitwiseXORExpressionOrHigher;
-    B: BitwiseANDExpressionOrHigher;
+  // BitwiseANDExpression (partial) :
+  //   BitwiseANDExpression `^&` EqualityExpression
+  export interface BitwiseANDExpression extends BaseParseNode {
+    readonly type: 'BitwiseANDExpression';
+    readonly operator: '&';
+    readonly A: BitwiseANDExpressionOrHigher;
+    readonly B: EqualityExpressionOrHigher;
   }
 
   // BitwiseXORExpression :
@@ -1165,13 +770,13 @@ export namespace ParseNode {
     | BitwiseANDExpressionOrHigher
     | BitwiseXORExpression;
 
-  // BitwiseORExpression (partial) :
-  //   BitwiseORExpression `|` BitwiseXORExpression
-  export interface BitwiseORExpression extends ParseNode {
-    type: 'BitwiseORExpression';
-    operator: '|';
-    A: BitwiseORExpressionOrHigher;
-    B: BitwiseXORExpressionOrHigher;
+  // BitwiseXORExpression (partial) :
+  //   BitwiseXORExpression `^` BitwiseANDExpression
+  export interface BitwiseXORExpression extends BaseParseNode {
+    readonly type: 'BitwiseXORExpression';
+    readonly operator: '^';
+    readonly A: BitwiseXORExpressionOrHigher;
+    readonly B: BitwiseANDExpressionOrHigher;
   }
 
   // BitwiseORExpression :
@@ -1181,12 +786,13 @@ export namespace ParseNode {
     | BitwiseXORExpressionOrHigher
     | BitwiseORExpression;
 
-  // LogicalANDExpression (partial) :
-  //   LogicalANDExpression `&&` BitwiseORExpression
-  export interface LogicalANDExpression extends ParseNode {
-    type: 'LogicalANDExpression';
-    LogicalANDExpression: LogicalANDExpressionOrHigher;
-    BitwiseORExpression: BitwiseORExpressionOrHigher;
+  // BitwiseORExpression (partial) :
+  //   BitwiseORExpression `|` BitwiseXORExpression
+  export interface BitwiseORExpression extends BaseParseNode {
+    readonly type: 'BitwiseORExpression';
+    readonly operator: '|';
+    readonly A: BitwiseORExpressionOrHigher;
+    readonly B: BitwiseXORExpressionOrHigher;
   }
 
   // LogicalANDExpression :
@@ -1196,12 +802,12 @@ export namespace ParseNode {
     | BitwiseORExpressionOrHigher
     | LogicalANDExpression;
 
-  // LogicalORExpression (partial) :
-  //   LogicalORExpression `||` LogicalANDExpression
-  export interface LogicalORExpression extends ParseNode {
-    type: 'LogicalORExpression';
-    LogicalORExpression: LogicalORExpressionOrHigher;
-    LogicalANDExpression: LogicalANDExpressionOrHigher;
+  // LogicalANDExpression (partial) :
+  //   LogicalANDExpression `&&` BitwiseORExpression
+  export interface LogicalANDExpression extends BaseParseNode {
+    readonly type: 'LogicalANDExpression';
+    readonly LogicalANDExpression: LogicalANDExpressionOrHigher;
+    readonly BitwiseORExpression: BitwiseORExpressionOrHigher;
   }
 
   // LogicalORExpression :
@@ -1211,12 +817,20 @@ export namespace ParseNode {
     | LogicalANDExpressionOrHigher
     | LogicalORExpression;
 
+  // LogicalORExpression (partial) :
+  //   LogicalORExpression `||` LogicalANDExpression
+  export interface LogicalORExpression extends BaseParseNode {
+    readonly type: 'LogicalORExpression';
+    readonly LogicalORExpression: LogicalORExpressionOrHigher;
+    readonly LogicalANDExpression: LogicalANDExpressionOrHigher;
+  }
+
   // CoalesceExpression :
   //   CoalesceExpressionHead `??` BitwiseORExpression
-  export interface CoalesceExpression extends ParseNode {
-    type: 'CoalesceExpression';
-    CoalesceExpressionHead: CoalesceExpressionHead;
-    BitwiseORExpression: BitwiseORExpressionOrHigher;
+  export interface CoalesceExpression extends BaseParseNode {
+    readonly type: 'CoalesceExpression';
+    readonly CoalesceExpressionHead: CoalesceExpressionHead;
+    readonly BitwiseORExpression: BitwiseORExpressionOrHigher;
   }
 
   // CoalesceExpressionHead :
@@ -1233,15 +847,6 @@ export namespace ParseNode {
     | LogicalORExpressionOrHigher
     | CoalesceExpression;
 
-  // ConditionalExpression (partial) :
-  //   ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
-  export interface ConditionalExpression extends ParseNode {
-    type: 'ConditionalExpression';
-    ShortCircuitExpression: ShortCircuitExpressionOrHigher;
-    AssignmentExpression_a: AssignmentExpressionOrHigher;
-    AssignmentExpression_b: AssignmentExpressionOrHigher;
-  }
-
   // ConditionalExpression :
   //   ShortCircuitExpression
   //   ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
@@ -1249,26 +854,14 @@ export namespace ParseNode {
     | ShortCircuitExpressionOrHigher
     | ConditionalExpression;
 
-  // AssignmentExpression (partial) :
-  //   LeftHandSideExpression `=` AssignmentExpression
-  //   LeftHandSideExpression AssignmentOperator AssignmentExpression
-  //   LeftHandSideExpression LogicalAssignmentOperator AssignmentExpression
-  //
-  export interface AssignmentExpression extends ParseNode {
-    type: 'AssignmentExpression';
-    // NOTE: Should be LeftHandSideExpression, but some invalid nodes are allowed as they report early errors
-    LeftHandSideExpression: AssignmentExpressionOrHigher;
-    AssignmentOperator: '=' | AssignmentOperator | LogicalAssignmentOperator;
-    AssignmentExpression: AssignmentExpressionOrHigher;
+  // ConditionalExpression (partial) :
+  //   ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
+  export interface ConditionalExpression extends BaseParseNode {
+    readonly type: 'ConditionalExpression';
+    readonly ShortCircuitExpression: ShortCircuitExpressionOrHigher;
+    readonly AssignmentExpression_a: AssignmentExpressionOrHigher;
+    readonly AssignmentExpression_b: AssignmentExpressionOrHigher;
   }
-
-  // AssignmentOperator : one of
-  //   `*=`  `/=`  `%=`  `+=`  `-=`  `<<=`  `>>=`  `>>>=`  `&=`  `^=`  `|=`  `**=`
-  export type AssignmentOperator = '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>=' | '>>>=' | '&=' | '^=' | '|=' | '**=';
-
-  // LogicalAssignmentOperator : one of
-  //   `&&=`  `||=`  `??=`
-  export type LogicalAssignmentOperator = '&&=' | '||=' | '??=';
 
   // AssignmentExpression :
   //   ConditionalExpression
@@ -1285,6 +878,39 @@ export namespace ParseNode {
     | AsyncArrowFunction
     | AssignmentExpression;
 
+  // AssignmentExpression (partial) :
+  //   LeftHandSideExpression `=` AssignmentExpression
+  //   LeftHandSideExpression AssignmentOperator AssignmentExpression
+  //   LeftHandSideExpression LogicalAssignmentOperator AssignmentExpression
+  //
+  export interface AssignmentExpression extends BaseParseNode {
+    readonly type: 'AssignmentExpression';
+    // NOTE: Should be LeftHandSideExpression, but some invalid nodes are allowed as they report early errors
+    readonly LeftHandSideExpression: AssignmentExpressionOrHigher;
+    readonly AssignmentOperator: '=' | AssignmentOperator | '&&=' | '||=' | '??=';
+    readonly AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // AssignmentOperator : one of
+  //   `*=`  `/=`  `%=`  `+=`  `-=`  `<<=`  `>>=`  `>>>=`  `&=`  `^=`  `|=`  `**=`
+  export type AssignmentOperator = '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>=' | '>>>=' | '&=' | '^=' | '|=' | '**=';
+
+  // AssignmentRestElement :
+  //   `...` DestructuringAssignmentTarget
+  //
+  // ArgumentList (partial) :
+  //   `...` AssignmentExpression
+  //   ArgumentList `,` `...` AssignmentExpression
+  export interface AssignmentRestElement extends BaseParseNode {
+    readonly type: 'AssignmentRestElement';
+    readonly AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // NON-SPEC
+  export type BinaryExpressionOrHigher =
+    | BinaryExpression
+    | UnaryExpressionOrHigher;
+
   // NON-SPEC
   export type BinaryExpression =
     | AssignmentExpression
@@ -1300,18 +926,6 @@ export namespace ParseNode {
     | MultiplicativeExpression
     | ExponentiationExpression;
 
-  // NON-SPEC
-  export type BinaryExpressionOrHigher =
-    | BinaryExpression
-    | UnaryExpressionOrHigher;
-
-  // Expression (partial) :
-  //   Expression `,` AssignmentExpression
-  export interface CommaOperator extends ParseNode {
-    type: 'CommaOperator';
-    ExpressionList: AssignmentExpressionOrHigher[];
-  }
-
   // Expression :
   //   AssignmentExpression
   //   Expression `,` AssignmentExpression
@@ -1319,144 +933,85 @@ export namespace ParseNode {
     | CommaOperator
     | AssignmentExpressionOrHigher;
 
-  // LetOrConst :
-  //   `let`
-  //   `const`
-  export type LetOrConst =
-    | 'let'
-    | 'const';
-
-  // LexicalDeclaration :
-  //   LetOrConst BindingList `;`
-  export interface LexicalDeclaration extends ParseNode {
-    type: 'LexicalDeclaration';
-    LetOrConst: LetOrConst;
-    BindingList: BindingList;
+  // Expression (partial) :
+  //   Expression `,` AssignmentExpression
+  export interface CommaOperator extends BaseParseNode {
+    readonly type: 'CommaOperator';
+    readonly ExpressionList: AssignmentExpressionOrHigher[];
   }
 
-  // LexicalDeclaration :
-  //   LetOrConst BindingList `;`
-  export type LexicalDeclarationLike =
-    | LexicalDeclaration;
+  // A.3 Statements
+  // https://tc39.es/ecma262/#sec-statements
 
-  // BindingList :
-  //   LexicalBinding
-  //   BindingList `,` LexicalBinding
-  export type BindingList = LexicalBinding[];
+  // Statement :
+  //   BlockStatement
+  //   VariableStatement
+  //   EmptyStatement
+  //   ExpressionStatement
+  //   IfStatement
+  //   BreakableStatement
+  //   ContinueStatement
+  //   BreakStatement
+  //   [+Return] ReturnStatement
+  //   WithStatement
+  //   LabelledStatement
+  //   ThrowStatement
+  //   TryStatement
+  //   DebuggerStatement
+  export type Statement =
+    | BlockStatement
+    | VariableStatement
+    | EmptyStatement
+    | ExpressionStatement
+    | IfStatement
+    | BreakableStatement
+    | ContinueStatement
+    | BreakStatement
+    | ReturnStatement
+    | WithStatement
+    | LabelledStatement
+    | ThrowStatement
+    | TryStatement
+    | DebuggerStatement;
 
-  // LexicalBinding :
-  //   BindingIdentifier Initializer?
-  //   BindingPattern Initializer
-  export interface LexicalBinding extends ParseNode {
-    type: 'LexicalBinding';
+  // Declaration :
+  //   HoistableDeclaration
+  //   ClassDeclaration
+  //   LexicalDeclarationLike
+  export type Declaration =
+    | HoistableDeclaration
+    | ClassDeclaration
+    | LexicalDeclarationLike;
 
-    // LexicalBinding : BindingIdentifier Initializer?
-    BindingIdentifier?: BindingIdentifier;
+  // HoistableDeclaration
+  //   FunctionDeclaration
+  //   GeneratorDeclaration
+  //   AsyncFunctionDeclaration
+  //   AsyncGeneratorDeclaration
+  export type HoistableDeclaration =
+    | FunctionDeclaration
+    | GeneratorDeclaration
+    | AsyncFunctionDeclaration
+    | AsyncGeneratorDeclaration;
 
-    // LexicalBinding : BindingPattern Initializer
-    BindingPattern?: BindingPattern;
+  // BreakableStatement :
+  //   IterationStatement
+  //   SwitchStatement
+  export type BreakableStatement =
+    | IterationStatement
+    | SwitchStatement;
 
-    Initializer: Initializer | null; // opt
+  // BlockStatement :
+  //   Block
+  export type BlockStatement =
+    | Block;
+
+  // Block :
+  //   `{` StatementList `}`
+  export interface Block extends BaseParseNode {
+    readonly type: 'Block';
+    readonly StatementList: StatementList;
   }
-
-  // ObjectBindingPattern :
-  //   `{` `}`
-  //   `{` BindingRestProperty `}`
-  //   `{` BindingPropertyList `}`
-  //   `{` BindingPropertyList `,` BindingRestProperty? `}`
-  export interface ObjectBindingPattern extends ParseNode {
-    type: 'ObjectBindingPattern';
-    BindingPropertyList: BindingPropertyList;
-    BindingRestProperty?: BindingRestProperty;
-  }
-
-  // ArrayBindingPattern :
-  //   `[` Elision? BindingRestElement `]`
-  //   `[` BindingElementList `]`
-  //   `[` BindingElementList `,` Elision? BindingRestElement `]`
-  export interface ArrayBindingPattern extends ParseNode {
-    type: 'ArrayBindingPattern';
-    BindingElementList: BindingElementList;
-    BindingRestElement: BindingRestElement;
-  }
-
-  // BindingRestProperty :
-  //  `...` BindingIdentifier
-  export interface BindingRestProperty extends ParseNode {
-    type: 'BindingRestProperty';
-    BindingIdentifier: BindingIdentifier;
-  }
-
-  // BindingProperty : PropertyName : BindingElement
-  export interface BindingProperty extends ParseNode {
-    type: 'BindingProperty';
-    PropertyName: PropertyNameLike;
-    BindingElement: BindingElementOrHigher;
-  }
-
-  // BindingProperty :
-  //   SingleNameBinding
-  //   PropertyName : BindingElement
-  export type BindingPropertyLike =
-    | BindingProperty
-    | SingleNameBinding;
-
-  // TODO: document
-  export type BindingPropertyList = BindingPropertyLike[];
-
-  // BindingRestElement :
-  //   `...` BindingIdentifier
-  //   `...` BindingPattern
-  export interface BindingRestElement extends ParseNode {
-    type: 'BindingRestElement';
-    BindingIdentifier?: BindingIdentifier;
-    BindingPattern?: BindingPattern;
-  }
-
-  // BindingElement :
-  //   SingleNameBinding
-  //   BindingPattern Initializer?
-  export interface BindingElement extends ParseNode {
-    type: 'BindingElement';
-    BindingPattern: BindingPattern;
-    Initializer: Initializer | null; // opt
-  }
-
-  // SingleNameBinding :
-  //   BindingIdentifier Initializer?
-  export interface SingleNameBinding extends ParseNode {
-    type: 'SingleNameBinding';
-    BindingIdentifier: BindingIdentifier;
-    Initializer: Initializer | null; // opt
-  }
-
-  // BindingElement :
-  //   SingleNameBinding
-  //   BindingPattern Initializer?
-  export type BindingElementOrHigher =
-    | BindingElement
-    | SingleNameBinding;
-
-  // BindingElementList :
-  //   BindingElisionElement
-  //   BindingElementList , BindingElisionElement
-  export type BindingElementList = BindingElementListItem[];
-
-  // NON-SPEC
-  export type BindingElementListItem =
-    | BindingElementOrHigher
-    | Elision;
-
-  // BindingPattern :
-  //   ObjectBindingPattern
-  //   ArrayBindingPattern
-  export type BindingPattern =
-    | ObjectBindingPattern
-    | ArrayBindingPattern;
-
-  // Initializer :
-  //   `=` AssignmentExpression
-  export type Initializer = AssignmentExpressionOrHigher;
 
   // StatementList :
   //   StatementListItem
@@ -1470,22 +1025,51 @@ export namespace ParseNode {
     | Statement
     | Declaration;
 
-  // Block :
-  //   `{` StatementList `}`
-  export interface Block extends ParseNode {
-    type: 'Block';
-    StatementList: StatementList;
+  // LexicalDeclaration :
+  //   LetOrConst BindingList `;`
+  export type LexicalDeclarationLike =
+    | LexicalDeclaration;
+
+  // LexicalDeclaration :
+  //   LetOrConst BindingList `;`
+  export interface LexicalDeclaration extends BaseParseNode {
+    readonly type: 'LexicalDeclaration';
+    readonly LetOrConst: LetOrConst;
+    readonly BindingList: BindingList;
   }
 
-  // BlockStatement :
-  //   Block
-  export type BlockStatement = Block;
+  // LetOrConst :
+  //   `let`
+  //   `const`
+  export type LetOrConst =
+    | 'let'
+    | 'const';
+
+  // BindingList :
+  //   LexicalBinding
+  //   BindingList `,` LexicalBinding
+  export type BindingList = LexicalBinding[];
+
+  // LexicalBinding :
+  //   BindingIdentifier Initializer?
+  //   BindingPattern Initializer
+  export interface LexicalBinding extends BaseParseNode {
+    readonly type: 'LexicalBinding';
+
+    // LexicalBinding : BindingIdentifier Initializer?
+    readonly BindingIdentifier?: BindingIdentifier;
+
+    // LexicalBinding : BindingPattern Initializer
+    readonly BindingPattern?: BindingPattern;
+
+    readonly Initializer: Initializer | null;
+  }
 
   // VariableStatement :
   //   `var` VariableDeclarationList `;`
-  export interface VariableStatement extends ParseNode {
-    type: 'VariableStatement';
-    VariableDeclarationList: VariableDeclarationList;
+  export interface VariableStatement extends BaseParseNode {
+    readonly type: 'VariableStatement';
+    readonly VariableDeclarationList: VariableDeclarationList;
   }
 
   // VariableDeclarationList :
@@ -1496,170 +1080,192 @@ export namespace ParseNode {
   // VariableDeclaration :
   //   BindingIdentifier Initializer?
   //   BindingPattern Initializer
-  export interface VariableDeclaration extends ParseNode {
-    type: 'VariableDeclaration';
-    BindingPattern?: BindingPattern;
-    BindingIdentifier?: BindingIdentifier;
-    Initializer: Initializer | null; // opt
+  export interface VariableDeclaration extends BaseParseNode {
+    readonly type: 'VariableDeclaration';
+    readonly BindingPattern?: BindingPattern;
+    readonly BindingIdentifier?: BindingIdentifier;
+    readonly Initializer: Initializer | null;
+  }
+
+  // BindingPattern :
+  //   ObjectBindingPattern
+  //   ArrayBindingPattern
+  export type BindingPattern =
+    | ObjectBindingPattern
+    | ArrayBindingPattern;
+
+  // ObjectBindingPattern :
+  //   `{` `}`
+  //   `{` BindingRestProperty `}`
+  //   `{` BindingPropertyList `}`
+  //   `{` BindingPropertyList `,` BindingRestProperty? `}`
+  export interface ObjectBindingPattern extends BaseParseNode {
+    readonly type: 'ObjectBindingPattern';
+    readonly BindingPropertyList: BindingPropertyList;
+    readonly BindingRestProperty?: BindingRestProperty;
+  }
+
+  // ArrayBindingPattern :
+  //   `[` Elision? BindingRestElement `]`
+  //   `[` BindingElementList `]`
+  //   `[` BindingElementList `,` Elision? BindingRestElement `]`
+  export interface ArrayBindingPattern extends BaseParseNode {
+    readonly type: 'ArrayBindingPattern';
+    readonly BindingElementList: BindingElementList;
+    readonly BindingRestElement: BindingRestElement;
+  }
+
+  // BindingRestProperty :
+  //  `...` BindingIdentifier
+  export interface BindingRestProperty extends BaseParseNode {
+    readonly type: 'BindingRestProperty';
+    readonly BindingIdentifier: BindingIdentifier;
+  }
+
+  // BindingPropertyList :
+  //   BindingProperty
+  //   BindingPropertyList BindingProperty
+  export type BindingPropertyList = BindingPropertyLike[];
+
+  // BindingElementList :
+  //   BindingElisionElement
+  //   BindingElementList `,` BindingElisionElement
+  export type BindingElementList = BindingElisionElement[];
+
+  // BindingElisionElement :
+  //   Elision? BindingElement
+  export type BindingElisionElement =
+    | BindingElementLike
+    | Elision;
+
+  // BindingProperty :
+  //   SingleNameBinding
+  //   PropertyName `:` BindingElement
+  export type BindingPropertyLike =
+    | BindingProperty
+    | SingleNameBinding;
+
+  // BindingProperty :
+  //   PropertyName `:` BindingElement
+  export interface BindingProperty extends BaseParseNode {
+    readonly type: 'BindingProperty';
+    readonly PropertyName: PropertyNameLike;
+    readonly BindingElement: BindingElementLike;
+  }
+
+  // BindingElement :
+  //   SingleNameBinding
+  //   BindingPattern Initializer?
+  export type BindingElementLike =
+    | BindingElement
+    | SingleNameBinding;
+
+  // BindingElement (partial) :
+  //   BindingPattern Initializer?
+  export interface BindingElement extends BaseParseNode {
+    readonly type: 'BindingElement';
+    readonly BindingPattern: BindingPattern;
+    readonly Initializer: Initializer | null;
+  }
+
+  // SingleNameBinding :
+  //   BindingIdentifier Initializer?
+  export interface SingleNameBinding extends BaseParseNode {
+    readonly type: 'SingleNameBinding';
+    readonly BindingIdentifier: BindingIdentifier;
+    readonly Initializer: Initializer | null;
+  }
+
+  // BindingRestElement :
+  //   `...` BindingIdentifier
+  //   `...` BindingPattern
+  export interface BindingRestElement extends BaseParseNode {
+    readonly type: 'BindingRestElement';
+    readonly BindingIdentifier?: BindingIdentifier;
+    readonly BindingPattern?: BindingPattern;
   }
 
   // EmptyStatement :
   //   `;`
-  export interface EmptyStatement extends ParseNode {
-    type: 'EmptyStatement';
+  export interface EmptyStatement extends BaseParseNode {
+    readonly type: 'EmptyStatement';
   }
 
   // ExpressionStatement :
   //   [lookahead != `{`, `function`, `async` [no LineTerminator here] `function`, `class`, `let` `[` ] Expression `;`
-  export interface ExpressionStatement extends ParseNode {
-    type: 'ExpressionStatement';
-    Expression: Expression;
+  export interface ExpressionStatement extends BaseParseNode {
+    readonly type: 'ExpressionStatement';
+    readonly Expression: Expression;
   }
 
   // IfStatement :
   //   `if` `(` Expression `)` Statement `else` Statement
   //   `if` `(` Expression `)` Statement [lookahead ≠ `else`]
-  export interface IfStatement extends ParseNode {
-    type: 'IfStatement';
-    Expression: Expression;
-    Statement_a: Statement;
-    Statement_b: Statement;
+  export interface IfStatement extends BaseParseNode {
+    readonly type: 'IfStatement';
+    readonly Expression: Expression;
+    readonly Statement_a: Statement;
+    readonly Statement_b: Statement;
   }
+
+  // IterationStatement :
+  //   DoWhileStatement
+  //   WhileStatement
+  //   ForStatement
+  //   ForInOfStatement
+  export type IterationStatement =
+    | DoWhileStatement
+    | WhileStatement
+    | ForStatement
+    | ForInOfStatement;
 
   // DoWhileStatement :
   //   `do` Statement `while` `(` Expression `)` `;`
-  export interface DoWhileStatement extends ParseNode {
-    type: 'DoWhileStatement';
-    Statement: Statement;
-    Expression: Expression;
+  export interface DoWhileStatement extends BaseParseNode {
+    readonly type: 'DoWhileStatement';
+    readonly Statement: Statement;
+    readonly Expression: Expression;
   }
 
   // WhileStatement :
   //   `while` `(` Expression `)` Statement
-  export interface WhileStatement extends ParseNode {
-    type: 'WhileStatement';
-    Expression: Expression;
-    Statement: Statement;
+  export interface WhileStatement extends BaseParseNode {
+    readonly type: 'WhileStatement';
+    readonly Expression: Expression;
+    readonly Statement: Statement;
   }
 
   // ForStatement :
   //   `for` `(` [lookahead != `let` `[`] Expression? `;` Expression? `;` Expression? `)` Statement
   //   `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
   //   `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
-  export interface ForStatement extends ParseNode {
-    type: 'ForStatement';
+  export interface ForStatement extends BaseParseNode {
+    readonly type: 'ForStatement';
 
-    /// / ForStatement : `for` `(` [lookahead != `let` `[`] Expression? `;` Expression? `;` Expression? `)` Statement
+    /// ForStatement : `for` `(` [lookahead != `let` `[`] Expression? `;` Expression? `;` Expression? `)` Statement
     // Expression_a?: Expression;
     // Expression_b?: Expression;
     // Expression_c?: Expression;
     // Statement: Statement;
 
-    /// / ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
+    /// ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
     // VariableDeclarationList: VariableDeclarationList;
     // Expression_a?: Expression;
     // Expression_b?: Expression;
     // Statement: Statement;
 
-    /// / ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+    /// ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
     // LexicalDeclaration?: LexicalDeclarationLike;
     // Expression_a?: Expression;
     // Expression_b?: Expression;
     // Statement: Statement;
 
-    VariableDeclarationList: VariableDeclarationList;
-    LexicalDeclaration?: LexicalDeclarationLike;
-    Expression_a?: Expression;
-    Expression_b?: Expression;
-    Expression_c?: Expression;
-    Statement: Statement;
-  }
-
-  // ForInOfStatement (partial) :
-  //   `for` `(` [lookahead != `let` `[`] LeftHandSideExpression `in` Expression `)` Statement
-  //   `for` `(` `var` ForBinding `in` Expression `)` Statement
-  //   `for` `(` ForDeclaration `in` Expression `)` Statement
-  export interface ForInStatement extends ParseNode {
-    type: 'ForInStatement';
-
-    /// / ForInStatement : `for` `(` [lookahead != `let` `[`] LeftHandSideExpression `in` Expression `)` Statement
-    // LeftHandSideExpression?: LeftHandSideExpression;
-    // Expression: Expression;
-    // Statement: Statement;
-
-    /// / ForInStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement
-    // ForBinding?: ForBinding;
-    // Expression: Expression;
-    // Statement: Statement;
-
-    /// / ForInStatement : `for` `(` ForDeclaration `in` Expression `)` Statement
-    // ForDeclaration?: ForDeclarationLike;
-    // Expression: Expression;
-    // Statement: Statement;
-
-    LeftHandSideExpression?: LeftHandSideExpression;
-    ForBinding?: ForBinding;
-    ForDeclaration?: ForDeclarationLike;
-    Expression: Expression;
-    Statement: Statement;
-  }
-
-  // ForInOfStatement (partial) :
-  //   `for` `(` [lookahead != { `let`, `async` `of` }] LeftHandSideExpression `of` AssignmentExpression `)` Statement
-  //   `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-  //   `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-  export interface ForOfStatement extends ParseNode {
-    type: 'ForOfStatement';
-
-    /// / ForOfStatement : `for` `(` [lookahead != { `let`, `async` `of` }] LeftHandSideExpression `of` AssignmentExpression `)` Statement
-    // LeftHandSideExpression?: LeftHandSideExpression;
-    // AssignmentExpression: AssignmentExpressionOrHigher;
-    // Statement: Statement;
-
-    /// / ForOfStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-    // ForBinding?: ForBinding;
-    // AssignmentExpression: AssignmentExpressionOrHigher;
-    // Statement: Statement;
-
-    /// / ForOfStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-    // ForDeclaration?: ForDeclarationLike;
-    // AssignmentExpression: AssignmentExpressionOrHigher;
-    // Statement: Statement;
-
-    LeftHandSideExpression?: LeftHandSideExpression;
-    ForDeclaration?: ForDeclarationLike;
-    ForBinding?: ForBinding;
-    AssignmentExpression: AssignmentExpressionOrHigher;
-    Statement: Statement;
-  }
-
-  // ForInOfStatement (partial) :
-  //   `for` `await` `(` [lookahead != `let`] LeftHandSideExpression `of` AssignmentExpression `)` Statement
-  //   `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-  //   `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-  export interface ForAwaitStatement extends ParseNode {
-    type: 'ForAwaitStatement';
-
-    /// / ForOfStatement : `for` `await` `(` [lookahead != `let`] LeftHandSideExpression `of` AssignmentExpression `)` Statement
-    // LeftHandSideExpression?: LeftHandSideExpression;
-    // AssignmentExpression: AssignmentExpressionOrHigher;
-    // Statement: Statement;
-
-    /// / ForOfStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-    // ForBinding?: ForBinding;
-    // AssignmentExpression: AssignmentExpressionOrHigher;
-    // Statement: Statement;
-
-    /// / ForOfStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-    // ForDeclaration?: ForDeclarationLike;
-    // AssignmentExpression: AssignmentExpressionOrHigher;
-    // Statement: Statement;
-
-    LeftHandSideExpression?: LeftHandSideExpression;
-    ForDeclaration?: ForDeclarationLike;
-    ForBinding?: ForBinding;
-    AssignmentExpression: AssignmentExpressionOrHigher;
-    Statement: Statement;
+    readonly VariableDeclarationList: VariableDeclarationList;
+    readonly LexicalDeclaration?: LexicalDeclarationLike;
+    readonly Expression_a?: Expression;
+    readonly Expression_b?: Expression;
+    readonly Expression_c?: Expression;
+    readonly Statement: Statement;
   }
 
   // ForInOfStatement :
@@ -1677,54 +1283,163 @@ export namespace ParseNode {
     | ForOfStatement
     | ForAwaitStatement;
 
-  // ForDeclaration :
-  //   LetOrConst ForBinding
-  export interface ForDeclaration extends ParseNode {
-    type: 'ForDeclaration';
-    LetOrConst: LetOrConst;
-    ForBinding: ForBinding;
+  // ForInOfStatement (partial) :
+  //   `for` `(` [lookahead != `let` `[`] LeftHandSideExpression `in` Expression `)` Statement
+  //   `for` `(` `var` ForBinding `in` Expression `)` Statement
+  //   `for` `(` ForDeclaration `in` Expression `)` Statement
+  export interface ForInStatement extends BaseParseNode {
+    readonly type: 'ForInStatement';
+
+    /// ForInStatement : `for` `(` [lookahead != `let` `[`] LeftHandSideExpression `in` Expression `)` Statement
+    // LeftHandSideExpression?: LeftHandSideExpression;
+    // Expression: Expression;
+    // Statement: Statement;
+
+    /// ForInStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement
+    // ForBinding?: ForBinding;
+    // Expression: Expression;
+    // Statement: Statement;
+
+    /// ForInStatement : `for` `(` ForDeclaration `in` Expression `)` Statement
+    // ForDeclaration?: ForDeclarationLike;
+    // Expression: Expression;
+    // Statement: Statement;
+
+    readonly LeftHandSideExpression?: LeftHandSideExpression;
+    readonly ForBinding?: ForBinding;
+    readonly ForDeclaration?: ForDeclarationLike;
+    readonly Expression: Expression;
+    readonly Statement: Statement;
   }
 
-  // NON-SPEC
+  // ForInOfStatement (partial) :
+  //   `for` `(` [lookahead != { `let`, `async` `of` }] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+  //   `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+  //   `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+  export interface ForOfStatement extends BaseParseNode {
+    readonly type: 'ForOfStatement';
+
+    /// ForOfStatement : `for` `(` [lookahead != { `let`, `async` `of` }] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+    // LeftHandSideExpression?: LeftHandSideExpression;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    /// ForOfStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+    // ForBinding?: ForBinding;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    /// ForOfStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+    // ForDeclaration?: ForDeclarationLike;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    readonly LeftHandSideExpression?: LeftHandSideExpression;
+    readonly ForDeclaration?: ForDeclarationLike;
+    readonly ForBinding?: ForBinding;
+    readonly AssignmentExpression: AssignmentExpressionOrHigher;
+    readonly Statement: Statement;
+  }
+
+  // ForInOfStatement (partial) :
+  //   `for` `await` `(` [lookahead != `let`] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+  //   `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+  //   `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+  export interface ForAwaitStatement extends BaseParseNode {
+    readonly type: 'ForAwaitStatement';
+
+    /// ForOfStatement : `for` `await` `(` [lookahead != `let`] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+    // LeftHandSideExpression?: LeftHandSideExpression;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    /// ForOfStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+    // ForBinding?: ForBinding;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    /// ForOfStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+    // ForDeclaration?: ForDeclarationLike;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    readonly LeftHandSideExpression?: LeftHandSideExpression;
+    readonly ForDeclaration?: ForDeclarationLike;
+    readonly ForBinding?: ForBinding;
+    readonly AssignmentExpression: AssignmentExpressionOrHigher;
+    readonly Statement: Statement;
+  }
+
+  // ForDeclaration :
+  //   LetOrConst ForBinding
   export type ForDeclarationLike =
     | ForDeclaration;
+
+  // ForDeclaration :
+  //   LetOrConst ForBinding
+  export interface ForDeclaration extends BaseParseNode {
+    readonly type: 'ForDeclaration';
+    readonly LetOrConst: LetOrConst;
+    readonly ForBinding: ForBinding;
+  }
 
   // ForBinding :
   //   BindingPattern
   //   BindingIdentifier
-  export interface ForBinding extends ParseNode {
-    type: 'ForBinding';
-    BindingIdentifier?: BindingIdentifier;
-    BindingPattern?: BindingPattern;
+  export interface ForBinding extends BaseParseNode {
+    readonly type: 'ForBinding';
+    readonly BindingIdentifier?: BindingIdentifier;
+    readonly BindingPattern?: BindingPattern;
   }
 
-  // IterationStatement :
-  //   DoWhileStatement
-  //   WhileStatement
-  //   ForStatement
-  //   ForInOfStatement
-  export type IterationStatement =
-    | DoWhileStatement
-    | WhileStatement
-    | ForStatement
-    | ForInOfStatement;
+  // ContinueStatement :
+  //   `continue` `;`
+  //   `continue` [no LineTerminator here] LabelIdentifier `;`
+  export interface ContinueStatement extends BaseParseNode {
+    readonly type: 'ContinueStatement';
+    readonly LabelIdentifier: LabelIdentifier | null;
+  }
+
+  // BreakStatement :
+  //   `break` `;`
+  //   `break` [no LineTerminator here] LabelIdentifier `;`
+  export interface BreakStatement extends BaseParseNode {
+    readonly type: 'BreakStatement';
+    readonly LabelIdentifier: LabelIdentifier | null;
+  }
+
+  // ReturnStatement :
+  //   `return` `;`
+  //   `return` [no LineTerminator here] Expression `;`
+  export interface ReturnStatement extends BaseParseNode {
+    readonly type: 'ReturnStatement';
+    readonly Expression: Expression | null;
+  }
+
+  // WithStatement :
+  //   `with` `(` Expression `)` Statement
+  export interface WithStatement extends BaseParseNode {
+    readonly type: 'WithStatement';
+    readonly Expression: Expression;
+    readonly Statement: Statement;
+  }
 
   // SwitchStatement :
   //   `switch` `(` Expression `)` CaseBlock
-  export interface SwitchStatement extends ParseNode {
-    type: 'SwitchStatement';
-    Expression: Expression;
-    CaseBlock: CaseBlock;
+  export interface SwitchStatement extends BaseParseNode {
+    readonly type: 'SwitchStatement';
+    readonly Expression: Expression;
+    readonly CaseBlock: CaseBlock;
   }
 
   // CaseBlock :
   //   `{` CaseClauses? `}`
   //   `{` CaseClauses? DefaultClause CaseClauses? `}`
-  export interface CaseBlock extends ParseNode {
-    type: 'CaseBlock';
-    CaseClauses_a?: CaseClauses;
-    DefaultClause?: DefaultClause;
-    CaseClauses_b?: CaseClauses;
+  export interface CaseBlock extends BaseParseNode {
+    readonly type: 'CaseBlock';
+    readonly CaseClauses_a?: CaseClauses;
+    readonly DefaultClause?: DefaultClause;
+    readonly CaseClauses_b?: CaseClauses;
   }
 
   // CaseClauses :
@@ -1734,81 +1449,50 @@ export namespace ParseNode {
 
   // CaseClause :
   //   `case` Expression `:` StatementList?
-  export interface CaseClause extends ParseNode {
-    type: 'CaseClause';
-    Expression: Expression;
-    StatementList: StatementList;
+  export interface CaseClause extends BaseParseNode {
+    readonly type: 'CaseClause';
+    readonly Expression: Expression;
+    readonly StatementList: StatementList;
   }
 
   // DefaultClause :
   //   `default` `:` StatementList?
-  export interface DefaultClause extends ParseNode {
-    type: 'DefaultClause';
-    StatementList: StatementList;
+  export interface DefaultClause extends BaseParseNode {
+    readonly type: 'DefaultClause';
+    readonly StatementList: StatementList;
   }
 
-  // BreakableStatement :
-  //   IterationStatement
-  //   SwitchStatement
-  export type BreakableStatement =
-    | IterationStatement
-    | SwitchStatement;
-
-  // ContinueStatement :
-  //   `continue` `;`
-  //   `continue` [no LineTerminator here] LabelIdentifier `;`
-  export interface ContinueStatement extends ParseNode {
-    type: 'ContinueStatement';
-    LabelIdentifier: LabelIdentifier | null;
+  // LabelledStatement :
+  //   LabelIdentifier `:` LabelledItem
+  export interface LabelledStatement extends BaseParseNode {
+    readonly type: 'LabelledStatement';
+    readonly LabelIdentifier: LabelIdentifier;
+    readonly LabelledItem: LabelledItem;
   }
 
-  // BreakStatement :
-  //   `break` `;`
-  //   `break` [no LineTerminator here] LabelIdentifier `;`
-  export interface BreakStatement extends ParseNode {
-    type: 'BreakStatement';
-    LabelIdentifier: LabelIdentifier | null;
-  }
-
-  // ReturnStatement :
-  //   `return` `;`
-  //   `return` [no LineTerminator here] Expression `;`
-  export interface ReturnStatement extends ParseNode {
-    type: 'ReturnStatement';
-    Expression: Expression | null;
-  }
-
-  // WithStatement :
-  //   `with` `(` Expression `)` Statement
-  export interface WithStatement extends ParseNode {
-    type: 'WithStatement';
-    Expression: Expression;
-    Statement: Statement;
-  }
-
-  // TODO: document
-  export interface LabelledStatement extends ParseNode {
-    type: 'LabelledStatement';
-    LabelIdentifier: LabelIdentifier;
-    LabelledItem: Statement;
-  }
+  // LabelledItem :
+  //   Statement
+  //   FunctionDeclaration
+  export type LabelledItem =
+    | Statement
+    | FunctionDeclaration; // SPEC QUESTION: why only |FunctionDeclaration| and not generators or async functions?
 
   // ThrowStatement :
   //   `throw` [no LineTerminator here] Expression `;`
-  export interface ThrowStatement extends ParseNode {
-    type: 'ThrowStatement';
-    Expression: Expression;
+  export interface ThrowStatement extends BaseParseNode {
+    readonly type: 'ThrowStatement';
+    readonly Expression: Expression;
   }
 
   // TryStatement :
   //   `try` Block Catch
   //   `try` Block Finally
   //   `try` Block Catch Finally
-  export interface TryStatement extends ParseNode {
-    type: 'TryStatement';
-    Block: Block;
-    Catch: Catch | null;
-    Finally: Finally | null;
+  export interface TryStatement extends BaseParseNode {
+    readonly type: 'TryStatement';
+    readonly Block: Block;
+    readonly Catch: Catch | null;
+    readonly Finally: Finally | null;
   }
 
   // Catch :
@@ -1818,10 +1502,10 @@ export namespace ParseNode {
   // CatchParameter :
   //   BindingIdentifier
   //   BindingPattern
-  export interface Catch extends ParseNode {
-    type: 'Catch';
-    CatchParameter: BindingPattern | BindingIdentifier | null;
-    Block: Block;
+  export interface Catch extends BaseParseNode {
+    readonly type: 'Catch';
+    readonly CatchParameter: CatchParameter | null;
+    readonly Block: Block;
   }
 
   // Finally :
@@ -1829,64 +1513,475 @@ export namespace ParseNode {
   export type Finally =
     | Block;
 
+  // CatchParameter :
+  //   BindingPattern
+  //   BindingIdentifier
+  export type CatchParameter =
+    | BindingPattern
+    | BindingIdentifier;
+
   // DebuggerStatement :
   //   `debugger` `;`
-  export interface DebuggerStatement extends ParseNode {
-    type: 'DebuggerStatement';
+  export interface DebuggerStatement extends BaseParseNode {
+    readonly type: 'DebuggerStatement';
   }
 
-  export type Statement =
-    | BlockStatement
-    | VariableStatement
-    | EmptyStatement
-    | ExpressionStatement
-    | IfStatement
-    | BreakableStatement
-    | ContinueStatement
-    | BreakStatement
-    | ReturnStatement
-    | WithStatement
-    | LabelledStatement
-    | ThrowStatement
-    | TryStatement
-    | DebuggerStatement;
-export type HoistableDeclaration =
+  // A.4 Functions and Classes
+  // https://tc39.es/ecma262/#sec-functions-and-classes
+
+  // UniqueFormalParameters :
+  //   FormalParameters
+  export type UniqueFormalParameters =
+    | FormalParameters;
+
+  // FormalParameters :
+  //   [empty]
+  //   FunctionRestParameter
+  //   FormalParameterList
+  //   FormalParameterList `,`
+  //   FormalParameterList `,` FunctionRestParameter
+  export type FormalParameters = FormalParametersElement[];
+
+  // NON-SPEC
+  export type FormalParametersElement = FormalParameterList[number] | FunctionRestParameter;
+
+  // FormalParameterList :
+  //   FormalParameter
+  //   FormalParameterList `,` FormalParameterList
+  export type FormalParameterList = FormalParameter[];
+
+  // FunctionRestParameter :
+  //   BindingRestElement
+  export type FunctionRestParameter =
+    | BindingRestElement;
+
+  // FormalParameter :
+  //   BindingElement
+  export type FormalParameter =
+    | BindingElementLike;
+
+  // NON-SPEC
+  export type FunctionLike =
+    | FunctionDeclarationLike
+    | FunctionExpressionLike;
+
+  // NON-SPEC
+  export type FunctionDeclarationLike =
     | FunctionDeclaration
     | GeneratorDeclaration
     | AsyncFunctionDeclaration
     | AsyncGeneratorDeclaration;
-export type Declaration =
-    | HoistableDeclaration
+
+  // NON-SPEC
+  export type FunctionExpressionLike =
+    | FunctionExpression
+    | GeneratorExpression
+    | AsyncFunctionExpression
+    | AsyncGeneratorExpression;
+
+  // NON-SPEC
+  export type FunctionBodyLike =
+    | FunctionBody
+    | GeneratorBody
+    | AsyncFunctionBody
+    | AsyncGeneratorBody;
+
+  // FunctionDeclaration :
+  //   `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+  //   [+Default] `function` `(` FormalParameters `)` `{` FunctionBody `}`
+  export interface FunctionDeclaration extends BaseParseNode {
+    readonly type: 'FunctionDeclaration';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly FormalParameters: FormalParameters;
+    readonly FunctionBody: FunctionBody;
+  }
+
+  // FunctionExpression :
+  //   `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+  export interface FunctionExpression extends BaseParseNode {
+    readonly type: 'FunctionExpression';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly FormalParameters: FormalParameters;
+    readonly FunctionBody: FunctionBody;
+  }
+
+  // FunctionBody :
+  //   FunctionStatementList
+  export interface FunctionBody extends BaseParseNode {
+    readonly type: 'FunctionBody';
+    readonly directives: string[];
+    readonly strict: boolean;
+    readonly FunctionStatementList: FunctionStatementList;
+  }
+
+  // FunctionStatementList :
+  //   StatementList
+  export type FunctionStatementList = StatementList;
+
+  // ArrowFunction :
+  //  ArrowParameters [no LineTerminator here] `=>` ConciseBody
+  export interface ArrowFunction extends BaseParseNode {
+    readonly type: 'ArrowFunction';
+    readonly ArrowParameters: ArrowParameters;
+    readonly ConciseBody: ConciseBodyOrHigher;
+  }
+
+  // ArrowParameters :
+  //   BindingIdentifier
+  //   CoverParenthesizedExpressionAndArrowParameterList
+  //
+  // CoverParenthesizedExpressionAndArrowParameterList refined as:
+  //   ArrowFormalParameters (refined) :
+  //    `(` UniqueFormalParameters `)`
+  export type ArrowParameters = ArrowFormalParameters;
+
+  // ConciseBody :
+  //   ExpressionBody
+  //   `{` FunctionBody `}`
+  export type ConciseBodyOrHigher =
+    | FunctionBody
+    | ConciseBody;
+
+  // ConciseBody (partial) :
+  //   ExpressionBody
+  export interface ConciseBody extends BaseParseNode {
+    readonly type: 'ConciseBody';
+    readonly directives?: undefined;
+    readonly ExpressionBody: ExpressionBody;
+  }
+
+  // ExpressionBody :
+  //   AssignmentExpression
+  export interface ExpressionBody extends BaseParseNode {
+    readonly type: 'ExpressionBody';
+    readonly AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // CoverParenthesizedExpressionAndArrowParameterList refined as:
+  //   ArrowFormalParameters :
+  //    `(` UniqueFormalParameters `)`
+  export type ArrowFormalParameters =
+    | UniqueFormalParameters;
+
+  // AsyncArrowFunction :
+  //   `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+  //   CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
+  //
+  // CoverCallExpressionAndAsyncArrowHead :
+  //   MemberExpression Arguments
+  //
+  // AsyncArrowHead (refined) :
+  //   `async` ArrowFormalParameters
+  export interface AsyncArrowFunction extends BaseParseNode {
+    readonly type: 'AsyncArrowFunction';
+    readonly ArrowParameters: ArrowParameters;
+    readonly AsyncConciseBody: AsyncConciseBodyLike;
+  }
+
+  // AsyncConciseBody :
+  //   ExpressionBody
+  //   `{` AsyncFunctionBody `}`
+  export type AsyncConciseBodyLike =
+    | AsyncConciseBody
+    | AsyncFunctionBody;
+
+  // AsyncConciseBody (partial) :
+  //   ExpressionBody
+  export interface AsyncConciseBody extends BaseParseNode {
+    readonly type: 'AsyncConciseBody';
+    readonly directives?: undefined;
+    readonly ExpressionBody: ExpressionBody;
+  }
+
+  // MethodDefinition :
+  //   ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
+  //   GeneratorMethod
+  //   AsyncMethod
+  //   AsyncGeneratorMethod
+  //   `get` ClassElementName `(` `)` `{` FunctionBody `}`
+  //   `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
+  export type MethodDefinitionLike =
+    | MethodDefinition
+    | GeneratorMethod
+    | AsyncMethod
+    | AsyncGeneratorMethod;
+
+  // MethodDefinition (partial) :
+  //   ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
+  //   `get` ClassElementName `(` `)` `{` FunctionBody `}`
+  //   `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
+  export interface MethodDefinition extends BaseParseNode {
+    readonly type: 'MethodDefinition';
+    readonly static?: boolean;
+    readonly ClassElementName: ClassElementName;
+    readonly PropertySetParameterList: PropertySetParameterList | null;
+    readonly UniqueFormalParameters: UniqueFormalParameters | null;
+    readonly FunctionBody: FunctionBody;
+  }
+
+  // PropertySetParameterList :
+  //   FormalParameter
+  export type PropertySetParameterList = [FormalParameter];
+
+  // GeneratorDeclaration :
+  //   `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+  //   [+Default] `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+  export interface GeneratorDeclaration extends BaseParseNode {
+    readonly type: 'GeneratorDeclaration';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly FormalParameters: FormalParameters;
+    readonly GeneratorBody: GeneratorBody;
+  }
+
+  // GeneratorExpression :
+  //   `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
+  export interface GeneratorExpression extends BaseParseNode {
+    readonly type: 'GeneratorExpression';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly FormalParameters: FormalParameters;
+    readonly GeneratorBody: GeneratorBody;
+  }
+
+  // GeneratorMethod :
+  //   `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`
+  export interface GeneratorMethod extends BaseParseNode {
+    readonly type: 'GeneratorMethod';
+    readonly static?: boolean;
+    readonly ClassElementName: ClassElementName;
+    readonly PropertySetParameterList: null;
+    readonly UniqueFormalParameters: UniqueFormalParameters;
+    readonly GeneratorBody: GeneratorBody;
+  }
+
+  // GeneratorBody :
+  //   FunctionBody
+  export interface GeneratorBody extends BaseParseNode {
+    readonly type: 'GeneratorBody';
+    readonly directives: string[];
+    readonly strict: boolean;
+    readonly FunctionStatementList: FunctionStatementList;
+  }
+
+  // YieldExpression :
+  //   `yield`
+  //   `yield` [no LineTerminator here] AssignmentExpression
+  //   `yield` [no LineTerminator here] `*` AssignmentExpression
+  export interface YieldExpression extends BaseParseNode {
+    readonly type: 'YieldExpression';
+    readonly hasStar: boolean;
+    readonly AssignmentExpression: AssignmentExpressionOrHigher | null;
+  }
+
+  // AsyncGeneratorDeclaration :
+  //   `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+  //   [+Default] `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+  export interface AsyncGeneratorDeclaration extends BaseParseNode {
+    readonly type: 'AsyncGeneratorDeclaration';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly FormalParameters: FormalParameters;
+    readonly AsyncGeneratorBody: AsyncGeneratorBody;
+  }
+
+  // AsyncGeneratorExpression :
+  //   `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+  export interface AsyncGeneratorExpression extends BaseParseNode {
+    readonly type: 'AsyncGeneratorExpression';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly FormalParameters: FormalParameters;
+    readonly AsyncGeneratorBody: AsyncGeneratorBody;
+  }
+
+  // AsyncGeneratorMethod :
+  //   `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
+  export interface AsyncGeneratorMethod extends BaseParseNode {
+    readonly type: 'AsyncGeneratorMethod';
+    readonly static?: boolean;
+    readonly ClassElementName: ClassElementName;
+    readonly PropertySetParameterList: null;
+    readonly UniqueFormalParameters: UniqueFormalParameters;
+    readonly AsyncGeneratorBody: AsyncGeneratorBody;
+  }
+
+  // AsyncGeneratorBody :
+  //   FunctionBody
+  export interface AsyncGeneratorBody extends BaseParseNode {
+    readonly type: 'AsyncGeneratorBody';
+    readonly directives: string[];
+    readonly strict: boolean;
+    readonly FunctionStatementList: FunctionStatementList;
+  }
+
+  // AsyncFunctionDeclaration :
+  //   `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncBody `}`
+  //   [+Default] `async` `function` `*` `(` FormalParameters `)` `{` AsyncBody `}`
+  export interface AsyncFunctionDeclaration extends BaseParseNode {
+    readonly type: 'AsyncFunctionDeclaration';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly FormalParameters: FormalParameters;
+    readonly AsyncBody: AsyncFunctionBody;
+  }
+
+  // AsyncFunctionExpression :
+  //   `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncBody `}`
+  export interface AsyncFunctionExpression extends BaseParseNode {
+    readonly type: 'AsyncFunctionExpression';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly FormalParameters: FormalParameters;
+    readonly AsyncBody: AsyncFunctionBody;
+  }
+
+  // AsyncMethod :
+  //   `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncBody `}`
+  export interface AsyncMethod extends BaseParseNode {
+    readonly type: 'AsyncMethod';
+    readonly static?: boolean;
+    readonly ClassElementName: ClassElementName;
+    readonly PropertySetParameterList: null;
+    readonly UniqueFormalParameters: UniqueFormalParameters;
+    readonly AsyncBody: AsyncFunctionBody;
+  }
+
+  // AsyncBody :
+  //   FunctionBody
+  export interface AsyncFunctionBody extends BaseParseNode {
+    readonly type: 'AsyncFunctionBody';
+    readonly directives: string[];
+    readonly strict: boolean;
+    readonly FunctionStatementList: FunctionStatementList;
+  }
+
+  // AwaitExpression : `await` UnaryExpression
+  export interface AwaitExpression extends BaseParseNode {
+    readonly type: 'AwaitExpression';
+    readonly UnaryExpression: UnaryExpressionOrHigher;
+  }
+
+  // pending
+
+  // NON-SPEC
+  export type ClassLike =
     | ClassDeclaration
-    | LexicalDeclarationLike;
+    | ClassExpression;
+
+  // ClassDeclaration :
+  //   `class` BindingIdentifier ClassTail
+  //   [+Default] `class` ClassTail
+  export interface ClassDeclaration extends BaseParseNode {
+    readonly type: 'ClassDeclaration';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly ClassTail: ClassTail;
+  }
+
+  // ClassExpression :
+  //   `class` BindingIdentifier? ClassTail
+  export interface ClassExpression extends BaseParseNode {
+    readonly type: 'ClassExpression';
+    readonly BindingIdentifier: BindingIdentifier | null;
+    readonly ClassTail: ClassTail;
+  }
+
+  // ClassTail :
+  //   ClassHeritage? `{` ClassBody? `}`
+  export interface ClassTail extends BaseParseNode {
+    readonly type: 'ClassTail';
+    readonly ClassHeritage: ClassHeritage | null;
+    readonly ClassBody: ClassBody | null;
+  }
+
+  // ClassHeritage :
+  //   `extends` LeftHandSideExpression
+  export type ClassHeritage =
+    | LeftHandSideExpression;
+
+  // ClassBody :
+  //   ClassElementList
+  export type ClassBody =
+    | ClassElementList;
+
+  // ClassElementList :
+  //   ClassElement
+  //   ClassElementList ClassElement
+  export type ClassElementList = ClassElement[];
+
+  // ClassElement :
+  //   MethodDefinition
+  //   `static` MethodDefinition
+  //   FieldDefinition `;`
+  //   `static` FieldDefinition `;`
+  //   ClassStaticBlock
+  //   `;`
+  export type ClassElement =
+    | MethodDefinitionLike
+    | FieldDefinition
+    | ClassStaticBlock;
+
+  // FieldDefinition :
+  //   ClassElementName Initializer?
+  export interface FieldDefinition extends BaseParseNode {
+    readonly type: 'FieldDefinition';
+    readonly static?: boolean;
+    readonly ClassElementName: ClassElementName;
+    readonly Initializer: Initializer | null;
+  }
+
+  // ClassElementName :
+  //   PropertyName
+  //   PrivateIdentifier
+  export type ClassElementName =
+    | PropertyNameLike
+    | PrivateIdentifier;
+
+  // ClassStaticBlock :
+  //   `static` `{` ClassStaticBlockBody `}`
+  export interface ClassStaticBlock extends BaseParseNode {
+    readonly type: 'ClassStaticBlock';
+    readonly static: true;
+    readonly ClassStaticBlockBody: ClassStaticBlockBody;
+  }
+
+  // ClassStaticBlockBody :
+  //   ClassStaticBlockStatementList
+  export interface ClassStaticBlockBody extends BaseParseNode {
+    readonly type: 'ClassStaticBlockBody';
+    readonly ClassStaticBlockStatementList: ClassStaticBlockStatementList;
+  }
+
+  // ClassStaticBlockStatementList :
+  //   StatementList?
+  export type ClassStaticBlockStatementList =
+    | StatementList;
+
+
+  // A.5 Scripts and Modules
+  // https://tc39.es/ecma262/#sec-scripts-and-modules
 
   // Script :
   //   ScriptBody?
-  export interface Script extends ParseNode {
-    type: 'Script';
-    ScriptBody: ScriptBody | null;
+  export interface Script extends BaseParseNode {
+    readonly type: 'Script';
+    readonly ScriptBody: ScriptBody | null;
   }
 
   // ScriptBody :
   //   StatementList
-  export interface ScriptBody extends ParseNode {
-    type: 'ScriptBody';
-    StatementList: StatementList;
+  export interface ScriptBody extends BaseParseNode {
+    readonly type: 'ScriptBody';
+    readonly StatementList: StatementList;
   }
 
   // Module :
   //   ModuleBody?
-  export interface Module extends ParseNode {
-    type: 'Module';
-    ModuleBody: ModuleBody | null;
-    hasTopLevelAwait: boolean;
+  export interface Module extends BaseParseNode {
+    readonly type: 'Module';
+    readonly ModuleBody: ModuleBody | null;
+    readonly hasTopLevelAwait: boolean;
   }
 
   // ModuleBody :
   //   ModuleItemList
-  export interface ModuleBody extends ParseNode {
-    type: 'ModuleBody';
-    ModuleItemList: ModuleItemList;
+  export interface ModuleBody extends BaseParseNode {
+    readonly type: 'ModuleBody';
+    readonly ModuleItemList: ModuleItemList;
   }
 
   // ModuleItemList :
@@ -1913,22 +2008,12 @@ export type Declaration =
   // ImportDeclaration :
   //   `import` ImportClause FromClause `;`
   //   `import` ModuleSpecifier `;`
-  export interface ImportDeclaration extends ParseNode {
-    type: 'ImportDeclaration';
-    ModuleSpecifier?: PrimaryExpression;
-    ImportClause?: ImportClause;
-    FromClause?: FromClause;
+  export interface ImportDeclaration extends BaseParseNode {
+    readonly type: 'ImportDeclaration';
+    readonly ModuleSpecifier?: PrimaryExpression;
+    readonly ImportClause?: ImportClause;
+    readonly FromClause?: FromClause;
   }
-
-  // FromClause :
-  //   `from` ModuleSpecifier
-  export type FromClause =
-    | ModuleSpecifier;
-
-  // ModuleSpecifier :
-  //   StringLiteral
-  export type ModuleSpecifier =
-    | StringLiteral;
 
   // ImportClause :
   //   ImportedDefaultBinding
@@ -1936,40 +2021,40 @@ export type Declaration =
   //   NamedImports
   //   ImportedDefaultBinding `,` NameSpaceImport
   //   ImportedDefaultBinding `,` NamedImports
-  export interface ImportClause extends ParseNode {
-    type: 'ImportClause';
-    ImportedDefaultBinding?: ImportedDefaultBinding;
-    NameSpaceImport?: NameSpaceImport;
-    NamedImports?: NamedImports;
+  export interface ImportClause extends BaseParseNode {
+    readonly type: 'ImportClause';
+    readonly ImportedDefaultBinding?: ImportedDefaultBinding;
+    readonly NameSpaceImport?: NameSpaceImport;
+    readonly NamedImports?: NamedImports;
   }
 
   // ImportedDefaultBinding :
   //   ImportedBinding
-  export interface ImportedDefaultBinding extends ParseNode {
-    type: 'ImportedDefaultBinding';
-    ImportedBinding: ImportedBinding;
+  export interface ImportedDefaultBinding extends BaseParseNode {
+    readonly type: 'ImportedDefaultBinding';
+    readonly ImportedBinding: ImportedBinding;
   }
-
-  // ImportedBinding :
-  //   BindingIdentifier
-  export type ImportedBinding =
-    | BindingIdentifier;
 
   // NameSpaceImport :
   //   `*` `as` ImportedBinding
-  export interface NameSpaceImport extends ParseNode {
-    type: 'NameSpaceImport';
-    ImportedBinding: ImportedBinding;
+  export interface NameSpaceImport extends BaseParseNode {
+    readonly type: 'NameSpaceImport';
+    readonly ImportedBinding: ImportedBinding;
   }
 
   // NamedImports :
   //   `{` `}`
   //   `{` ImportsList `}`
   //   `{` ImportsList `,` `}`
-  export interface NamedImports extends ParseNode {
-    type: 'NamedImports';
-    ImportsList: ImportsList;
+  export interface NamedImports extends BaseParseNode {
+    readonly type: 'NamedImports';
+    readonly ImportsList: ImportsList;
   }
+
+  // FromClause :
+  //   `from` ModuleSpecifier
+  export type FromClause =
+    | ModuleSpecifier;
 
   // ImportsList :
   //   ImportSpecifier
@@ -1979,11 +2064,21 @@ export type Declaration =
   // ImportSpecifier :
   //   ImportedBinding
   //   ModuleExportName `as` ImportedBinding
-  export interface ImportSpecifier extends ParseNode {
-    type: 'ImportSpecifier';
-    ModuleExportName?: ModuleExportName;
-    ImportedBinding: ImportedBinding;
+  export interface ImportSpecifier extends BaseParseNode {
+    readonly type: 'ImportSpecifier';
+    readonly ModuleExportName?: ModuleExportName;
+    readonly ImportedBinding: ImportedBinding;
   }
+
+  // ModuleSpecifier :
+  //   StringLiteral
+  export type ModuleSpecifier =
+    | StringLiteral;
+
+  // ImportedBinding :
+  //   BindingIdentifier
+  export type ImportedBinding =
+    | BindingIdentifier;
 
   // ExportDeclaration :
   //   `export` ExportFromClause FromClause `;`
@@ -1993,25 +2088,17 @@ export type Declaration =
   //   `export` `default` HoistableDeclaration
   //   `export` `default` ClassDeclaration
   //   `export` `default` AssignmentExpression `;`
-  export interface ExportDeclaration extends ParseNode {
-    type: 'ExportDeclaration';
-    default: boolean;
-    HoistableDeclaration?: HoistableDeclaration;
-    ClassDeclaration?: ClassDeclaration;
-    AssignmentExpression?: AssignmentExpressionOrHigher;
-    Declaration?: Declaration;
-    VariableStatement?: VariableStatement;
-    ExportFromClause?: ExportFromClauseLike;
-    FromClause?: FromClause;
-    NamedExports?: NamedExports;
-  }
-
-  // ExportFromClause (partial) :
-  //   `*`
-  //   `*` as ModuleExportName
-  export interface ExportFromClause extends ParseNode {
-    type: 'ExportFromClause';
-    ModuleExportName?: ModuleExportName;
+  export interface ExportDeclaration extends BaseParseNode {
+    readonly type: 'ExportDeclaration';
+    readonly default: boolean;
+    readonly HoistableDeclaration?: HoistableDeclaration;
+    readonly ClassDeclaration?: ClassDeclaration;
+    readonly AssignmentExpression?: AssignmentExpressionOrHigher;
+    readonly Declaration?: Declaration;
+    readonly VariableStatement?: VariableStatement;
+    readonly ExportFromClause?: ExportFromClauseLike;
+    readonly FromClause?: FromClause;
+    readonly NamedExports?: NamedExports;
   }
 
   // ExportFromClause :
@@ -2022,13 +2109,21 @@ export type Declaration =
     | NamedExports
     | ExportFromClause;
 
+  // ExportFromClause (partial) :
+  //   `*`
+  //   `*` as ModuleExportName
+  export interface ExportFromClause extends BaseParseNode {
+    readonly type: 'ExportFromClause';
+    readonly ModuleExportName?: ModuleExportName;
+  }
+
   // NamedExports :
   //   `{` `}`
   //   `{` ExportsList `}`
   //   `{` ExportsList `,` `}`
-  export interface NamedExports extends ParseNode {
-    type: 'NamedExports';
-    ExportsList: ExportsList;
+  export interface NamedExports extends BaseParseNode {
+    readonly type: 'NamedExports';
+    readonly ExportsList: ExportsList;
   }
 
   // ExportsList :
@@ -2039,11 +2134,14 @@ export type Declaration =
   // ExportSpecifier :
   //   ModuleExportName
   //   ModuleExportName `as` ModuleExportName
-  export interface ExportSpecifier extends ParseNode {
-    type: 'ExportSpecifier';
-    localName: ModuleExportName;
-    exportName: ModuleExportName;
+  export interface ExportSpecifier extends BaseParseNode {
+    readonly type: 'ExportSpecifier';
+    readonly localName: ModuleExportName;
+    readonly exportName: ModuleExportName;
   }
+
+  // Helpers
+  // NON-SPEC
 
   // Gets all keys of all constituents of a union
   type AllKeysOf<T> = T extends unknown ? keyof T : never;
@@ -2053,30 +2151,176 @@ export type Declaration =
 
   // NON-SPEC
   /**
-   * Used internally to describe a node that is still being parsed. Unfinished nodes may not yet be fully defined.
+   * Used internally to describe a node that is still in the process of being parsed. Unfinished nodes may not yet be
+   * fully defined.
    */
-  export type Unfinished<T extends ParseNode> = (
+  export type Unfinished<T extends ParseNode = ParseNode> = (
     // An unfinished node...
 
-    // ...includes all properties of ParseNode except `type`
-    & Pick<ParseNode, 'location' | 'strict' | 'sourceText'>
+    // ...includes all properties of BaseParseNode
+    & {
+      type?: T['type'] & ParseNode['type'];
+      location: {
+        startIndex: number;
+        endIndex: number;
+        start: { line: number, column: number };
+        end: { line: number, column: number };
+      };
+      strict: boolean;
+      sourceText: () => string;
+    }
 
     // ...includes all properties of all potential types, with each property marked as optional
-    & { [K in Exclude<AllKeysOf<T>, 'location' | 'strict' | 'sourceText'>]?: AllValuesOf<T, K>; }
-
-    // ...includes a type-only cache of the potential nodes it represents. The finished type will be extracted from
-    //    this cache.
-    & { [K in typeof kPotentialNodes]: T }
+    & { -readonly [K in Exclude<AllKeysOf<T>, 'location' | 'strict' | 'sourceText'>]?: AllValuesOf<T, K>; }
   );
 
   // NON-SPEC
   /**
    * Used internally to indicate a node that has finished parsing.
    */
-  export type Finished<T extends ParseNode | Unfinished<ParseNode>, K extends T['type']> =
-    T extends Unfinished<ParseNode> ? Extract<T[typeof kPotentialNodes], { type: K }> :
+  export type Finished<T extends BaseParseNode | Unfinished<ParseNode>, K extends T['type'] & ParseNode['type']> =
+    T extends Unfinished<ParseNode> ? Extract<ParseNodesByType[K], T> :
     T;
 }
 
-// This value does not exist at runtime. Only its type is used to stash additional type information on a `ParseNode.Unfinished` type.
-declare const kPotentialNodes: unique symbol;
+export type ParseNode =
+  | ParseNode.PrivateIdentifier
+  | ParseNode.IdentifierName
+  | ParseNode.IdentifierReference
+  | ParseNode.BindingIdentifier
+  | ParseNode.LabelIdentifier
+  | ParseNode.PropertyName
+  | ParseNode.ThisExpression
+  | ParseNode.NullLiteral
+  | ParseNode.BooleanLiteral
+  | ParseNode.NumericLiteral
+  | ParseNode.StringLiteral
+  | ParseNode.Elision
+  | ParseNode.ArrayLiteral
+  | ParseNode.SpreadElement
+  | ParseNode.ObjectLiteral
+  | ParseNode.PropertyDefinition
+  | ParseNode.CoverInitializedName
+  | ParseNode.MethodDefinition
+  | ParseNode.FunctionDeclaration
+  | ParseNode.FunctionExpression
+  | ParseNode.FunctionBody
+  | ParseNode.ArrowFunction
+  | ParseNode.ExpressionBody
+  | ParseNode.ConciseBody
+  | ParseNode.GeneratorDeclaration
+  | ParseNode.GeneratorExpression
+  | ParseNode.GeneratorMethod
+  | ParseNode.GeneratorBody
+  | ParseNode.YieldExpression
+  | ParseNode.AsyncGeneratorDeclaration
+  | ParseNode.AsyncGeneratorExpression
+  | ParseNode.AsyncGeneratorMethod
+  | ParseNode.AsyncGeneratorBody
+  | ParseNode.ClassDeclaration
+  | ParseNode.ClassExpression
+  | ParseNode.ClassTail
+  | ParseNode.FieldDefinition
+  | ParseNode.ClassStaticBlock
+  | ParseNode.ClassStaticBlockBody
+  | ParseNode.AsyncFunctionDeclaration
+  | ParseNode.AsyncFunctionExpression
+  | ParseNode.AsyncMethod
+  | ParseNode.AsyncFunctionBody
+  | ParseNode.AsyncArrowFunction
+  | ParseNode.AsyncConciseBody
+  | ParseNode.RegularExpressionLiteral
+  | ParseNode.CoverParenthesizedExpressionAndArrowParameterList
+  | ParseNode.ParenthesizedExpression
+  | ParseNode.SuperProperty
+  | ParseNode.SuperProperty
+  | ParseNode.NewTarget
+  | ParseNode.ImportMeta
+  | ParseNode.MemberExpression
+  | ParseNode.NewExpression
+  | ParseNode.SuperCall
+  | ParseNode.ImportCall
+  | ParseNode.CallExpression
+  | ParseNode.TemplateLiteral
+  | ParseNode.TaggedTemplateExpression
+  | ParseNode.OptionalExpression
+  | ParseNode.OptionalChain
+  | ParseNode.AssignmentRestElement
+  | ParseNode.UpdateExpression
+  | ParseNode.AwaitExpression
+  | ParseNode.UnaryExpression
+  | ParseNode.ExponentiationExpression
+  | ParseNode.MultiplicativeExpression
+  | ParseNode.AdditiveExpression
+  | ParseNode.ShiftExpression
+  | ParseNode.RelationalExpression
+  | ParseNode.EqualityExpression
+  | ParseNode.BitwiseANDExpression
+  | ParseNode.BitwiseXORExpression
+  | ParseNode.BitwiseORExpression
+  | ParseNode.LogicalANDExpression
+  | ParseNode.LogicalORExpression
+  | ParseNode.CoalesceExpression
+  | ParseNode.ConditionalExpression
+  | ParseNode.AssignmentExpression
+  | ParseNode.CommaOperator
+  | ParseNode.LexicalDeclaration
+  | ParseNode.LexicalBinding
+  | ParseNode.ObjectBindingPattern
+  | ParseNode.ArrayBindingPattern
+  | ParseNode.BindingRestProperty
+  | ParseNode.BindingProperty
+  | ParseNode.BindingRestElement
+  | ParseNode.BindingElement
+  | ParseNode.SingleNameBinding
+  | ParseNode.Block
+  | ParseNode.VariableStatement
+  | ParseNode.VariableDeclaration
+  | ParseNode.EmptyStatement
+  | ParseNode.ExpressionStatement
+  | ParseNode.IfStatement
+  | ParseNode.DoWhileStatement
+  | ParseNode.WhileStatement
+  | ParseNode.ForStatement
+  | ParseNode.ForInStatement
+  | ParseNode.ForOfStatement
+  | ParseNode.ForDeclaration
+  | ParseNode.ForBinding
+  | ParseNode.ForAwaitStatement
+  | ParseNode.SwitchStatement
+  | ParseNode.CaseBlock
+  | ParseNode.CaseClause
+  | ParseNode.DefaultClause
+  | ParseNode.ContinueStatement
+  | ParseNode.BreakStatement
+  | ParseNode.ReturnStatement
+  | ParseNode.WithStatement
+  | ParseNode.LabelledStatement
+  | ParseNode.ThrowStatement
+  | ParseNode.TryStatement
+  | ParseNode.Catch
+  | ParseNode.DebuggerStatement
+  | ParseNode.ImportDeclaration
+  | ParseNode.ImportClause
+  | ParseNode.ImportedDefaultBinding
+  | ParseNode.NameSpaceImport
+  | ParseNode.NamedImports
+  | ParseNode.ImportSpecifier
+  | ParseNode.ExportDeclaration
+  | ParseNode.ExportFromClause
+  | ParseNode.NamedExports
+  | ParseNode.ExportSpecifier
+  | ParseNode.Script
+  | ParseNode.ScriptBody
+  | ParseNode.Module
+  | ParseNode.ModuleBody;
+
+/**
+ * A type that contains a mapping of {@link ParseNode} type names to their corresponding {@link ParseNode} type.
+ *
+ * You can use `ParseNodesByType[T]` instead of a conditional type like `Extract<ParseNode, { type: T }>` which is often
+ * more expensive and can complicate assignability checks.
+ */
+export type ParseNodesByType = {
+  [N in ParseNode as N['type']]: N;
+};

--- a/src/parser/ParseNode.mts
+++ b/src/parser/ParseNode.mts
@@ -719,6 +719,7 @@ export namespace ParseNode {
   //   RelationalExpression `>=` ShiftExpression
   //   RelationalExpression `instanceof` ShiftExpression
   //   RelationalExpression `in` ShiftExpression
+  //   PrivateIdentifier `in` ShiftExpression
   export interface RelationalExpression extends BaseParseNode {
     readonly type: 'RelationalExpression';
     readonly operator: '<' | '>' | '<=' | '>=' | 'instanceof' | 'in';

--- a/src/parser/ParseNode.mts
+++ b/src/parser/ParseNode.mts
@@ -1,0 +1,2082 @@
+import type { ArrowInfo } from './Scope.mjs';
+
+export interface Position {
+  line: number;
+  column: number;
+}
+
+export interface Location {
+  startIndex: number;
+  endIndex: number;
+  start: Position;
+  end: Position;
+}
+
+export interface ParseNode {
+  type: string;
+  location: Location;
+  strict: boolean;
+  sourceText: () => string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace ParseNode {
+  export interface PrivateIdentifier extends ParseNode {
+    type: 'PrivateIdentifier';
+    name: string;
+  }
+
+  export interface IdentifierName extends ParseNode {
+    type: 'IdentifierName';
+    name: string;
+  }
+
+  export interface IdentifierReference extends ParseNode {
+    type: 'IdentifierReference';
+    escaped: boolean;
+    name: string;
+  }
+
+  export interface BindingIdentifier extends ParseNode {
+    type: 'BindingIdentifier';
+    name: string;
+  }
+
+  export interface LabelIdentifier extends ParseNode {
+    type: 'LabelIdentifier';
+    name: string;
+  }
+
+  // PropertyName : ComputedPropertyName
+  // ComputedPropertyName : `[` AssignmentExpression `]`
+  export interface PropertyName extends ParseNode {
+    type: 'PropertyName';
+    ComputedPropertyName: AssignmentExpressionOrHigher;
+  }
+
+  // PropertyName :
+  //   LiteralPropertyName
+  //   ComputedPropertyName
+  // LiteralPropertyName :
+  //   IdentifierName
+  //   StringLiteral
+  //   NumericLiteral
+  // ComputedPropertyName :
+  //   `[` AssignmentExpression `]`
+  export type PropertyNameLike =
+    | PropertyName
+    | StringLiteral
+    | NumericLiteral
+    | IdentifierName;
+
+  // ClassElementName :
+  //   PropertyName
+  //   PrivateIdentifier
+  export type ClassElementName =
+    | PropertyNameLike
+    | PrivateIdentifier;
+
+  // PrimaryExpression (partial) :
+  //   `this`
+  export interface ThisExpression extends ParseNode {
+    type: 'ThisExpression';
+  }
+
+  // NullLiteral :
+  //   `null`
+  export interface NullLiteral extends ParseNode {
+    type: 'NullLiteral';
+  }
+
+  // BooleanLiteral :
+  //   `true`
+  //   `false`
+  export interface BooleanLiteral extends ParseNode {
+    type: 'BooleanLiteral';
+    value: boolean;
+  }
+
+  export interface NumericLiteral extends ParseNode {
+    type: 'NumericLiteral';
+    value: number | bigint;
+  }
+
+  export interface StringLiteral extends ParseNode {
+    type: 'StringLiteral';
+    value: string;
+  }
+
+  // Literal :
+  //   NullLiteral
+  //   BooleanLiteral
+  //   NumericLiteral
+  //   StringLiteral
+  export type Literal =
+    | NullLiteral
+    | BooleanLiteral
+    | NumericLiteral
+    | StringLiteral;
+
+  // Elision :
+  //   `,`
+  //   Elision `,`
+  export interface Elision extends ParseNode {
+    type: 'Elision';
+  }
+
+  // ArrayLiteral :
+  //   `[` `]`
+  //   `[` Elision `]`
+  //   `[` ElementList `]`
+  //   `[` ElementList `,` `]`
+  //   `[` ElementList `,` Elision `]`
+  export interface ArrayLiteral extends ParseNode {
+    type: 'ArrayLiteral';
+    ElementList: ElementList;
+    hasTrailingComma: boolean;
+  }
+
+  // SpreadElement :
+  // `...` AssignmentExpression
+  export interface SpreadElement extends ParseNode {
+    type: 'SpreadElement';
+    AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // ElementList :
+  //   Elision? AssignmentExpression
+  //   Elision? SpreadElement
+  //   ElementList `,` Elision? AssignmentExpression
+  //   ElementList `,` Elision? SpreadElement
+  export type ElementList = ElementListElement[];
+
+  // ElementList :
+  //   Elision? AssignmentExpression
+  //   Elision? SpreadElement
+  //   ElementList `,` Elision? AssignmentExpression
+  //   ElementList `,` Elision? SpreadElement
+  export type ElementListElement =
+    | AssignmentExpressionOrHigher
+    | SpreadElement
+    | Elision;
+
+  // ObjectLiteral :
+  //   `{` `}`
+  //   `{` PropertyDefinitionList `}`
+  //   `{` PropertyDefinitionList `,` `}`
+  export interface ObjectLiteral extends ParseNode {
+    type: 'ObjectLiteral';
+    PropertyDefinitionList: PropertyDefinitionList;
+  }
+
+  // PropertyDefinition (partial) :
+  //   PropertyName `:` AssignmentExpression
+  //   `...` AssignmentExpression
+  export interface PropertyDefinition extends ParseNode {
+    type: 'PropertyDefinition';
+    PropertyName: PropertyNameLike | null;
+    AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // CoverInitializedName :
+  //   IdentifierReference Initializer
+  export interface CoverInitializedName extends ParseNode {
+    type: 'CoverInitializedName';
+    IdentifierReference: IdentifierReference;
+    Initializer: Initializer | null; // opt
+  }
+
+  // MethodDefinition (partial) :
+  //   ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
+  //   `get` ClassElementName `(` `)` `{` FunctionBody `}`
+  //   `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
+  export interface MethodDefinition extends ParseNode {
+    type: 'MethodDefinition';
+    static?: boolean;
+    ClassElementName: ClassElementName;
+    PropertySetParameterList: [FormalParameter] | null;
+    UniqueFormalParameters: UniqueFormalParameters | null;
+    FunctionBody: FunctionBody;
+  }
+
+  // NON-SPEC
+  export type MethodLike =
+    | MethodDefinition
+    | AsyncMethod
+    | GeneratorMethod
+    | AsyncGeneratorMethod;
+
+  // UniqueFormalParameters :
+  //   FormalParameters
+  export type UniqueFormalParameters =
+    | FormalParameters;
+
+  // FormalParameters :
+  //   [empty]
+  //   FunctionRestParameter
+  //   FormalParameterList
+  //   FormalParameterList `,`
+  //   FormalParameterList `,` FunctionRestParameter
+  export type FormalParameters = FormalParametersElement[];
+
+  // NON-SPEC
+  export type FormalParametersElement = FunctionRestParameter | FormalParameter;
+
+  // FunctionRestParameter :
+  //   BindingRestElement
+  export type FunctionRestParameter =
+    | BindingRestElement;
+
+  // FormalParameter :
+  //   BindingElement
+  export type FormalParameter =
+    | BindingElementOrHigher;
+
+  // MethodDefinition :
+  //   ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
+  //   GeneratorMethod
+  //   AsyncMethod
+  //   AsyncGeneratorMethod
+  //   `get` ClassElementName `(` `)` `{` FunctionBody `}`
+  //   `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
+  export type MethodDefinitionOrHigher =
+    | MethodDefinition
+    | GeneratorMethod
+    | AsyncMethod
+    | AsyncGeneratorMethod;
+
+  // PropertyDefinitionList :
+  //   PropertyDefinition
+  //   PropertyDefinitionList `,` PropertyDefinition
+  export type PropertyDefinitionList = PropertyDefinitionListElement[];
+
+  // PropertyDefinition :
+  //   IdentifierReference
+  //   CoverInitializedName
+  //   PropertyName `:` AssignmentExpression
+  //   MethodDefinition
+  //   `...` AssignmentExpression
+  export type PropertyDefinitionListElement =
+    | IdentifierReference
+    | CoverInitializedName
+    | PropertyDefinition
+    | MethodDefinitionOrHigher;
+
+  // FunctionDeclaration :
+  //   `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+  //   [+Default] `function` `(` FormalParameters `)` `{` FunctionBody `}`
+  export interface FunctionDeclaration extends ParseNode {
+    type: 'FunctionDeclaration';
+    BindingIdentifier: BindingIdentifier | null;
+    FormalParameters: FormalParameters;
+    FunctionBody: FunctionBody;
+  }
+
+  // FunctionExpression :
+  //   `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+  export interface FunctionExpression extends ParseNode {
+    type: 'FunctionExpression';
+    BindingIdentifier: BindingIdentifier | null;
+    FormalParameters: FormalParameters;
+    FunctionBody: FunctionBody;
+  }
+
+  // FunctionBody :
+  //   FunctionStatementList
+  export interface FunctionBody extends ParseNode {
+    type: 'FunctionBody';
+    directives: string[];
+    strict: boolean;
+    FunctionStatementList: FunctionStatementList;
+  }
+
+  // FunctionStatementList :
+  //   StatementList
+  export type FunctionStatementList = StatementList;
+
+  // ArrowFunction :
+  //  ArrowParameters `=>` ConciseBody
+  export interface ArrowFunction extends ParseNode {
+    type: 'ArrowFunction';
+    ArrowParameters: ArrowParameters;
+    ConciseBody: ConciseBodyOrHigher;
+  }
+
+  // ArrowParameters :
+  //   BindingIdentifier
+  //   CoverParenthesizedExpressionAndArrowParameterList
+  //
+  //   ArrowFormalParameters (refined) :
+  //    `(` UniqueFormalParameters `)`
+  export type ArrowParameters = ArrowFormalParameters;
+
+  //   ArrowFormalParameters :
+  //    `(` UniqueFormalParameters `)`
+  export type ArrowFormalParameters = UniqueFormalParameters;
+
+  // ExpressionBody :
+  //   AssignmentExpression
+  export interface ExpressionBody extends ParseNode {
+    type: 'ExpressionBody';
+    AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // ConciseBody (partial) :
+  //   ExpressionBody
+  export interface ConciseBody extends ParseNode {
+    type: 'ConciseBody';
+    directives?: undefined;
+    ExpressionBody: ExpressionBody;
+  }
+
+  // ConciseBody :
+  //   ExpressionBody
+  //   `{` FunctionBody `}`
+  export type ConciseBodyOrHigher =
+    | FunctionBody
+    | ConciseBody;
+
+  // GeneratorDeclaration :
+  //   `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+  //   [+Default] `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+  export interface GeneratorDeclaration extends ParseNode {
+    type: 'GeneratorDeclaration';
+    BindingIdentifier: BindingIdentifier | null;
+    FormalParameters: FormalParameters;
+    GeneratorBody: GeneratorBody;
+  }
+
+  // GeneratorExpression :
+  //   `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
+  export interface GeneratorExpression extends ParseNode {
+    type: 'GeneratorExpression';
+    BindingIdentifier: BindingIdentifier | null;
+    FormalParameters: FormalParameters;
+    GeneratorBody: GeneratorBody;
+  }
+
+  // GeneratorMethod :
+  //   `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`
+  export interface GeneratorMethod extends ParseNode {
+    type: 'GeneratorMethod';
+    static?: boolean;
+    ClassElementName: ClassElementName;
+    PropertySetParameterList: null;
+    UniqueFormalParameters: UniqueFormalParameters;
+    GeneratorBody: GeneratorBody;
+  }
+
+  // GeneratorBody :
+  //   FunctionBody
+  export interface GeneratorBody extends ParseNode {
+    type: 'GeneratorBody';
+    directives: string[];
+    strict: boolean;
+    FunctionStatementList: FunctionStatementList;
+  }
+
+  // YieldExpression :
+  //   `yield`
+  //   `yield` [no LineTerminator here] AssignmentExpression
+  //   `yield` [no LineTerminator here] `*` AssignmentExpression
+  export interface YieldExpression extends ParseNode {
+    type: 'YieldExpression';
+    hasStar: boolean;
+    AssignmentExpression: AssignmentExpressionOrHigher | null;
+  }
+
+  // AsyncGeneratorDeclaration :
+  //   `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+  //   [+Default] `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+  export interface AsyncGeneratorDeclaration extends ParseNode {
+    type: 'AsyncGeneratorDeclaration';
+    BindingIdentifier: BindingIdentifier | null;
+    FormalParameters: FormalParameters;
+    AsyncGeneratorBody: AsyncGeneratorBody;
+  }
+
+  // AsyncGeneratorExpression :
+  //   `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+  export interface AsyncGeneratorExpression extends ParseNode {
+    type: 'AsyncGeneratorExpression';
+    BindingIdentifier: BindingIdentifier | null;
+    FormalParameters: FormalParameters;
+    AsyncGeneratorBody: AsyncGeneratorBody;
+  }
+
+  // AsyncGeneratorMethod :
+  //   `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
+  export interface AsyncGeneratorMethod extends ParseNode {
+    type: 'AsyncGeneratorMethod';
+    static?: boolean;
+    ClassElementName: ClassElementName;
+    PropertySetParameterList: null;
+    UniqueFormalParameters: UniqueFormalParameters;
+    AsyncGeneratorBody: AsyncGeneratorBody;
+  }
+
+  // AsyncGeneratorBody :
+  //   FunctionBody
+  export interface AsyncGeneratorBody extends ParseNode {
+    type: 'AsyncGeneratorBody';
+    directives: string[];
+    strict: boolean;
+    FunctionStatementList: FunctionStatementList;
+  }
+
+  // NON-SPEC
+  export type FunctionLike =
+    | FunctionDeclaration
+    | GeneratorDeclaration
+    | AsyncFunctionDeclaration
+    | AsyncGeneratorDeclaration
+    | FunctionExpression
+    | GeneratorExpression
+    | AsyncFunctionExpression
+    | AsyncGeneratorExpression;
+
+  // NON-SPEC
+  export type FunctionDeclarationLike =
+    | FunctionDeclaration
+    | GeneratorDeclaration
+    | AsyncFunctionDeclaration
+    | AsyncGeneratorDeclaration;
+
+  // NON-SPEC
+  export type FunctionExpressionLike =
+    | FunctionExpression
+    | GeneratorExpression
+    | AsyncFunctionExpression
+    | AsyncGeneratorExpression;
+
+  // NON-SPEC
+  export type FunctionBodyLike =
+    | FunctionBody
+    | GeneratorBody
+    | AsyncFunctionBody
+    | AsyncGeneratorBody;
+
+  // ClassDeclaration :
+  //   `class` BindingIdentifier ClassTail
+  //   [+Default] `class` ClassTail
+  export interface ClassDeclaration extends ParseNode {
+    type: 'ClassDeclaration';
+    BindingIdentifier: BindingIdentifier | null;
+    ClassTail: ClassTail;
+  }
+
+  // ClassExpression :
+  //   `class` BindingIdentifier? ClassTail
+  export interface ClassExpression extends ParseNode {
+    type: 'ClassExpression';
+    BindingIdentifier: BindingIdentifier | null;
+    ClassTail: ClassTail;
+  }
+
+  // NON-SPEC
+  export type ClassLike =
+    | ClassDeclaration
+    | ClassExpression;
+
+  // ClassTail :
+  //   ClassHeritage? `{` ClassBody? `}`
+  export interface ClassTail extends ParseNode {
+    type: 'ClassTail';
+    ClassHeritage: ClassHeritage | null;
+    ClassBody: ClassBody | null;
+  }
+
+  // ClassHeritage :
+  //   `extends` LeftHandSideExpression
+  export type ClassHeritage = LeftHandSideExpression;
+
+  // ClassBody :
+  //   ClassElementList
+  export type ClassBody = ClassElementList;
+
+  // ClassElementList :
+  //   ClassElement
+  //   ClassElementList ClassElement
+  export type ClassElementList = ClassElement[];
+
+  // ClassElement :
+  //   MethodDefinition
+  //   `static` MethodDefinition
+  //   FieldDefinition `;`
+  //   `static` FieldDefinition `;`
+  //   ClassStaticBlock
+  //   `;`
+  export type ClassElement =
+    | MethodDefinitionOrHigher
+    | FieldDefinition
+    | ClassStaticBlock;
+
+  // FieldDefinition :
+  //   ClassElementName Initializer?
+  export interface FieldDefinition extends ParseNode {
+    type: 'FieldDefinition';
+    static?: boolean;
+    ClassElementName: ClassElementName;
+    Initializer: Initializer | null; // opt
+  }
+
+  // ClassStaticBlock :
+  //   `static` `{` ClassStaticBlockBody `}`
+  export interface ClassStaticBlock extends ParseNode {
+    type: 'ClassStaticBlock';
+    static: true;
+    ClassStaticBlockBody: ClassStaticBlockBody;
+  }
+
+  // ClassStaticBlockBody :
+  //   ClassStaticBlockStatementList
+  export interface ClassStaticBlockBody extends ParseNode {
+    type: 'ClassStaticBlockBody';
+    ClassStaticBlockStatementList: ClassStaticBlockStatementList;
+  }
+
+  // ClassStaticBlockStatementList :
+  //   StatementList?
+  export type ClassStaticBlockStatementList = StatementList;
+
+  // AsyncFunctionDeclaration :
+  //   `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncBody `}`
+  //   [+Default] `async` `function` `*` `(` FormalParameters `)` `{` AsyncBody `}`
+  export interface AsyncFunctionDeclaration extends ParseNode {
+    type: 'AsyncFunctionDeclaration';
+    BindingIdentifier: BindingIdentifier | null;
+    FormalParameters: FormalParameters;
+    AsyncBody: AsyncFunctionBody;
+  }
+
+  // AsyncFunctionExpression :
+  //   `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncBody `}`
+  export interface AsyncFunctionExpression extends ParseNode {
+    type: 'AsyncFunctionExpression';
+    BindingIdentifier: BindingIdentifier | null;
+    FormalParameters: FormalParameters;
+    AsyncBody: AsyncFunctionBody;
+  }
+
+  // AsyncMethod :
+  //   `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncBody `}`
+  export interface AsyncMethod extends ParseNode {
+    type: 'AsyncMethod';
+    static?: boolean;
+    ClassElementName: ClassElementName;
+    PropertySetParameterList: null;
+    UniqueFormalParameters: UniqueFormalParameters;
+    AsyncBody: AsyncFunctionBody;
+  }
+
+  // AsyncBody :
+  //   FunctionBody
+  export interface AsyncFunctionBody extends ParseNode {
+    type: 'AsyncFunctionBody';
+    directives: string[];
+    strict: boolean;
+    FunctionStatementList: FunctionStatementList;
+  }
+
+  // AsyncArrowFunction :
+  //   `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+  //   CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
+  //
+  // CoverCallExpressionAndAsyncArrowHead :
+  //   MemberExpression Arguments
+  //
+  // AsyncArrowHead (refined) :
+  //   `async` ArrowFormalParameters
+  export interface AsyncArrowFunction extends ParseNode {
+    type: 'AsyncArrowFunction';
+    ArrowParameters: ArrowParameters;
+    AsyncConciseBody: AsyncConciseBodyOrHigher;
+  }
+
+  // AsyncConciseBody (partial) :
+  //   ExpressionBody
+  export interface AsyncConciseBody extends ParseNode {
+    type: 'AsyncConciseBody';
+    directives?: undefined;
+    ExpressionBody: ExpressionBody;
+  }
+
+  // AsyncConciseBody :
+  //   ExpressionBody
+  //   `{` AsyncFunctionBody `}`
+  export type AsyncConciseBodyOrHigher =
+    | AsyncFunctionBody
+    | AsyncConciseBody;
+
+  // NON-SPEC
+  export type ArrowFunctionLike = ArrowFunction | AsyncArrowFunction;
+
+  // NON-SPEC
+  export type ConciseBodyLike = ConciseBody | AsyncConciseBody;
+
+  // NON-SPEC
+  export type ConciseBodyLikeOrHigher = ConciseBodyOrHigher | AsyncConciseBodyOrHigher;
+
+  export interface RegularExpressionLiteral extends ParseNode {
+    type: 'RegularExpressionLiteral';
+    RegularExpressionBody: string;
+    RegularExpressionFlags: string;
+  }
+
+  // CoverParenthesizedExpressionAndArrowParameterList :
+  //   `(` Expression `)`
+  //   `(` Expression `,` `)`
+  //   `(` `)`
+  //   `(` `...` BindingIdentifier `)`
+  //   `(` `...` BindingPattern `)`
+  //   `(` Expression `,` `...` BindingIdentifier `)`
+  //   `(` Expression `.` `...` BindingPattern `)`
+  export interface CoverParenthesizedExpressionAndArrowParameterList extends ParseNode {
+    type: 'CoverParenthesizedExpressionAndArrowParameterList';
+    Arguments: (ArgumentListElement | BindingRestElement)[];
+    arrowInfo?: ArrowInfo;
+  }
+
+  // CoverParenthesizedExpressionAndArrowParameterList (partial) :
+  //   `(` Expression `)`
+  //
+  // ParenthesizedExpression (refined) :
+  //   `(` Expression `)`
+  export interface ParenthesizedExpression extends ParseNode {
+    type: 'ParenthesizedExpression';
+    Expression: Expression;
+  }
+
+  // PrimaryExpression :
+  //   `this`
+  //   IdentifierReference
+  //   Literal
+  //   ArrayLiteral
+  //   ObjectLiteral
+  //   FunctionExpression
+  //   ClassExpression
+  //   GeneratorExpression
+  //   AsyncFunctionExpression
+  //   AsyncGeneratorExpression
+  //   RegularExpressionLiteral
+  //   TemplateLiteral
+  //   CoverParenthesizedExpressionAndArrowParameterList
+  export type PrimaryExpression =
+    | ThisExpression
+    | IdentifierReference
+    | Literal
+    | ArrayLiteral
+    | ObjectLiteral
+    | FunctionExpression
+    | ClassExpression
+    | GeneratorExpression
+    | AsyncFunctionExpression
+    | AsyncGeneratorExpression
+    | RegularExpressionLiteral
+    | TemplateLiteral
+    | CoverParenthesizedExpressionAndArrowParameterList
+    | ParenthesizedExpression;
+
+  // SuperProperty (partial) :
+  //   super `[` Expression `]`
+  export interface SuperProperty extends ParseNode {
+    type: 'SuperProperty';
+    Expression: Expression | null;
+  }
+
+  // SuperProperty (partial) :
+  //   super `.` IdentifierName
+  export interface SuperProperty extends ParseNode {
+    type: 'SuperProperty';
+    IdentifierName: IdentifierName | null;
+  }
+
+  // NewTarget :
+  //   `new` `.` `target`
+  export interface NewTarget extends ParseNode {
+    type: 'NewTarget';
+  }
+
+  // ImportMeta :
+  //   `import` `.` `meta`
+  export interface ImportMeta extends ParseNode {
+    type: 'ImportMeta';
+  }
+
+  // MetaProperty :
+  //   NewTarget
+  //   ImportMeta
+  export type MetaProperty =
+    | NewTarget
+    | ImportMeta;
+
+  // MemberExpression (partial) :
+  //   MemberExpression `[` Expression `]`
+  export interface MemberExpression extends ParseNode {
+    type: 'MemberExpression';
+    // NOTE: Should be MemberExpressionOrHigher
+    MemberExpression: LeftHandSideExpression;
+    Expression: Expression | null;
+  }
+
+  // MemberExpression (partial) :
+  //   MemberExpression `.` IdentifierName
+  export interface MemberExpression extends ParseNode {
+    type: 'MemberExpression';
+    // NOTE: Should be MemberExpressionOrHigher
+    MemberExpression: LeftHandSideExpression;
+    IdentifierName: IdentifierName | null;
+  }
+
+  // MemberExpression (partial) :
+  //   MemberExpression `.` PrivateIdentifier
+  export interface MemberExpression extends ParseNode {
+    type: 'MemberExpression';
+    // NOTE: Should be MemberExpressionOrHigher
+    MemberExpression: LeftHandSideExpression;
+    PrivateIdentifier: PrivateIdentifier | null;
+  }
+
+  // MemberExpression :
+  //   PrimaryExpression
+  //   MemberExpression `[` Expression `]`
+  //   MemberExpression `.` IdentifierName
+  //   MemberExpression TemplateLiteral
+  //   SuperProperty
+  //   MetaProperty
+  //   `new` MemberExpression Arguments
+  //   MemberExpression `.` PrivateIdentifier
+  export type MemberExpressionOrHigher =
+    | PrimaryExpression
+    | MemberExpression
+    | SuperProperty
+    | MetaProperty
+    | NewExpression;
+
+  // NewExpression (partial) :
+  //   `new` NewExpression
+  //
+  // MemberExpression (partial) :
+  //   `new` MemberExpression Arguments
+  export interface NewExpression extends ParseNode {
+    type: 'NewExpression';
+    // NOTE: Should be NewExpressionOrHigher | MemberExpressionOrHigher
+    MemberExpression: LeftHandSideExpression;
+    Arguments: Arguments | null;
+  }
+
+  // NewExpression :
+  //   MemberExpression
+  //   `new` NewExpression
+  export type NewExpressionOrHigher =
+    | MemberExpressionOrHigher
+    | NewExpression;
+
+  // SuperCall :
+  //   `super` Arguments
+  export interface SuperCall extends ParseNode {
+    type: 'SuperCall';
+    Arguments: Arguments;
+  }
+
+  // ImportCall :
+  //   `import` `(` AssignmentExpression `)`
+  export interface ImportCall extends ParseNode {
+    type: 'ImportCall';
+    AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // CallExpression (partial) :
+  //   CallExpression Arguments
+  export interface CallExpression extends ParseNode {
+    type: 'CallExpression';
+    // NOTE: Should be CallExpressionOrHigher
+    CallExpression: LeftHandSideExpression;
+    Arguments: Arguments;
+    arrowInfo?: ArrowInfo;
+  }
+
+  // TemplateLiteral :
+  //   NoSubstitutionTemplate
+  //   SubstitutionTemplate
+  //
+  // SubstitutionTemplate :
+  //   TemplateHead Expression TemplateSpans
+  //
+  // TemplateSpans :
+  //   TemplateTail
+  //   TemplateMiddleList TemplateTail
+  //
+  // TemplateMiddleList :
+  //   TemplateMiddle Expression
+  //   TemplateMiddleList TemplateMiddle Expression
+  export interface TemplateLiteral extends ParseNode {
+    type: 'TemplateLiteral';
+    TemplateSpanList: string[];
+    ExpressionList: Expression[];
+  }
+
+  // CallExpression (partial) :
+  //   CallExpression TemplateLiteral
+  //
+  // MemberExpression (partial) :
+  //   MemberExpression TemplateLiteral
+  export interface TaggedTemplateExpression extends ParseNode {
+    type: 'TaggedTemplateExpression';
+    // NOTE: Should be CallExpressionOrHigher
+    MemberExpression: LeftHandSideExpression;
+    TemplateLiteral: TemplateLiteral;
+    arrowInfo?: ArrowInfo;
+  }
+
+  // CallExpression :
+  //   CoverCallExpressionAndAsyncArrowHead
+  //   SuperCall
+  //   ImportCall
+  //   CallExpression Arguments
+  //   CallExpression `[` Expression `]`
+  //   CallExpression `.` IdentifierName
+  //   CallExpression TemplateLiteral
+  //   CallExpression `.` PrivateIdentifier
+  export type CallExpressionOrHigher =
+    | MemberExpressionOrHigher
+    | SuperCall
+    | ImportCall
+    | CallExpression
+    | TaggedTemplateExpression;
+
+  // OptionalExpression :
+  //   MemberExpression OptionalChain
+  //   CallExpression OptionalChain
+  //   OptionalExpression OptionalChain
+  export interface OptionalExpression extends ParseNode {
+    type: 'OptionalExpression';
+    MemberExpression: MemberExpressionOrHigher | CallExpressionOrHigher | OptionalExpression;
+    OptionalChain: OptionalChain;
+  }
+
+  // OptionalChain (partial) :
+  //   `?.` Arguments
+  export interface OptionalChain extends ParseNode {
+    type: 'OptionalChain';
+    Arguments?: Arguments;
+  }
+
+  // OptionalChain (partial) :
+  //   `?.` `[` Expression `]`
+  export interface OptionalChain extends ParseNode {
+    type: 'OptionalChain';
+    Expression?: Expression;
+  }
+
+  // OptionalChain (partial) :
+  //   `?.` IdentifierName
+  export interface OptionalChain extends ParseNode {
+    type: 'OptionalChain';
+    IdentifierName?: IdentifierName;
+  }
+
+  // OptionalChain (partial) :
+  //   `?.` PrivateIdentifier
+  export interface OptionalChain extends ParseNode {
+    type: 'OptionalChain';
+    PrivateIdentifier?: PrivateIdentifier;
+  }
+
+  // OptionalChain (partial) :
+  //   OptionalChain `?.` Arguments
+  export interface OptionalChain extends ParseNode {
+    type: 'OptionalChain';
+    OptionalChain: OptionalChain | null;
+    Arguments?: Arguments;
+  }
+
+  // OptionalChain (partial) :
+  //   OptionalChain `?.` `[` Expression `]`
+  export interface OptionalChain extends ParseNode {
+    type: 'OptionalChain';
+    OptionalChain: OptionalChain | null;
+    Expression?: Expression;
+  }
+
+  // OptionalChain (partial) :
+  //   OptionalChain `?.` IdentifierName
+  export interface OptionalChain extends ParseNode {
+    type: 'OptionalChain';
+    OptionalChain: OptionalChain | null;
+    IdentifierName?: IdentifierName;
+  }
+
+  // OptionalChain (partial) :
+  //   OptionalChain `?.` PrivateIdentifier
+  export interface OptionalChain extends ParseNode {
+    type: 'OptionalChain';
+    OptionalChain: OptionalChain | null;
+    PrivateIdentifier?: PrivateIdentifier;
+  }
+
+  // ArgumentList (partial) :
+  //   `...` AssignmentExpression
+  //   ArgumentList `,` `...` AssignmentExpression
+  export interface AssignmentRestElement extends ParseNode {
+    type: 'AssignmentRestElement';
+    AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // ArgumentList :
+  //   AssignmentExpression
+  //   `...` AssignmentExpression
+  //   ArgumentList `,` AssignmentExpression
+  //   ArgumentList `,` `...` AssignmentExpression
+  export type ArgumentListElement =
+    | AssignmentExpressionOrHigher
+    | AssignmentRestElement;
+
+  // Arguments :
+  //   `(` `)`
+  //   `(` ArgumentList `)`
+  //   `(` ArgumentList `,` `)`
+  //
+  // ArgumentList :
+  //   AssignmentExpression
+  //   `...` AssignmentExpression
+  //   ArgumentList `,` AssignmentExpression
+  //   ArgumentList `,` `...` AssignmentExpression
+  export type Arguments = ArgumentListElement[];
+
+  // LeftHandSideExpression :
+  //   NewExpression
+  //   CallExpression
+  //   OptionalExpression
+  export type LeftHandSideExpression =
+    | NewExpressionOrHigher
+    | CallExpressionOrHigher
+    | OptionalExpression;
+
+  // UpdateExpression :
+  //   LeftHandSideExpression
+  //   LeftHandSideExpression [no LineTerminator here] `++`
+  //   LeftHandSideExpression [no LineTerminator here] `--`
+  //   `++` UnaryExpression
+  //   `--` UnaryExpression
+  export interface UpdateExpression extends ParseNode {
+    type: 'UpdateExpression';
+    operator: '++' | '--';
+    LeftHandSideExpression: LeftHandSideExpression | null;
+    UnaryExpression: UnaryExpressionOrHigher | null;
+  }
+
+  // UpdateExpression :
+  //   LeftHandSideExpression
+  //   LeftHandSideExpression [no LineTerminator here] `++`
+  //   LeftHandSideExpression [no LineTerminator here] `--`
+  //   `++` UnaryExpression
+  //   `--` UnaryExpression
+  export type UpdateExpressionOrHigher =
+    | LeftHandSideExpression
+    | UpdateExpression;
+
+  // AwaitExpression : `await` UnaryExpression
+  export interface AwaitExpression extends ParseNode {
+    type: 'AwaitExpression';
+    UnaryExpression: UnaryExpressionOrHigher;
+  }
+
+  // UnaryExpression (partial) :
+  //   `delete` UnaryExpression
+  //   `void` UnaryExpression
+  //   `typeof` UnaryExpression
+  //   `+` UnaryExpression
+  //   `-` UnaryExpression
+  //   `~` UnaryExpression
+  //   `!` UnaryExpression
+  export interface UnaryExpression extends ParseNode {
+    type: 'UnaryExpression';
+    operator: 'delete' | 'void' | 'typeof' | '+' | '-' | '~' | '!';
+    UnaryExpression: UnaryExpressionOrHigher;
+  }
+
+  // UnaryExpression :
+  //   UpdateExpression
+  //   `delete` UnaryExpression
+  //   `void` UnaryExpression
+  //   `typeof` UnaryExpression
+  //   `+` UnaryExpression
+  //   `-` UnaryExpression
+  //   `~` UnaryExpression
+  //   `!` UnaryExpression
+  //   [+Await] AwaitExpression
+  export type UnaryExpressionOrHigher =
+    | UpdateExpressionOrHigher
+    | UnaryExpression
+    | AwaitExpression;
+
+  // ExponentiationExpression (partial) :
+  //   UpdateExpresion `**` ExponentiationExpression
+  export interface ExponentiationExpression extends ParseNode {
+    type: 'ExponentiationExpression';
+    UpdateExpression: UpdateExpressionOrHigher;
+    ExponentiationExpression: ExponentiationExpressionOrHigher;
+  }
+
+  // ExponentiationExpression :
+  //   UnaryExpression
+  //   UpdateExpresion `**` ExponentiationExpression
+  export type ExponentiationExpressionOrHigher =
+    | UnaryExpressionOrHigher
+    | ExponentiationExpression;
+
+  // MultiplicativeOperator : one of
+  //   `*`  `/`  `%`;
+  export type MultiplicativeOperator = '*' | '/' | '%';
+
+  // ExponentiationExpression (partial) :
+  //   MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
+  export interface MultiplicativeExpression extends ParseNode {
+    type: 'MultiplicativeExpression';
+    MultiplicativeExpression: MultiplicativeExpressionOrHigher;
+    MultiplicativeOperator: MultiplicativeOperator;
+    ExponentiationExpression: ExponentiationExpressionOrHigher;
+  }
+
+  // MultiplicativeExpression :
+  //   ExponentiationExpression
+  //   MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
+  export type MultiplicativeExpressionOrHigher =
+    | ExponentiationExpressionOrHigher
+    | MultiplicativeExpression;
+
+  // AdditiveExpression (partial) :
+  //   AdditiveExpression `+` MultiplicativeExpression
+  //   AdditiveExpression `-` MultiplicativeExpression
+  export interface AdditiveExpression extends ParseNode {
+    type: 'AdditiveExpression';
+    operator: '+' | '-';
+    AdditiveExpression: AdditiveExpressionOrHigher;
+    MultiplicativeExpression: MultiplicativeExpressionOrHigher;
+  }
+
+  // AdditiveExpression :
+  //   MultiplicativeExpression
+  //   AdditiveExpression `+` MultiplicativeExpression
+  //   AdditiveExpression `-` MultiplicativeExpression
+  export type AdditiveExpressionOrHigher =
+    | MultiplicativeExpressionOrHigher
+    | AdditiveExpression;
+
+  // ShiftExpression (partial) :
+  //   ShiftExpression `<<` AdditiveExpression
+  //   ShiftExpression `>>` AdditiveExpression
+  //   ShiftExpression `>>>` AdditiveExpression
+  export interface ShiftExpression extends ParseNode {
+    type: 'ShiftExpression';
+    operator: '<<' | '>>' | '>>>';
+    ShiftExpression: ShiftExpressionOrHigher;
+    AdditiveExpression: AdditiveExpressionOrHigher;
+  }
+
+  // ShiftExpression :
+  //   AdditiveExpression
+  //   ShiftExpression `<<` AdditiveExpression
+  //   ShiftExpression `>>` AdditiveExpression
+  //   ShiftExpression `>>>` AdditiveExpression
+  export type ShiftExpressionOrHigher =
+    | AdditiveExpressionOrHigher
+    | ShiftExpression;
+
+  // RelationalExpression (partial) :
+  //   RelationalExpression `<` ShiftExpression
+  //   RelationalExpression `>` ShiftExpression
+  //   RelationalExpression `<=` ShiftExpression
+  //   RelationalExpression `>=` ShiftExpression
+  //   RelationalExpression `instanceof` ShiftExpression
+  //   RelationalExpression `in` ShiftExpression
+  export interface RelationalExpression extends ParseNode {
+    type: 'RelationalExpression';
+    operator: '<' | '>' | '<=' | '>=' | 'instanceof' | 'in';
+    PrivateIdentifier?: PrivateIdentifier;
+    RelationalExpression?: RelationalExpressionOrHigher;
+    ShiftExpression: ShiftExpressionOrHigher;
+  }
+
+  // RelationalExpression :
+  //   ShiftExpression
+  //   RelationalExpression `<` ShiftExpression
+  //   RelationalExpression `>` ShiftExpression
+  //   RelationalExpression `<=` ShiftExpression
+  //   RelationalExpression `>=` ShiftExpression
+  //   RelationalExpression `instanceof` ShiftExpression
+  //   RelationalExpression `in` ShiftExpression
+  export type RelationalExpressionOrHigher =
+    | ShiftExpressionOrHigher
+    | RelationalExpression;
+
+  // EqualityExpression (partial) :
+  //   EqualityExpression == RelationalExpression
+  //   EqualityExpression != RelationalExpression
+  //   EqualityExpression === RelationalExpression
+  //   EqualityExpression !== RelationalExpression
+  export interface EqualityExpression extends ParseNode {
+    type: 'EqualityExpression';
+    operator: '==' | '!=' | '===' | '!==';
+    EqualityExpression: EqualityExpressionOrHigher;
+    RelationalExpression: RelationalExpressionOrHigher;
+  }
+
+  // EqualityExpression :
+  //   RelationalExpression
+  //   EqualityExpression == RelationalExpression
+  //   EqualityExpression != RelationalExpression
+  //   EqualityExpression === RelationalExpression
+  //   EqualityExpression !== RelationalExpression
+  export type EqualityExpressionOrHigher =
+    | RelationalExpressionOrHigher
+    | EqualityExpression;
+
+  // BitwiseANDExpression (partial) :
+  //   BitwiseANDExpression `^&` EqualityExpression
+  export interface BitwiseANDExpression extends ParseNode {
+    type: 'BitwiseANDExpression';
+    operator: '&';
+    A: BitwiseANDExpressionOrHigher;
+    B: EqualityExpressionOrHigher;
+  }
+
+  // BitwiseANDExpression :
+  //   EqualityExpression
+  //   BitwiseANDExpression `^&` EqualityExpression
+  export type BitwiseANDExpressionOrHigher =
+    | EqualityExpressionOrHigher
+    | BitwiseANDExpression;
+
+  // BitwiseXORExpression (partial) :
+  //   BitwiseXORExpression `^` BitwiseANDExpression
+  export interface BitwiseXORExpression extends ParseNode {
+    type: 'BitwiseXORExpression';
+    operator: '^';
+    A: BitwiseXORExpressionOrHigher;
+    B: BitwiseANDExpressionOrHigher;
+  }
+
+  // BitwiseXORExpression :
+  //   BitwiseANDExpression
+  //   BitwiseXORExpression `^` BitwiseANDExpression
+  export type BitwiseXORExpressionOrHigher =
+    | BitwiseANDExpressionOrHigher
+    | BitwiseXORExpression;
+
+  // BitwiseORExpression (partial) :
+  //   BitwiseORExpression `|` BitwiseXORExpression
+  export interface BitwiseORExpression extends ParseNode {
+    type: 'BitwiseORExpression';
+    operator: '|';
+    A: BitwiseORExpressionOrHigher;
+    B: BitwiseXORExpressionOrHigher;
+  }
+
+  // BitwiseORExpression :
+  //   BitwiseXORExpression
+  //   BitwiseORExpression `|` BitwiseXORExpression
+  export type BitwiseORExpressionOrHigher =
+    | BitwiseXORExpressionOrHigher
+    | BitwiseORExpression;
+
+  // LogicalANDExpression (partial) :
+  //   LogicalANDExpression `&&` BitwiseORExpression
+  export interface LogicalANDExpression extends ParseNode {
+    type: 'LogicalANDExpression';
+    LogicalANDExpression: LogicalANDExpressionOrHigher;
+    BitwiseORExpression: BitwiseORExpressionOrHigher;
+  }
+
+  // LogicalANDExpression :
+  //   BitwiseORExpression
+  //   LogicalANDExpression `&&` BitwiseORExpression
+  export type LogicalANDExpressionOrHigher =
+    | BitwiseORExpressionOrHigher
+    | LogicalANDExpression;
+
+  // LogicalORExpression (partial) :
+  //   LogicalORExpression `||` LogicalANDExpression
+  export interface LogicalORExpression extends ParseNode {
+    type: 'LogicalORExpression';
+    LogicalORExpression: LogicalORExpressionOrHigher;
+    LogicalANDExpression: LogicalANDExpressionOrHigher;
+  }
+
+  // LogicalORExpression :
+  //   LogicalANDExpression
+  //   LogicalORExpression `||` LogicalANDExpression
+  export type LogicalORExpressionOrHigher =
+    | LogicalANDExpressionOrHigher
+    | LogicalORExpression;
+
+  // CoalesceExpression :
+  //   CoalesceExpressionHead `??` BitwiseORExpression
+  export interface CoalesceExpression extends ParseNode {
+    type: 'CoalesceExpression';
+    CoalesceExpressionHead: CoalesceExpressionHead;
+    BitwiseORExpression: BitwiseORExpressionOrHigher;
+  }
+
+  // CoalesceExpressionHead :
+  //   CoalesceExpression
+  //   BitwiseORExpression
+  export type CoalesceExpressionHead =
+    | BitwiseORExpressionOrHigher
+    | CoalesceExpression;
+
+  // ShortCircuitExpression :
+  //   LogicalORExpression
+  //   CoalesceExpression
+  export type ShortCircuitExpressionOrHigher =
+    | LogicalORExpressionOrHigher
+    | CoalesceExpression;
+
+  // ConditionalExpression (partial) :
+  //   ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
+  export interface ConditionalExpression extends ParseNode {
+    type: 'ConditionalExpression';
+    ShortCircuitExpression: ShortCircuitExpressionOrHigher;
+    AssignmentExpression_a: AssignmentExpressionOrHigher;
+    AssignmentExpression_b: AssignmentExpressionOrHigher;
+  }
+
+  // ConditionalExpression :
+  //   ShortCircuitExpression
+  //   ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
+  export type ConditionalExpressionOrHigher =
+    | ShortCircuitExpressionOrHigher
+    | ConditionalExpression;
+
+  // AssignmentExpression (partial) :
+  //   LeftHandSideExpression `=` AssignmentExpression
+  //   LeftHandSideExpression AssignmentOperator AssignmentExpression
+  //   LeftHandSideExpression LogicalAssignmentOperator AssignmentExpression
+  //
+  export interface AssignmentExpression extends ParseNode {
+    type: 'AssignmentExpression';
+    // NOTE: Should be LeftHandSideExpression, but some invalid nodes are allowed as they report early errors
+    LeftHandSideExpression: AssignmentExpressionOrHigher;
+    AssignmentOperator: '=' | AssignmentOperator | LogicalAssignmentOperator;
+    AssignmentExpression: AssignmentExpressionOrHigher;
+  }
+
+  // AssignmentOperator : one of
+  //   `*=`  `/=`  `%=`  `+=`  `-=`  `<<=`  `>>=`  `>>>=`  `&=`  `^=`  `|=`  `**=`
+  export type AssignmentOperator = '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>=' | '>>>=' | '&=' | '^=' | '|=' | '**=';
+
+  // LogicalAssignmentOperator : one of
+  //   `&&=`  `||=`  `??=`
+  export type LogicalAssignmentOperator = '&&=' | '||=' | '??=';
+
+  // AssignmentExpression :
+  //   ConditionalExpression
+  //   [+Yield] YieldExpression
+  //   ArrowFunction
+  //   AsyncArrowFunction
+  //   LeftHandSideExpression `=` AssignmentExpression
+  //   LeftHandSideExpression AssignmentOperator AssignmentExpression
+  //   LeftHandSideExpression LogicalAssignmentOperator AssignmentExpression
+  export type AssignmentExpressionOrHigher =
+    | ConditionalExpressionOrHigher
+    | YieldExpression
+    | ArrowFunction
+    | AsyncArrowFunction
+    | AssignmentExpression;
+
+  // NON-SPEC
+  export type BinaryExpression =
+    | AssignmentExpression
+    | LogicalORExpression
+    | LogicalANDExpression
+    | BitwiseORExpression
+    | BitwiseXORExpression
+    | BitwiseANDExpression
+    | RelationalExpression
+    | EqualityExpression
+    | ShiftExpression
+    | AdditiveExpression
+    | MultiplicativeExpression
+    | ExponentiationExpression;
+
+  // NON-SPEC
+  export type BinaryExpressionOrHigher =
+    | BinaryExpression
+    | UnaryExpressionOrHigher;
+
+  // Expression (partial) :
+  //   Expression `,` AssignmentExpression
+  export interface CommaOperator extends ParseNode {
+    type: 'CommaOperator';
+    ExpressionList: AssignmentExpressionOrHigher[];
+  }
+
+  // Expression :
+  //   AssignmentExpression
+  //   Expression `,` AssignmentExpression
+  export type Expression =
+    | CommaOperator
+    | AssignmentExpressionOrHigher;
+
+  // LetOrConst :
+  //   `let`
+  //   `const`
+  export type LetOrConst =
+    | 'let'
+    | 'const';
+
+  // LexicalDeclaration :
+  //   LetOrConst BindingList `;`
+  export interface LexicalDeclaration extends ParseNode {
+    type: 'LexicalDeclaration';
+    LetOrConst: LetOrConst;
+    BindingList: BindingList;
+  }
+
+  // LexicalDeclaration :
+  //   LetOrConst BindingList `;`
+  export type LexicalDeclarationLike =
+    | LexicalDeclaration;
+
+  // BindingList :
+  //   LexicalBinding
+  //   BindingList `,` LexicalBinding
+  export type BindingList = LexicalBinding[];
+
+  // LexicalBinding :
+  //   BindingIdentifier Initializer?
+  //   BindingPattern Initializer
+  export interface LexicalBinding extends ParseNode {
+    type: 'LexicalBinding';
+
+    // LexicalBinding : BindingIdentifier Initializer?
+    BindingIdentifier?: BindingIdentifier;
+
+    // LexicalBinding : BindingPattern Initializer
+    BindingPattern?: BindingPattern;
+
+    Initializer: Initializer | null; // opt
+  }
+
+  // ObjectBindingPattern :
+  //   `{` `}`
+  //   `{` BindingRestProperty `}`
+  //   `{` BindingPropertyList `}`
+  //   `{` BindingPropertyList `,` BindingRestProperty? `}`
+  export interface ObjectBindingPattern extends ParseNode {
+    type: 'ObjectBindingPattern';
+    BindingPropertyList: BindingPropertyList;
+    BindingRestProperty?: BindingRestProperty;
+  }
+
+  // ArrayBindingPattern :
+  //   `[` Elision? BindingRestElement `]`
+  //   `[` BindingElementList `]`
+  //   `[` BindingElementList `,` Elision? BindingRestElement `]`
+  export interface ArrayBindingPattern extends ParseNode {
+    type: 'ArrayBindingPattern';
+    BindingElementList: BindingElementList;
+    BindingRestElement: BindingRestElement;
+  }
+
+  // BindingRestProperty :
+  //  `...` BindingIdentifier
+  export interface BindingRestProperty extends ParseNode {
+    type: 'BindingRestProperty';
+    BindingIdentifier: BindingIdentifier;
+  }
+
+  // BindingProperty : PropertyName : BindingElement
+  export interface BindingProperty extends ParseNode {
+    type: 'BindingProperty';
+    PropertyName: PropertyNameLike;
+    BindingElement: BindingElementOrHigher;
+  }
+
+  // BindingProperty :
+  //   SingleNameBinding
+  //   PropertyName : BindingElement
+  export type BindingPropertyLike =
+    | BindingProperty
+    | SingleNameBinding;
+
+  // TODO: document
+  export type BindingPropertyList = BindingPropertyLike[];
+
+  // BindingRestElement :
+  //   `...` BindingIdentifier
+  //   `...` BindingPattern
+  export interface BindingRestElement extends ParseNode {
+    type: 'BindingRestElement';
+    BindingIdentifier?: BindingIdentifier;
+    BindingPattern?: BindingPattern;
+  }
+
+  // BindingElement :
+  //   SingleNameBinding
+  //   BindingPattern Initializer?
+  export interface BindingElement extends ParseNode {
+    type: 'BindingElement';
+    BindingPattern: BindingPattern;
+    Initializer: Initializer | null; // opt
+  }
+
+  // SingleNameBinding :
+  //   BindingIdentifier Initializer?
+  export interface SingleNameBinding extends ParseNode {
+    type: 'SingleNameBinding';
+    BindingIdentifier: BindingIdentifier;
+    Initializer: Initializer | null; // opt
+  }
+
+  // BindingElement :
+  //   SingleNameBinding
+  //   BindingPattern Initializer?
+  export type BindingElementOrHigher =
+    | BindingElement
+    | SingleNameBinding;
+
+  // BindingElementList :
+  //   BindingElisionElement
+  //   BindingElementList , BindingElisionElement
+  export type BindingElementList = BindingElementListItem[];
+
+  // NON-SPEC
+  export type BindingElementListItem =
+    | BindingElementOrHigher
+    | Elision;
+
+  // BindingPattern :
+  //   ObjectBindingPattern
+  //   ArrayBindingPattern
+  export type BindingPattern =
+    | ObjectBindingPattern
+    | ArrayBindingPattern;
+
+  // Initializer :
+  //   `=` AssignmentExpression
+  export type Initializer = AssignmentExpressionOrHigher;
+
+  // StatementList :
+  //   StatementListItem
+  //   StatementList StatementListItem
+  export type StatementList = StatementListItem[];
+
+  // StatementListItem :
+  //   Statement
+  //   Declaration
+  export type StatementListItem =
+    | Statement
+    | Declaration;
+
+  // Block :
+  //   `{` StatementList `}`
+  export interface Block extends ParseNode {
+    type: 'Block';
+    StatementList: StatementList;
+  }
+
+  // BlockStatement :
+  //   Block
+  export type BlockStatement = Block;
+
+  // VariableStatement :
+  //   `var` VariableDeclarationList `;`
+  export interface VariableStatement extends ParseNode {
+    type: 'VariableStatement';
+    VariableDeclarationList: VariableDeclarationList;
+  }
+
+  // VariableDeclarationList :
+  //   VariableDeclaration
+  //   VariableDeclarationList `,` VariableDeclaration
+  export type VariableDeclarationList = VariableDeclaration[];
+
+  // VariableDeclaration :
+  //   BindingIdentifier Initializer?
+  //   BindingPattern Initializer
+  export interface VariableDeclaration extends ParseNode {
+    type: 'VariableDeclaration';
+    BindingPattern?: BindingPattern;
+    BindingIdentifier?: BindingIdentifier;
+    Initializer: Initializer | null; // opt
+  }
+
+  // EmptyStatement :
+  //   `;`
+  export interface EmptyStatement extends ParseNode {
+    type: 'EmptyStatement';
+  }
+
+  // ExpressionStatement :
+  //   [lookahead != `{`, `function`, `async` [no LineTerminator here] `function`, `class`, `let` `[` ] Expression `;`
+  export interface ExpressionStatement extends ParseNode {
+    type: 'ExpressionStatement';
+    Expression: Expression;
+  }
+
+  // IfStatement :
+  //   `if` `(` Expression `)` Statement `else` Statement
+  //   `if` `(` Expression `)` Statement [lookahead ≠ `else`]
+  export interface IfStatement extends ParseNode {
+    type: 'IfStatement';
+    Expression: Expression;
+    Statement_a: Statement;
+    Statement_b: Statement;
+  }
+
+  // DoWhileStatement :
+  //   `do` Statement `while` `(` Expression `)` `;`
+  export interface DoWhileStatement extends ParseNode {
+    type: 'DoWhileStatement';
+    Statement: Statement;
+    Expression: Expression;
+  }
+
+  // WhileStatement :
+  //   `while` `(` Expression `)` Statement
+  export interface WhileStatement extends ParseNode {
+    type: 'WhileStatement';
+    Expression: Expression;
+    Statement: Statement;
+  }
+
+  // ForStatement :
+  //   `for` `(` [lookahead != `let` `[`] Expression? `;` Expression? `;` Expression? `)` Statement
+  //   `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
+  //   `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+  export interface ForStatement extends ParseNode {
+    type: 'ForStatement';
+
+    /// / ForStatement : `for` `(` [lookahead != `let` `[`] Expression? `;` Expression? `;` Expression? `)` Statement
+    // Expression_a?: Expression;
+    // Expression_b?: Expression;
+    // Expression_c?: Expression;
+    // Statement: Statement;
+
+    /// / ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
+    // VariableDeclarationList: VariableDeclarationList;
+    // Expression_a?: Expression;
+    // Expression_b?: Expression;
+    // Statement: Statement;
+
+    /// / ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+    // LexicalDeclaration?: LexicalDeclarationLike;
+    // Expression_a?: Expression;
+    // Expression_b?: Expression;
+    // Statement: Statement;
+
+    VariableDeclarationList: VariableDeclarationList;
+    LexicalDeclaration?: LexicalDeclarationLike;
+    Expression_a?: Expression;
+    Expression_b?: Expression;
+    Expression_c?: Expression;
+    Statement: Statement;
+  }
+
+  // ForInOfStatement (partial) :
+  //   `for` `(` [lookahead != `let` `[`] LeftHandSideExpression `in` Expression `)` Statement
+  //   `for` `(` `var` ForBinding `in` Expression `)` Statement
+  //   `for` `(` ForDeclaration `in` Expression `)` Statement
+  export interface ForInStatement extends ParseNode {
+    type: 'ForInStatement';
+
+    /// / ForInStatement : `for` `(` [lookahead != `let` `[`] LeftHandSideExpression `in` Expression `)` Statement
+    // LeftHandSideExpression?: LeftHandSideExpression;
+    // Expression: Expression;
+    // Statement: Statement;
+
+    /// / ForInStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement
+    // ForBinding?: ForBinding;
+    // Expression: Expression;
+    // Statement: Statement;
+
+    /// / ForInStatement : `for` `(` ForDeclaration `in` Expression `)` Statement
+    // ForDeclaration?: ForDeclarationLike;
+    // Expression: Expression;
+    // Statement: Statement;
+
+    LeftHandSideExpression?: LeftHandSideExpression;
+    ForBinding?: ForBinding;
+    ForDeclaration?: ForDeclarationLike;
+    Expression: Expression;
+    Statement: Statement;
+  }
+
+  // ForInOfStatement (partial) :
+  //   `for` `(` [lookahead != { `let`, `async` `of` }] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+  //   `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+  //   `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+  export interface ForOfStatement extends ParseNode {
+    type: 'ForOfStatement';
+
+    /// / ForOfStatement : `for` `(` [lookahead != { `let`, `async` `of` }] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+    // LeftHandSideExpression?: LeftHandSideExpression;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    /// / ForOfStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+    // ForBinding?: ForBinding;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    /// / ForOfStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+    // ForDeclaration?: ForDeclarationLike;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    LeftHandSideExpression?: LeftHandSideExpression;
+    ForDeclaration?: ForDeclarationLike;
+    ForBinding?: ForBinding;
+    AssignmentExpression: AssignmentExpressionOrHigher;
+    Statement: Statement;
+  }
+
+  // ForInOfStatement (partial) :
+  //   `for` `await` `(` [lookahead != `let`] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+  //   `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+  //   `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+  export interface ForAwaitStatement extends ParseNode {
+    type: 'ForAwaitStatement';
+
+    /// / ForOfStatement : `for` `await` `(` [lookahead != `let`] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+    // LeftHandSideExpression?: LeftHandSideExpression;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    /// / ForOfStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+    // ForBinding?: ForBinding;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    /// / ForOfStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+    // ForDeclaration?: ForDeclarationLike;
+    // AssignmentExpression: AssignmentExpressionOrHigher;
+    // Statement: Statement;
+
+    LeftHandSideExpression?: LeftHandSideExpression;
+    ForDeclaration?: ForDeclarationLike;
+    ForBinding?: ForBinding;
+    AssignmentExpression: AssignmentExpressionOrHigher;
+    Statement: Statement;
+  }
+
+  // ForInOfStatement :
+  //   `for` `(` [lookahead != `let` `[`] LeftHandSideExpression `in` Expression `)` Statement
+  //   `for` `(` `var` ForBinding `in` Expression `)` Statement
+  //   `for` `(` ForDeclaration `in` Expression `)` Statement
+  //   `for` `(` [lookahead != { `let`, `async` `of` }] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+  //   `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+  //   `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+  //   `for` `await` `(` [lookahead != `let`] LeftHandSideExpression `of` AssignmentExpression `)` Statement
+  //   `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+  //   `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+  export type ForInOfStatement =
+    | ForInStatement
+    | ForOfStatement
+    | ForAwaitStatement;
+
+  // ForDeclaration :
+  //   LetOrConst ForBinding
+  export interface ForDeclaration extends ParseNode {
+    type: 'ForDeclaration';
+    LetOrConst: LetOrConst;
+    ForBinding: ForBinding;
+  }
+
+  // NON-SPEC
+  export type ForDeclarationLike =
+    | ForDeclaration;
+
+  // ForBinding :
+  //   BindingPattern
+  //   BindingIdentifier
+  export interface ForBinding extends ParseNode {
+    type: 'ForBinding';
+    BindingIdentifier?: BindingIdentifier;
+    BindingPattern?: BindingPattern;
+  }
+
+  // IterationStatement :
+  //   DoWhileStatement
+  //   WhileStatement
+  //   ForStatement
+  //   ForInOfStatement
+  export type IterationStatement =
+    | DoWhileStatement
+    | WhileStatement
+    | ForStatement
+    | ForInOfStatement;
+
+  // SwitchStatement :
+  //   `switch` `(` Expression `)` CaseBlock
+  export interface SwitchStatement extends ParseNode {
+    type: 'SwitchStatement';
+    Expression: Expression;
+    CaseBlock: CaseBlock;
+  }
+
+  // CaseBlock :
+  //   `{` CaseClauses? `}`
+  //   `{` CaseClauses? DefaultClause CaseClauses? `}`
+  export interface CaseBlock extends ParseNode {
+    type: 'CaseBlock';
+    CaseClauses_a?: CaseClauses;
+    DefaultClause?: DefaultClause;
+    CaseClauses_b?: CaseClauses;
+  }
+
+  // CaseClauses :
+  //   CaseClause
+  //   CaseClauses CauseClause
+  export type CaseClauses = CaseClause[];
+
+  // CaseClause :
+  //   `case` Expression `:` StatementList?
+  export interface CaseClause extends ParseNode {
+    type: 'CaseClause';
+    Expression: Expression;
+    StatementList: StatementList;
+  }
+
+  // DefaultClause :
+  //   `default` `:` StatementList?
+  export interface DefaultClause extends ParseNode {
+    type: 'DefaultClause';
+    StatementList: StatementList;
+  }
+
+  // BreakableStatement :
+  //   IterationStatement
+  //   SwitchStatement
+  export type BreakableStatement =
+    | IterationStatement
+    | SwitchStatement;
+
+  // ContinueStatement :
+  //   `continue` `;`
+  //   `continue` [no LineTerminator here] LabelIdentifier `;`
+  export interface ContinueStatement extends ParseNode {
+    type: 'ContinueStatement';
+    LabelIdentifier: LabelIdentifier | null;
+  }
+
+  // BreakStatement :
+  //   `break` `;`
+  //   `break` [no LineTerminator here] LabelIdentifier `;`
+  export interface BreakStatement extends ParseNode {
+    type: 'BreakStatement';
+    LabelIdentifier: LabelIdentifier | null;
+  }
+
+  // ReturnStatement :
+  //   `return` `;`
+  //   `return` [no LineTerminator here] Expression `;`
+  export interface ReturnStatement extends ParseNode {
+    type: 'ReturnStatement';
+    Expression: Expression | null;
+  }
+
+  // WithStatement :
+  //   `with` `(` Expression `)` Statement
+  export interface WithStatement extends ParseNode {
+    type: 'WithStatement';
+    Expression: Expression;
+    Statement: Statement;
+  }
+
+  // TODO: document
+  export interface LabelledStatement extends ParseNode {
+    type: 'LabelledStatement';
+    LabelIdentifier: LabelIdentifier;
+    LabelledItem: Statement;
+  }
+
+  // ThrowStatement :
+  //   `throw` [no LineTerminator here] Expression `;`
+  export interface ThrowStatement extends ParseNode {
+    type: 'ThrowStatement';
+    Expression: Expression;
+  }
+
+  // TryStatement :
+  //   `try` Block Catch
+  //   `try` Block Finally
+  //   `try` Block Catch Finally
+  export interface TryStatement extends ParseNode {
+    type: 'TryStatement';
+    Block: Block;
+    Catch: Catch | null;
+    Finally: Finally | null;
+  }
+
+  // Catch :
+  //   `catch` `(` CatchParameter `)` Block
+  //   `catch` Block
+  //
+  // CatchParameter :
+  //   BindingIdentifier
+  //   BindingPattern
+  export interface Catch extends ParseNode {
+    type: 'Catch';
+    CatchParameter: BindingPattern | BindingIdentifier | null;
+    Block: Block;
+  }
+
+  // Finally :
+  //   `finally` Block
+  export type Finally =
+    | Block;
+
+  // DebuggerStatement :
+  //   `debugger` `;`
+  export interface DebuggerStatement extends ParseNode {
+    type: 'DebuggerStatement';
+  }
+
+  export type Statement =
+    | BlockStatement
+    | VariableStatement
+    | EmptyStatement
+    | ExpressionStatement
+    | IfStatement
+    | BreakableStatement
+    | ContinueStatement
+    | BreakStatement
+    | ReturnStatement
+    | WithStatement
+    | LabelledStatement
+    | ThrowStatement
+    | TryStatement
+    | DebuggerStatement;
+export type HoistableDeclaration =
+    | FunctionDeclaration
+    | GeneratorDeclaration
+    | AsyncFunctionDeclaration
+    | AsyncGeneratorDeclaration;
+export type Declaration =
+    | HoistableDeclaration
+    | ClassDeclaration
+    | LexicalDeclarationLike;
+
+  // Script :
+  //   ScriptBody?
+  export interface Script extends ParseNode {
+    type: 'Script';
+    ScriptBody: ScriptBody | null;
+  }
+
+  // ScriptBody :
+  //   StatementList
+  export interface ScriptBody extends ParseNode {
+    type: 'ScriptBody';
+    StatementList: StatementList;
+  }
+
+  // Module :
+  //   ModuleBody?
+  export interface Module extends ParseNode {
+    type: 'Module';
+    ModuleBody: ModuleBody | null;
+    hasTopLevelAwait: boolean;
+  }
+
+  // ModuleBody :
+  //   ModuleItemList
+  export interface ModuleBody extends ParseNode {
+    type: 'ModuleBody';
+    ModuleItemList: ModuleItemList;
+  }
+
+  // ModuleItemList :
+  //   ModuleItem
+  //   ModuleItemList ModuleItem
+  export type ModuleItemList = ModuleItem[];
+
+  // ModuleItem :
+  //   ImportDeclaration
+  //   ExportDeclaration
+  //   StatementListItem
+  export type ModuleItem =
+    | ImportDeclaration
+    | ExportDeclaration
+    | StatementListItem;
+
+  // ModuleExportName :
+  //   IdentifierName
+  //   StringLiteral
+  export type ModuleExportName =
+    | IdentifierName
+    | StringLiteral;
+
+  // ImportDeclaration :
+  //   `import` ImportClause FromClause `;`
+  //   `import` ModuleSpecifier `;`
+  export interface ImportDeclaration extends ParseNode {
+    type: 'ImportDeclaration';
+    ModuleSpecifier?: PrimaryExpression;
+    ImportClause?: ImportClause;
+    FromClause?: FromClause;
+  }
+
+  // FromClause :
+  //   `from` ModuleSpecifier
+  export type FromClause =
+    | ModuleSpecifier;
+
+  // ModuleSpecifier :
+  //   StringLiteral
+  export type ModuleSpecifier =
+    | StringLiteral;
+
+  // ImportClause :
+  //   ImportedDefaultBinding
+  //   NameSpaceImport
+  //   NamedImports
+  //   ImportedDefaultBinding `,` NameSpaceImport
+  //   ImportedDefaultBinding `,` NamedImports
+  export interface ImportClause extends ParseNode {
+    type: 'ImportClause';
+    ImportedDefaultBinding?: ImportedDefaultBinding;
+    NameSpaceImport?: NameSpaceImport;
+    NamedImports?: NamedImports;
+  }
+
+  // ImportedDefaultBinding :
+  //   ImportedBinding
+  export interface ImportedDefaultBinding extends ParseNode {
+    type: 'ImportedDefaultBinding';
+    ImportedBinding: ImportedBinding;
+  }
+
+  // ImportedBinding :
+  //   BindingIdentifier
+  export type ImportedBinding =
+    | BindingIdentifier;
+
+  // NameSpaceImport :
+  //   `*` `as` ImportedBinding
+  export interface NameSpaceImport extends ParseNode {
+    type: 'NameSpaceImport';
+    ImportedBinding: ImportedBinding;
+  }
+
+  // NamedImports :
+  //   `{` `}`
+  //   `{` ImportsList `}`
+  //   `{` ImportsList `,` `}`
+  export interface NamedImports extends ParseNode {
+    type: 'NamedImports';
+    ImportsList: ImportsList;
+  }
+
+  // ImportsList :
+  //   ImportSpecifier
+  //   ImportsList `,` ImportSpecifier
+  export type ImportsList = ImportSpecifier[];
+
+  // ImportSpecifier :
+  //   ImportedBinding
+  //   ModuleExportName `as` ImportedBinding
+  export interface ImportSpecifier extends ParseNode {
+    type: 'ImportSpecifier';
+    ModuleExportName?: ModuleExportName;
+    ImportedBinding: ImportedBinding;
+  }
+
+  // ExportDeclaration :
+  //   `export` ExportFromClause FromClause `;`
+  //   `export` NamedExports `;`
+  //   `export` VariableStatement
+  //   `export` Declaration
+  //   `export` `default` HoistableDeclaration
+  //   `export` `default` ClassDeclaration
+  //   `export` `default` AssignmentExpression `;`
+  export interface ExportDeclaration extends ParseNode {
+    type: 'ExportDeclaration';
+    default: boolean;
+    HoistableDeclaration?: HoistableDeclaration;
+    ClassDeclaration?: ClassDeclaration;
+    AssignmentExpression?: AssignmentExpressionOrHigher;
+    Declaration?: Declaration;
+    VariableStatement?: VariableStatement;
+    ExportFromClause?: ExportFromClauseLike;
+    FromClause?: FromClause;
+    NamedExports?: NamedExports;
+  }
+
+  // ExportFromClause (partial) :
+  //   `*`
+  //   `*` as ModuleExportName
+  export interface ExportFromClause extends ParseNode {
+    type: 'ExportFromClause';
+    ModuleExportName?: ModuleExportName;
+  }
+
+  // ExportFromClause :
+  //   `*`
+  //   `*` as ModuleExportName
+  //   NamedExports
+  export type ExportFromClauseLike =
+    | NamedExports
+    | ExportFromClause;
+
+  // NamedExports :
+  //   `{` `}`
+  //   `{` ExportsList `}`
+  //   `{` ExportsList `,` `}`
+  export interface NamedExports extends ParseNode {
+    type: 'NamedExports';
+    ExportsList: ExportsList;
+  }
+
+  // ExportsList :
+  //   ExportSpecifier
+  //   ExportsList `,` ExportSpecifier
+  export type ExportsList = ExportSpecifier[];
+
+  // ExportSpecifier :
+  //   ModuleExportName
+  //   ModuleExportName `as` ModuleExportName
+  export interface ExportSpecifier extends ParseNode {
+    type: 'ExportSpecifier';
+    localName: ModuleExportName;
+    exportName: ModuleExportName;
+  }
+
+  // Gets all keys of all constituents of a union
+  type AllKeysOf<T> = T extends unknown ? keyof T : never;
+
+  // Gets all values for a given key for all constituents of a union
+  type AllValuesOf<T, K extends AllKeysOf<T>> = T extends unknown ? K extends keyof T ? T[K] : never : never;
+
+  // NON-SPEC
+  /**
+   * Used internally to describe a node that is still being parsed. Unfinished nodes may not yet be fully defined.
+   */
+  export type Unfinished<T extends ParseNode> = (
+    // An unfinished node...
+
+    // ...includes all properties of ParseNode except `type`
+    & Pick<ParseNode, 'location' | 'strict' | 'sourceText'>
+
+    // ...includes all properties of all potential types, with each property marked as optional
+    & { [K in Exclude<AllKeysOf<T>, 'location' | 'strict' | 'sourceText'>]?: AllValuesOf<T, K>; }
+
+    // ...includes a type-only cache of the potential nodes it represents. The finished type will be extracted from
+    //    this cache.
+    & { [K in typeof kPotentialNodes]: T }
+  );
+
+  // NON-SPEC
+  /**
+   * Used internally to indicate a node that has finished parsing.
+   */
+  export type Finished<T extends ParseNode | Unfinished<ParseNode>, K extends T['type']> =
+    T extends Unfinished<ParseNode> ? Extract<T[typeof kPotentialNodes], { type: K }> :
+    T;
+}
+
+// This value does not exist at runtime. Only its type is used to stash additional type information on a `ParseNode.Unfinished` type.
+declare const kPotentialNodes: unique symbol;

--- a/src/parser/ParseNode.mts
+++ b/src/parser/ParseNode.mts
@@ -448,6 +448,7 @@ export namespace ParseNode {
     readonly type: 'CallExpression';
     readonly CallExpression: CallExpressionOrHigher | MemberExpressionOrHigher;
     readonly Arguments: Arguments;
+    // NON-SPEC
     readonly arrowInfo?: ArrowInfo;
   }
 
@@ -460,6 +461,7 @@ export namespace ParseNode {
     readonly type: 'TaggedTemplateExpression';
     readonly MemberExpression: CallExpressionOrHigher | MemberExpressionOrHigher;
     readonly TemplateLiteral: TemplateLiteral;
+    // NON-SPEC
     readonly arrowInfo?: ArrowInfo;
   }
 

--- a/src/parser/ParseNode.mts
+++ b/src/parser/ParseNode.mts
@@ -168,7 +168,7 @@ export namespace ParseNode {
   //   `(` Expression `.` `...` BindingPattern `)`
   export interface CoverParenthesizedExpressionAndArrowParameterList extends BaseParseNode {
     readonly type: 'CoverParenthesizedExpressionAndArrowParameterList';
-    readonly Arguments: (ArgumentListElement | BindingRestElement)[];
+    readonly Arguments: readonly (ArgumentListElement | BindingRestElement)[];
     readonly arrowInfo?: ArrowInfo;
   }
 
@@ -210,7 +210,7 @@ export namespace ParseNode {
   //   Elision? SpreadElement
   //   ElementList `,` Elision? AssignmentExpression
   //   ElementList `,` Elision? SpreadElement
-  export type ElementList = ElementListElement[];
+  export type ElementList = readonly ElementListElement[];
 
   // NON-SPEC
   export type ElementListElement =
@@ -244,7 +244,7 @@ export namespace ParseNode {
   // PropertyDefinitionList :
   //   PropertyDefinition
   //   PropertyDefinitionList `,` PropertyDefinition
-  export type PropertyDefinitionList = PropertyDefinitionLike[];
+  export type PropertyDefinitionList = readonly PropertyDefinitionLike[];
 
   // PropertyDefinition :
   //   IdentifierReference
@@ -322,8 +322,8 @@ export namespace ParseNode {
   //   TemplateMiddleList TemplateMiddle Expression
   export interface TemplateLiteral extends BaseParseNode {
     readonly type: 'TemplateLiteral';
-    readonly TemplateSpanList: string[];
-    readonly ExpressionList: Expression[];
+    readonly TemplateSpanList: readonly string[];
+    readonly ExpressionList: readonly Expression[];
   }
 
   // MemberExpression :
@@ -487,7 +487,7 @@ export namespace ParseNode {
   //   `...` AssignmentExpression
   //   ArgumentList `,` AssignmentExpression
   //   ArgumentList `,` `...` AssignmentExpression
-  export type Arguments = ArgumentListElement[];
+  export type Arguments = readonly ArgumentListElement[];
 
   // NON-SPEC
   export type ArgumentListElement =
@@ -937,7 +937,7 @@ export namespace ParseNode {
   //   Expression `,` AssignmentExpression
   export interface CommaOperator extends BaseParseNode {
     readonly type: 'CommaOperator';
-    readonly ExpressionList: AssignmentExpressionOrHigher[];
+    readonly ExpressionList: readonly AssignmentExpressionOrHigher[];
   }
 
   // A.3 Statements
@@ -1016,7 +1016,7 @@ export namespace ParseNode {
   // StatementList :
   //   StatementListItem
   //   StatementList StatementListItem
-  export type StatementList = StatementListItem[];
+  export type StatementList = readonly StatementListItem[];
 
   // StatementListItem :
   //   Statement
@@ -1048,7 +1048,7 @@ export namespace ParseNode {
   // BindingList :
   //   LexicalBinding
   //   BindingList `,` LexicalBinding
-  export type BindingList = LexicalBinding[];
+  export type BindingList = readonly LexicalBinding[];
 
   // LexicalBinding :
   //   BindingIdentifier Initializer?
@@ -1075,7 +1075,7 @@ export namespace ParseNode {
   // VariableDeclarationList :
   //   VariableDeclaration
   //   VariableDeclarationList `,` VariableDeclaration
-  export type VariableDeclarationList = VariableDeclaration[];
+  export type VariableDeclarationList = readonly VariableDeclaration[];
 
   // VariableDeclaration :
   //   BindingIdentifier Initializer?
@@ -1125,12 +1125,12 @@ export namespace ParseNode {
   // BindingPropertyList :
   //   BindingProperty
   //   BindingPropertyList BindingProperty
-  export type BindingPropertyList = BindingPropertyLike[];
+  export type BindingPropertyList = readonly BindingPropertyLike[];
 
   // BindingElementList :
   //   BindingElisionElement
   //   BindingElementList `,` BindingElisionElement
-  export type BindingElementList = BindingElisionElement[];
+  export type BindingElementList = readonly BindingElisionElement[];
 
   // BindingElisionElement :
   //   Elision? BindingElement
@@ -1445,7 +1445,7 @@ export namespace ParseNode {
   // CaseClauses :
   //   CaseClause
   //   CaseClauses CauseClause
-  export type CaseClauses = CaseClause[];
+  export type CaseClauses = readonly CaseClause[];
 
   // CaseClause :
   //   `case` Expression `:` StatementList?
@@ -1540,7 +1540,7 @@ export namespace ParseNode {
   //   FormalParameterList
   //   FormalParameterList `,`
   //   FormalParameterList `,` FunctionRestParameter
-  export type FormalParameters = FormalParametersElement[];
+  export type FormalParameters = readonly FormalParametersElement[];
 
   // NON-SPEC
   export type FormalParametersElement = FormalParameterList[number] | FunctionRestParameter;
@@ -1548,7 +1548,7 @@ export namespace ParseNode {
   // FormalParameterList :
   //   FormalParameter
   //   FormalParameterList `,` FormalParameterList
-  export type FormalParameterList = FormalParameter[];
+  export type FormalParameterList = readonly FormalParameter[];
 
   // FunctionRestParameter :
   //   BindingRestElement
@@ -1901,7 +1901,7 @@ export namespace ParseNode {
   // ClassElementList :
   //   ClassElement
   //   ClassElementList ClassElement
-  export type ClassElementList = ClassElement[];
+  export type ClassElementList = readonly ClassElement[];
 
   // ClassElement :
   //   MethodDefinition
@@ -1987,7 +1987,7 @@ export namespace ParseNode {
   // ModuleItemList :
   //   ModuleItem
   //   ModuleItemList ModuleItem
-  export type ModuleItemList = ModuleItem[];
+  export type ModuleItemList = readonly ModuleItem[];
 
   // ModuleItem :
   //   ImportDeclaration
@@ -2059,7 +2059,7 @@ export namespace ParseNode {
   // ImportsList :
   //   ImportSpecifier
   //   ImportsList `,` ImportSpecifier
-  export type ImportsList = ImportSpecifier[];
+  export type ImportsList = readonly ImportSpecifier[];
 
   // ImportSpecifier :
   //   ImportedBinding
@@ -2129,7 +2129,7 @@ export namespace ParseNode {
   // ExportsList :
   //   ExportSpecifier
   //   ExportsList `,` ExportSpecifier
-  export type ExportsList = ExportSpecifier[];
+  export type ExportsList = readonly ExportSpecifier[];
 
   // ExportSpecifier :
   //   ModuleExportName
@@ -2171,7 +2171,9 @@ export namespace ParseNode {
     }
 
     // ...includes all properties of all potential types, with each property marked as optional
-    & { -readonly [K in Exclude<AllKeysOf<T>, 'location' | 'strict' | 'sourceText'>]?: AllValuesOf<T, K>; }
+    & {
+      -readonly [K in Exclude<AllKeysOf<T>, 'location' | 'strict' | 'sourceText'>]?: AllValuesOf<T, K>;
+    }
   );
 
   // NON-SPEC

--- a/src/parser/ParseNode.mts
+++ b/src/parser/ParseNode.mts
@@ -1586,7 +1586,7 @@ export namespace ParseNode {
   export type FunctionBodyLike =
     | FunctionBody
     | GeneratorBody
-    | AsyncFunctionBody
+    | AsyncBody
     | AsyncGeneratorBody;
 
   // FunctionDeclaration :
@@ -1626,7 +1626,7 @@ export namespace ParseNode {
   export interface ArrowFunction extends BaseParseNode {
     readonly type: 'ArrowFunction';
     readonly ArrowParameters: ArrowParameters;
-    readonly ConciseBody: ConciseBodyOrHigher;
+    readonly ConciseBody: ConciseBodyLike;
   }
 
   // ArrowParameters :
@@ -1641,7 +1641,7 @@ export namespace ParseNode {
   // ConciseBody :
   //   ExpressionBody
   //   `{` FunctionBody `}`
-  export type ConciseBodyOrHigher =
+  export type ConciseBodyLike =
     | FunctionBody
     | ConciseBody;
 
@@ -1683,10 +1683,10 @@ export namespace ParseNode {
 
   // AsyncConciseBody :
   //   ExpressionBody
-  //   `{` AsyncFunctionBody `}`
+  //   `{` AsyncBody `}`
   export type AsyncConciseBodyLike =
     | AsyncConciseBody
-    | AsyncFunctionBody;
+    | AsyncBody;
 
   // AsyncConciseBody (partial) :
   //   ExpressionBody
@@ -1821,7 +1821,7 @@ export namespace ParseNode {
     readonly type: 'AsyncFunctionDeclaration';
     readonly BindingIdentifier: BindingIdentifier | null;
     readonly FormalParameters: FormalParameters;
-    readonly AsyncBody: AsyncFunctionBody;
+    readonly AsyncBody: AsyncBody;
   }
 
   // AsyncFunctionExpression :
@@ -1830,7 +1830,7 @@ export namespace ParseNode {
     readonly type: 'AsyncFunctionExpression';
     readonly BindingIdentifier: BindingIdentifier | null;
     readonly FormalParameters: FormalParameters;
-    readonly AsyncBody: AsyncFunctionBody;
+    readonly AsyncBody: AsyncBody;
   }
 
   // AsyncMethod :
@@ -1841,13 +1841,13 @@ export namespace ParseNode {
     readonly ClassElementName: ClassElementName;
     readonly PropertySetParameterList: null;
     readonly UniqueFormalParameters: UniqueFormalParameters;
-    readonly AsyncBody: AsyncFunctionBody;
+    readonly AsyncBody: AsyncBody;
   }
 
   // AsyncBody :
   //   FunctionBody
-  export interface AsyncFunctionBody extends BaseParseNode {
-    readonly type: 'AsyncFunctionBody';
+  export interface AsyncBody extends BaseParseNode {
+    readonly type: 'AsyncBody';
     readonly directives: string[];
     readonly strict: boolean;
     readonly FunctionStatementList: FunctionStatementList;
@@ -2231,7 +2231,7 @@ export type ParseNode =
   | ParseNode.AsyncFunctionDeclaration
   | ParseNode.AsyncFunctionExpression
   | ParseNode.AsyncMethod
-  | ParseNode.AsyncFunctionBody
+  | ParseNode.AsyncBody
   | ParseNode.AsyncArrowFunction
   | ParseNode.AsyncConciseBody
   | ParseNode.RegularExpressionLiteral

--- a/src/parser/Parser.mts
+++ b/src/parser/Parser.mts
@@ -15,13 +15,13 @@ export class Parser extends LanguageParser {
   source: string;
   specifier: string;
   earlyErrors: Set<SyntaxError>;
-  state: {
+  readonly state: {
     hasTopLevelAwait: boolean;
     strict: boolean;
     json: boolean;
   };
 
-  scope = new Scope(this);
+  readonly scope = new Scope(this);
   constructor({ source, specifier, json = false }: { source: string, specifier: string, json?: boolean }) {
     super();
     this.source = source;
@@ -32,7 +32,6 @@ export class Parser extends LanguageParser {
       strict: false,
       json,
     };
-    this.scope = new Scope(this);
   }
 
   isStrictMode() {

--- a/src/parser/Parser.mts
+++ b/src/parser/Parser.mts
@@ -182,5 +182,6 @@ ${' '.repeat(startIndex - lineStart)}${'^'.repeat(Math.max(endIndex - startIndex
 declare global {
   interface SyntaxError {
     decoration?: string;
+    position?: number
   }
 }

--- a/src/parser/Parser.mts
+++ b/src/parser/Parser.mts
@@ -12,9 +12,9 @@ import { Scope } from './Scope.mjs';
 import { Token } from './tokens.mjs';
 
 export class Parser extends LanguageParser {
-  source: string;
-  specifier: string;
-  earlyErrors: Set<SyntaxError>;
+  protected readonly source: string;
+  protected readonly specifier: string;
+  readonly earlyErrors: Set<SyntaxError>;
   readonly state: {
     hasTopLevelAwait: boolean;
     strict: boolean;

--- a/src/parser/Parser.mts
+++ b/src/parser/Parser.mts
@@ -21,7 +21,7 @@ export class Parser extends LanguageParser {
     json: boolean;
   };
 
-  readonly scope = new Scope(this);
+  protected readonly scope = new Scope(this);
   constructor({ source, specifier, json = false }: { source: string, specifier: string, json?: boolean }) {
     super();
     this.source = source;

--- a/src/parser/Scope.mts
+++ b/src/parser/Scope.mts
@@ -147,11 +147,11 @@ export interface UndefinedPrivateAccessInfo {
 }
 
 export interface ArrowInfo {
-  isAsync: boolean;
+  readonly isAsync: boolean;
   hasTrailingComma: boolean;
-  yieldExpressions: ParseNode[];
-  awaitExpressions: ParseNode[];
-  awaitIdentifiers: ParseNode[];
+  readonly yieldExpressions: ParseNode[];
+  readonly awaitExpressions: ParseNode[];
+  readonly awaitIdentifiers: ParseNode[];
   merge(other: ArrowInfo): void;
 }
 

--- a/src/parser/Scope.mts
+++ b/src/parser/Scope.mts
@@ -1,4 +1,5 @@
 import { Assert, Parser } from '../api.mjs';
+import { isArray } from '../helpers.mjs';
 import { OutOfRange } from '../helpers.mjs';
 import type { TokenData } from './Lexer.mjs';
 import type { ParseNode } from './ParseNode.mjs';
@@ -19,12 +20,12 @@ export enum Flag {
 }
 
 export interface DeclarationInfo {
-  name: string;
-  node: ParseNode;
+  readonly name: string;
+  readonly node: ParseNode;
 }
 
 export function getDeclarations(node: ParseNode | readonly ParseNode[]): DeclarationInfo[] {
-  if ((Array.isArray as (ar: unknown) => ar is readonly unknown[])(node)) {
+  if (isArray(node)) {
     return node.flatMap((n) => getDeclarations(n));
   }
   switch (node.type) {
@@ -117,33 +118,33 @@ export function getDeclarations(node: ParseNode | readonly ParseNode[]): Declara
 }
 
 export type ScopeFlagSetters =
-  & { [P in (keyof typeof Flag) & string]?: boolean; }
+  & { readonly [P in (keyof typeof Flag) & string]?: boolean; }
   & {
-    lexical?: boolean;
-    variable?: boolean;
-    variableFunctions?: boolean;
-    private?: boolean;
-    label?: string;
-    strict?: boolean;
+    readonly lexical?: boolean;
+    readonly variable?: boolean;
+    readonly variableFunctions?: boolean;
+    readonly private?: boolean;
+    readonly label?: string;
+    readonly strict?: boolean;
   };
 
 export interface ScopeInfo {
-  flags: ScopeFlagSetters;
-  lexicals: Set<string>;
-  variables: Set<string>;
-  functions: Set<string>;
-  parameters: Set<string>;
+  readonly flags: ScopeFlagSetters;
+  readonly lexicals: Set<string>;
+  readonly variables: Set<string>;
+  readonly functions: Set<string>;
+  readonly parameters: Set<string>;
 }
 
 export interface PrivateScopeInfo {
-  outer: PrivateScopeInfo | undefined;
-  names: Map<string, Set<'field' | 'method' | 'get' | 'set'>>;
+  readonly outer: PrivateScopeInfo | undefined;
+  readonly names: Map<string, Set<'field' | 'method' | 'get' | 'set'>>;
 }
 
 export interface UndefinedPrivateAccessInfo {
-  node: ParseNode;
-  name: string;
-  scope: PrivateScopeInfo | undefined;
+  readonly node: ParseNode;
+  readonly name: string;
+  readonly scope: PrivateScopeInfo | undefined;
 }
 
 export interface ArrowInfo {
@@ -156,28 +157,28 @@ export interface ArrowInfo {
 }
 
 export interface AssignmentInfo {
-  type: 'assign' | 'arrow' | 'for';
-  earlyErrors: SyntaxError[];
+  readonly type: 'assign' | 'arrow' | 'for';
+  readonly earlyErrors: SyntaxError[];
   clear(): void;
 }
 
 export interface Label {
   type: string | null;
-  name?: string;
-  nextToken?: TokenData | null;
+  readonly name?: string;
+  readonly nextToken?: TokenData | null;
 }
 
 export class Scope {
-  parser: Parser;
-  scopeStack: ScopeInfo[] = [];
+  private readonly parser: Parser;
+  private readonly scopeStack: ScopeInfo[] = [];
   labels: Label[] = [];
-  arrowInfoStack: (ArrowInfo | null)[] = [];
-  assignmentInfoStack: AssignmentInfo[] = [];
-  exports = new Set<string>();
-  undefinedExports = new Map<string, ParseNode.ModuleExportName>();
-  privateScope: PrivateScopeInfo | undefined;
-  undefinedPrivateAccesses: UndefinedPrivateAccessInfo[] = [];
-  flags: Flag = 0 as Flag;
+  readonly arrowInfoStack: (ArrowInfo | null)[] = [];
+  readonly assignmentInfoStack: AssignmentInfo[] = [];
+  readonly exports = new Set<string>();
+  readonly undefinedExports = new Map<string, ParseNode.ModuleExportName>();
+  private privateScope: PrivateScopeInfo | undefined;
+  private readonly undefinedPrivateAccesses: UndefinedPrivateAccessInfo[] = [];
+  private flags: Flag = 0 as Flag;
   constructor(parser: Parser) {
     this.parser = parser;
   }

--- a/src/parser/Scope.mts
+++ b/src/parser/Scope.mts
@@ -31,97 +31,86 @@ export function getDeclarations(node: ParseNode | ParseNode[]): DeclarationInfo[
     case 'LexicalBinding':
     case 'VariableDeclaration':
     case 'BindingRestElement':
-    case 'ForBinding': {
-      const typedNode = node as ParseNode.LexicalBinding | ParseNode.VariableDeclaration | ParseNode.BindingRestElement | ParseNode.ForBinding;
-      if (typedNode.BindingIdentifier) {
-        return getDeclarations(typedNode.BindingIdentifier);
+    case 'ForBinding':
+      if (node.BindingIdentifier) {
+        return getDeclarations(node.BindingIdentifier);
       }
-      if (typedNode.BindingPattern) {
-        return getDeclarations(typedNode.BindingPattern);
-      }
-      return [];
-    }
-    case 'BindingRestProperty': {
-      const typedNode = node as ParseNode.BindingRestProperty;
-      if (typedNode.BindingIdentifier) {
-        return getDeclarations(typedNode.BindingIdentifier);
+      if (node.BindingPattern) {
+        return getDeclarations(node.BindingPattern);
       }
       return [];
-    }
+    case 'BindingRestProperty':
+      if (node.BindingIdentifier) {
+        return getDeclarations(node.BindingIdentifier);
+      }
+      return [];
     case 'SingleNameBinding':
-      return getDeclarations((node as ParseNode.SingleNameBinding).BindingIdentifier);
+      return getDeclarations(node.BindingIdentifier);
     case 'ImportClause': {
-      const typedNode = node as ParseNode.ImportClause;
       const d = [];
-      if (typedNode.ImportedDefaultBinding) {
-        d.push(...getDeclarations(typedNode.ImportedDefaultBinding));
+      if (node.ImportedDefaultBinding) {
+        d.push(...getDeclarations(node.ImportedDefaultBinding));
       }
-      if (typedNode.NameSpaceImport) {
-        d.push(...getDeclarations(typedNode.NameSpaceImport));
+      if (node.NameSpaceImport) {
+        d.push(...getDeclarations(node.NameSpaceImport));
       }
-      if (typedNode.NamedImports) {
-        d.push(...getDeclarations(typedNode.NamedImports));
+      if (node.NamedImports) {
+        d.push(...getDeclarations(node.NamedImports));
       }
       return d;
     }
     case 'ImportSpecifier':
-      return getDeclarations((node as ParseNode.ImportSpecifier).ImportedBinding);
+      return getDeclarations(node.ImportedBinding);
     case 'ImportedDefaultBinding':
     case 'NameSpaceImport':
-      return getDeclarations((node as ParseNode.ImportedDefaultBinding | ParseNode.NameSpaceImport).ImportedBinding);
+      return getDeclarations(node.ImportedBinding);
     case 'NamedImports':
-      return getDeclarations((node as ParseNode.NamedImports).ImportsList);
+      return getDeclarations(node.ImportsList);
     case 'ObjectBindingPattern': {
-      const typedNode = node as ParseNode.ObjectBindingPattern;
-      const declarations = getDeclarations(typedNode.BindingPropertyList);
-      if (typedNode.BindingRestProperty) {
-        declarations.push(...getDeclarations(typedNode.BindingRestProperty));
+      const declarations = getDeclarations(node.BindingPropertyList);
+      if (node.BindingRestProperty) {
+        declarations.push(...getDeclarations(node.BindingRestProperty));
       }
       return declarations;
     }
     case 'ArrayBindingPattern': {
-      const typedNode = node as ParseNode.ArrayBindingPattern;
-      const declarations = getDeclarations(typedNode.BindingElementList);
-      if (typedNode.BindingRestElement) {
-        declarations.push(...getDeclarations(typedNode.BindingRestElement));
+      const declarations = getDeclarations(node.BindingElementList);
+      if (node.BindingRestElement) {
+        declarations.push(...getDeclarations(node.BindingRestElement));
       }
       return declarations;
     }
     case 'BindingElement':
-      return getDeclarations((node as ParseNode.BindingElement).BindingPattern);
+      return getDeclarations(node.BindingPattern);
     case 'BindingProperty':
-      return getDeclarations((node as ParseNode.BindingProperty).BindingElement);
+      return getDeclarations(node.BindingElement);
     case 'BindingIdentifier':
     case 'IdentifierName':
     case 'LabelIdentifier':
-      return [{ name: (node as ParseNode.BindingIdentifier | ParseNode.IdentifierName | ParseNode.LabelIdentifier).name, node }];
+      return [{ name: node.name, node }];
     case 'PrivateIdentifier':
-      return [{ name: `#${(node as ParseNode.PrivateIdentifier).name}`, node }];
+      return [{ name: `#${node.name}`, node }];
     case 'StringLiteral':
-      return [{ name: (node as ParseNode.StringLiteral).value, node }];
+      return [{ name: node.value, node }];
     case 'Elision':
       return [];
     case 'ForDeclaration':
-      return getDeclarations((node as ParseNode.ForDeclaration).ForBinding);
+      return getDeclarations(node.ForBinding);
     case 'ExportSpecifier':
-      return getDeclarations((node as ParseNode.ExportSpecifier).exportName);
+      return getDeclarations(node.exportName);
     case 'FunctionDeclaration':
     case 'GeneratorDeclaration':
     case 'AsyncFunctionDeclaration':
-    case 'AsyncGeneratorDeclaration': {
-      const typedNode = node as ParseNode.FunctionDeclarationLike;
-      Assert(!!typedNode.BindingIdentifier);
-      return getDeclarations(typedNode.BindingIdentifier);
-    }
+    case 'AsyncGeneratorDeclaration':
+      Assert(!!node.BindingIdentifier);
+      return getDeclarations(node.BindingIdentifier);
     case 'LexicalDeclaration':
-      return getDeclarations((node as ParseNode.LexicalDeclaration).BindingList);
+      return getDeclarations(node.BindingList);
     case 'VariableStatement':
-      return getDeclarations((node as ParseNode.VariableStatement).VariableDeclarationList);
-    case 'ClassDeclaration': {
-      const typedNode = node as ParseNode.ClassDeclaration;
-      Assert(!!typedNode.BindingIdentifier);
-      return getDeclarations(typedNode.BindingIdentifier);
-    }
+      return getDeclarations(node.VariableDeclarationList);
+    case 'ClassDeclaration':
+      Assert(!!node.BindingIdentifier);
+      return getDeclarations(node.BindingIdentifier);
     default:
       throw new OutOfRange('getDeclarations', node);
   }

--- a/src/parser/Scope.mts
+++ b/src/parser/Scope.mts
@@ -1,6 +1,5 @@
 import { Assert, Parser } from '../api.mjs';
-import { isArray } from '../helpers.mjs';
-import { OutOfRange } from '../helpers.mjs';
+import { isArray, OutOfRange } from '../helpers.mjs';
 import type { TokenData } from './Lexer.mjs';
 import type { ParseNode } from './ParseNode.mjs';
 

--- a/src/parser/Scope.mts
+++ b/src/parser/Scope.mts
@@ -23,8 +23,8 @@ export interface DeclarationInfo {
   node: ParseNode;
 }
 
-export function getDeclarations(node: ParseNode | ParseNode[]): DeclarationInfo[] {
-  if (Array.isArray(node)) {
+export function getDeclarations(node: ParseNode | readonly ParseNode[]): DeclarationInfo[] {
+  if ((Array.isArray as (ar: unknown) => ar is readonly unknown[])(node)) {
     return node.flatMap((n) => getDeclarations(n));
   }
   switch (node.type) {
@@ -388,9 +388,9 @@ export class Scope {
     throw new RangeError();
   }
 
-  declare(node: ParseNode | ParseNode[], type: 'private', extraType?: 'field' | 'method' | 'get' | 'set'): void;
-  declare(node: ParseNode | ParseNode[], type: 'lexical' | 'import' | 'function' | 'parameter' | 'variable' | 'export'): void;
-  declare(node: ParseNode | ParseNode[], type: 'lexical' | 'import' | 'function' | 'parameter' | 'variable' | 'export' | 'private', extraType?: 'field' | 'method' | 'get' | 'set') {
+  declare(node: ParseNode | readonly ParseNode[], type: 'private', extraType?: 'field' | 'method' | 'get' | 'set'): void;
+  declare(node: ParseNode | readonly ParseNode[], type: 'lexical' | 'import' | 'function' | 'parameter' | 'variable' | 'export'): void;
+  declare(node: ParseNode | readonly ParseNode[], type: 'lexical' | 'import' | 'function' | 'parameter' | 'variable' | 'export' | 'private', extraType?: 'field' | 'method' | 'get' | 'set') {
     const declarations = getDeclarations(node);
     declarations.forEach((d) => {
       switch (type) {

--- a/src/parser/StatementParser.mts
+++ b/src/parser/StatementParser.mts
@@ -25,6 +25,10 @@ export abstract class StatementParser extends ExpressionParser {
   // StatementList :
   //   StatementListItem
   //   StatementList StatementListItem
+  /**
+   * @param endToken endToken
+   * @param directives directives, this array will be mutated.
+   */
   parseStatementList(endToken: string | Token, directives?: string[]): ParseNode.StatementList {
     const statementList: Mutable<ParseNode.StatementList> = [];
     const oldStrict = this.state.strict;

--- a/src/parser/StatementParser.mts
+++ b/src/parser/StatementParser.mts
@@ -1,10 +1,10 @@
-// @ts-nocheck
 import { Token, isAutomaticSemicolon } from './tokens.mjs';
 import { ExpressionParser } from './ExpressionParser.mjs';
 import { FunctionKind } from './FunctionParser.mjs';
 import { getDeclarations } from './Scope.mjs';
+import type { ParseNode } from './ParseNode.mjs';
 
-export class StatementParser extends ExpressionParser {
+export abstract class StatementParser extends ExpressionParser {
   eatSemicolonWithASI() {
     if (this.eat(Token.SEMICOLON)) {
       return true;
@@ -24,8 +24,8 @@ export class StatementParser extends ExpressionParser {
   // StatementList :
   //   StatementListItem
   //   StatementList StatementListItem
-  parseStatementList(endToken, directives) {
-    const statementList = [];
+  parseStatementList(endToken: string | Token, directives?: string[]): ParseNode.StatementList {
+    const statementList: ParseNode.StatementList = [];
     const oldStrict = this.state.strict;
     const directiveData = [];
     while (!this.eat(endToken)) {
@@ -63,7 +63,7 @@ export class StatementParser extends ExpressionParser {
   //   HoistableDeclaration
   //   ClassDeclaration
   //   LexicalDeclaration
-  parseStatementListItem() {
+  parseStatementListItem(): ParseNode.StatementListItem {
     switch (this.peek().type) {
       case Token.FUNCTION:
         return this.parseHoistableDeclaration();
@@ -96,7 +96,7 @@ export class StatementParser extends ExpressionParser {
   //   GeneratorDeclaration
   //   AsyncFunctionDeclaration
   //   AsyncGeneratorDeclaration
-  parseHoistableDeclaration() {
+  parseHoistableDeclaration(): ParseNode.HoistableDeclaration {
     switch (this.peek().type) {
       case Token.FUNCTION:
         return this.parseFunctionDeclaration(FunctionKind.NORMAL);
@@ -111,15 +111,15 @@ export class StatementParser extends ExpressionParser {
   // ClassDeclaration :
   //   `class` BindingIdentifier ClassTail
   //   [+Default] `class` ClassTail
-  parseClassDeclaration() {
-    return this.parseClass(false);
+  parseClassDeclaration(): ParseNode.ClassDeclaration {
+    return this.parseClass(false) as ParseNode.ClassDeclaration;
   }
 
   // LexicalDeclaration : LetOrConst BindingList `;`
-  parseLexicalDeclaration() {
-    const node = this.startNode();
-    const letOrConst = this.eat('let') || this.expect(Token.CONST);
-    node.LetOrConst = letOrConst.type === Token.CONST ? 'const' : 'let';
+  parseLexicalDeclaration(): ParseNode.LexicalDeclarationLike {
+    const node = this.startNode<ParseNode.LexicalDeclaration>();
+    const letOrConst = this.eat('let') ? 'let' : this.expect(Token.CONST) && 'const';
+    node.LetOrConst = letOrConst;
     node.BindingList = this.parseBindingList();
     this.semicolon();
 
@@ -140,12 +140,11 @@ export class StatementParser extends ExpressionParser {
   // LexicalBinding :
   //   BindingIdentifier Initializer?
   //   BindingPattern Initializer
-  parseBindingList() {
-    const bindingList = [];
+  parseBindingList(): ParseNode.BindingList {
+    const bindingList: ParseNode.BindingList = [];
     do {
       const node = this.parseBindingElement();
-      node.type = 'LexicalBinding';
-      bindingList.push(node);
+      bindingList.push(this.repurpose(node, 'LexicalBinding') as ParseNode.LexicalBinding);
     } while (this.eat(Token.COMMA));
     return bindingList;
   }
@@ -155,8 +154,8 @@ export class StatementParser extends ExpressionParser {
   //   BindingPattern Initializer?
   // SingleNameBinding :
   //   BindingIdentifier Initializer?
-  parseBindingElement() {
-    const node = this.startNode();
+  parseBindingElement(): ParseNode.BindingElementOrHigher {
+    const node = this.startNode<ParseNode.BindingElementOrHigher>();
     if (this.test(Token.LBRACE) || this.test(Token.LBRACK)) {
       node.BindingPattern = this.parseBindingPattern();
     } else {
@@ -169,7 +168,7 @@ export class StatementParser extends ExpressionParser {
   // BindingPattern:
   //   ObjectBindingPattern
   //   ArrayBindingPattern
-  parseBindingPattern() {
+  parseBindingPattern(): ParseNode.BindingPattern {
     switch (this.peek().type) {
       case Token.LBRACE:
         return this.parseObjectBindingPattern();
@@ -185,8 +184,8 @@ export class StatementParser extends ExpressionParser {
   //   `{` BindingRestProperty `}`
   //   `{` BindingPropertyList `}`
   //   `{` BindingPropertyList `,` BindingRestProperty? `}`
-  parseObjectBindingPattern() {
-    const node = this.startNode();
+  parseObjectBindingPattern(): ParseNode.ObjectBindingPattern {
+    const node = this.startNode<ParseNode.ObjectBindingPattern>();
     this.expect(Token.LBRACE);
     node.BindingPropertyList = [];
     while (!this.eat(Token.RBRACE)) {
@@ -208,30 +207,28 @@ export class StatementParser extends ExpressionParser {
   // BindingProperty :
   //   SingleNameBinding
   //   PropertyName : BindingElement
-  parseBindingProperty() {
-    const node = this.startNode();
+  parseBindingProperty(): ParseNode.BindingPropertyLike {
+    const node = this.startNode<ParseNode.BindingProperty | ParseNode.SingleNameBinding>();
     const name = this.parsePropertyName();
     if (this.eat(Token.COLON)) {
       node.PropertyName = name;
       node.BindingElement = this.parseBindingElement();
       return this.finishNode(node, 'BindingProperty');
     } else {
+      if (name.type !== 'IdentifierName') {
+        this.unexpected(name);
+      }
       this.validateIdentifierReference(name.name, node);
     }
-    node.BindingIdentifier = name;
-    if (name.type === 'IdentifierName') {
-      name.type = 'BindingIdentifier';
-    } else {
-      this.unexpected(name);
-    }
+    node.BindingIdentifier = this.repurpose(name, 'BindingIdentifier') as ParseNode.BindingIdentifier;
     node.Initializer = this.parseInitializerOpt();
     return this.finishNode(node, 'SingleNameBinding');
   }
 
   // BindingRestProperty :
   //  `...` BindingIdentifier
-  parseBindingRestProperty() {
-    const node = this.startNode();
+  parseBindingRestProperty(): ParseNode.BindingRestProperty {
+    const node = this.startNode<ParseNode.BindingRestProperty>();
     this.expect(Token.ELLIPSIS);
     node.BindingIdentifier = this.parseBindingIdentifier();
     return this.finishNode(node, 'BindingRestProperty');
@@ -241,13 +238,13 @@ export class StatementParser extends ExpressionParser {
   //   `[` Elision? BindingRestElement `]`
   //   `[` BindingElementList `]`
   //   `[` BindingElementList `,` Elision? BindingRestElement `]`
-  parseArrayBindingPattern() {
-    const node = this.startNode();
+  parseArrayBindingPattern(): ParseNode.ArrayBindingPattern {
+    const node = this.startNode<ParseNode.ArrayBindingPattern>();
     this.expect(Token.LBRACK);
     node.BindingElementList = [];
     while (true) {
       while (this.test(Token.COMMA)) {
-        const elision = this.startNode();
+        const elision = this.startNode<ParseNode.Elision>();
         this.next();
         node.BindingElementList.push(this.finishNode(elision, 'Elision'));
       }
@@ -272,8 +269,8 @@ export class StatementParser extends ExpressionParser {
   // BindingRestElement :
   //   `...` BindingIdentifier
   //   `...` BindingPattern
-  parseBindingRestElement() {
-    const node = this.startNode();
+  parseBindingRestElement(): ParseNode.BindingRestElement {
+    const node = this.startNode<ParseNode.BindingRestElement>();
     this.expect(Token.ELLIPSIS);
     switch (this.peek().type) {
       case Token.LBRACE:
@@ -288,7 +285,7 @@ export class StatementParser extends ExpressionParser {
   }
 
   // Initializer : `=` AssignmentExpression
-  parseInitializerOpt() {
+  parseInitializerOpt(): ParseNode.Initializer | null {
     if (this.eat(Token.ASSIGN)) {
       return this.parseAssignmentExpression();
     }
@@ -296,20 +293,20 @@ export class StatementParser extends ExpressionParser {
   }
 
   // FunctionDeclaration
-  parseFunctionDeclaration(kind) {
-    return this.parseFunction(false, kind);
+  parseFunctionDeclaration(kind: FunctionKind): ParseNode.FunctionDeclarationLike {
+    return this.parseFunction(false, kind) as ParseNode.FunctionDeclarationLike;
   }
 
   // Statement :
   //   ...
-  parseStatement() {
+  parseStatement(): ParseNode.Statement {
     switch (this.peek().type) {
       case Token.LBRACE:
         return this.parseBlockStatement();
       case Token.VAR:
         return this.parseVariableStatement();
       case Token.SEMICOLON: {
-        const node = this.startNode();
+        const node = this.startNode<ParseNode.EmptyStatement>();
         this.next();
         return this.finishNode(node, 'EmptyStatement');
       }
@@ -342,23 +339,21 @@ export class StatementParser extends ExpressionParser {
   }
 
   // BlockStatement : Block
-  parseBlockStatement() {
+  parseBlockStatement(): ParseNode.BlockStatement {
     return this.parseBlock();
   }
 
   // Block : `{` StatementList `}`
-  parseBlock(lexical = true) {
-    const node = this.startNode();
+  parseBlock(lexical = true): ParseNode.Block {
+    const node = this.startNode<ParseNode.Block>();
     this.expect(Token.LBRACE);
-    this.scope.with({ lexical }, () => {
-      node.StatementList = this.parseStatementList(Token.RBRACE);
-    });
+    node.StatementList = this.scope.with({ lexical }, () => this.parseStatementList(Token.RBRACE));
     return this.finishNode(node, 'Block');
   }
 
   // VariableStatement : `var` VariableDeclarationList `;`
-  parseVariableStatement() {
-    const node = this.startNode();
+  parseVariableStatement(): ParseNode.VariableStatement {
+    const node = this.startNode<ParseNode.VariableStatement>();
     this.expect(Token.VAR);
     node.VariableDeclarationList = this.parseVariableDeclarationList();
     this.semicolon();
@@ -369,8 +364,8 @@ export class StatementParser extends ExpressionParser {
   // VariableDeclarationList :
   //   VariableDeclaration
   //   VariableDeclarationList `,` VariableDeclaration
-  parseVariableDeclarationList(firstDeclarationRequiresInit = true) {
-    const declarationList = [];
+  parseVariableDeclarationList(firstDeclarationRequiresInit = true): ParseNode.VariableDeclarationList {
+    const declarationList: ParseNode.VariableDeclarationList = [];
     do {
       const node = this.parseVariableDeclaration(firstDeclarationRequiresInit);
       declarationList.push(node);
@@ -381,8 +376,8 @@ export class StatementParser extends ExpressionParser {
   // VariableDeclaration :
   //   BindingIdentifier Initializer?
   //   BindingPattern Initializer
-  parseVariableDeclaration(firstDeclarationRequiresInit) {
-    const node = this.startNode();
+  parseVariableDeclaration(firstDeclarationRequiresInit: boolean): ParseNode.VariableDeclaration {
+    const node = this.startNode<ParseNode.VariableDeclaration>();
     switch (this.peek().type) {
       case Token.LBRACE:
       case Token.LBRACK:
@@ -405,8 +400,8 @@ export class StatementParser extends ExpressionParser {
   // IfStatement :
   //  `if` `(` Expression `)` Statement `else` Statement
   //  `if` `(` Expression `)` Statement [lookahead != `else`]
-  parseIfStatement() {
-    const node = this.startNode();
+  parseIfStatement(): ParseNode.IfStatement {
+    const node = this.startNode<ParseNode.IfStatement>();
     this.expect(Token.IF);
     this.expect(Token.LPAREN);
     node.Expression = this.parseExpression();
@@ -419,8 +414,8 @@ export class StatementParser extends ExpressionParser {
   }
 
   // `while` `(` Expression `)` Statement
-  parseWhileStatement() {
-    const node = this.startNode();
+  parseWhileStatement(): ParseNode.WhileStatement {
+    const node = this.startNode<ParseNode.WhileStatement>();
     this.expect(Token.WHILE);
     this.expect(Token.LPAREN);
     node.Expression = this.parseExpression();
@@ -432,12 +427,10 @@ export class StatementParser extends ExpressionParser {
   }
 
   // `do` Statement `while` `(` Expression `)` `;`
-  parseDoWhileStatement() {
-    const node = this.startNode();
+  parseDoWhileStatement(): ParseNode.DoWhileStatement {
+    const node = this.startNode<ParseNode.DoWhileStatement>();
     this.expect(Token.DO);
-    this.scope.with({ label: 'loop' }, () => {
-      node.Statement = this.parseStatement();
-    });
+    node.Statement = this.scope.with({ label: 'loop' }, () => this.parseStatement());
     this.expect(Token.WHILE);
     this.expect(Token.LPAREN);
     node.Expression = this.parseExpression();
@@ -461,12 +454,12 @@ export class StatementParser extends ExpressionParser {
   // `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
   //
   // ForDeclaration : LetOrConst ForBinding
-  parseForStatement() {
+  parseForStatement(): ParseNode.ForStatement | ParseNode.ForInOfStatement {
     return this.scope.with({
       lexical: true,
       label: 'loop',
     }, () => {
-      const node = this.startNode();
+      const node = this.startNode<ParseNode.ForStatement | ParseNode.ForInOfStatement>();
       this.expect(Token.FOR);
       const isAwait = this.scope.hasAwait() && this.eat(Token.AWAIT);
       if (isAwait && !this.scope.hasReturn()) {
@@ -501,7 +494,7 @@ export class StatementParser extends ExpressionParser {
         }
       };
       if ((this.test('let') || this.test(Token.CONST)) && isLexicalStart()) {
-        const inner = this.startNode();
+        const inner = this.startNode<ParseNode.LexicalDeclaration | ParseNode.ForDeclaration>();
         if (this.eat('let')) {
           inner.LetOrConst = 'let';
         } else {
@@ -525,10 +518,9 @@ export class StatementParser extends ExpressionParser {
           node.Statement = this.parseStatement();
           return this.finishNode(node, 'ForStatement');
         }
-        inner.ForBinding = list[0];
-        inner.ForBinding.type = 'ForBinding';
-        if (inner.ForBinding.Initializer) {
-          this.unexpected(inner.ForBinding.Initializer);
+        inner.ForBinding = this.repurpose(list[0], 'ForBinding') as ParseNode.ForBinding;
+        if (list[0].Initializer) {
+          this.unexpected(list[0].Initializer);
         }
         node.ForDeclaration = this.finishNode(inner, 'ForDeclaration');
         getDeclarations(node.ForDeclaration)
@@ -573,10 +565,9 @@ export class StatementParser extends ExpressionParser {
           node.Statement = this.parseStatement();
           return this.finishNode(node, 'ForStatement');
         }
-        node.ForBinding = list[0];
-        node.ForBinding.type = 'ForBinding';
-        if (node.ForBinding.Initializer) {
-          this.unexpected(node.ForBinding.Initializer);
+        node.ForBinding = this.repurpose(list[0], 'ForBinding') as ParseNode.ForBinding;
+        if (list[0].Initializer) {
+          this.unexpected(list[0].Initializer);
         }
         if (this.eat('of')) {
           node.AssignmentExpression = this.parseAssignmentExpression();
@@ -591,7 +582,7 @@ export class StatementParser extends ExpressionParser {
 
       this.scope.pushAssignmentInfo('for');
       const expression = this.scope.with({ in: false }, () => this.parseExpression());
-      const validateLHS = (n) => {
+      const validateLHS = (n: ParseNode) => {
         if (n.type === 'AssignmentExpression') {
           this.raiseEarly('UnexpectedToken', n);
         } else {
@@ -602,7 +593,7 @@ export class StatementParser extends ExpressionParser {
       if (!isAwait && this.eat(Token.IN)) {
         assignmentInfo.clear();
         validateLHS(expression);
-        node.LeftHandSideExpression = expression;
+        node.LeftHandSideExpression = expression as ParseNode.LeftHandSideExpression; // NOTE: unsound cast
         node.Expression = this.parseExpression();
         this.expect(Token.RPAREN);
         node.Statement = this.parseStatement();
@@ -614,7 +605,7 @@ export class StatementParser extends ExpressionParser {
       if ((!isExactlyAsync || isAwait) && this.eat('of')) {
         assignmentInfo.clear();
         validateLHS(expression);
-        node.LeftHandSideExpression = expression;
+        node.LeftHandSideExpression = expression as ParseNode.LeftHandSideExpression; // NOTE: unsound cast
         node.AssignmentExpression = this.parseAssignmentExpression();
         this.expect(Token.RPAREN);
         node.Statement = this.parseStatement();
@@ -642,8 +633,8 @@ export class StatementParser extends ExpressionParser {
   // ForBinding :
   //   BindingIdentifier
   //   BindingPattern
-  parseForBinding() {
-    const node = this.startNode();
+  parseForBinding(): ParseNode.ForBinding {
+    const node = this.startNode<ParseNode.ForBinding>();
     switch (this.peek().type) {
       case Token.LBRACE:
       case Token.LBRACK:
@@ -659,8 +650,8 @@ export class StatementParser extends ExpressionParser {
 
   // SwitchStatement :
   //   `switch` `(` Expression `)` CaseBlock
-  parseSwitchStatement() {
-    const node = this.startNode();
+  parseSwitchStatement(): ParseNode.SwitchStatement {
+    const node = this.startNode<ParseNode.SwitchStatement>();
     this.expect(Token.SWITCH);
     this.expect(Token.LPAREN);
     node.Expression = this.parseExpression();
@@ -684,14 +675,14 @@ export class StatementParser extends ExpressionParser {
   //   `case` Expression `:` StatementList?
   // DefaultClause :
   //   `default` `:` StatementList?
-  parseCaseBlock() {
-    const node = this.startNode();
+  parseCaseBlock(): ParseNode.CaseBlock {
+    const node = this.startNode<ParseNode.CaseBlock>();
     this.expect(Token.LBRACE);
     while (!this.eat(Token.RBRACE)) {
       switch (this.peek().type) {
         case Token.CASE:
         case Token.DEFAULT: {
-          const inner = this.startNode();
+          const inner = this.startNode<ParseNode.CaseClause | ParseNode.DefaultClause>();
           const t = this.next().type;
           if (t === Token.DEFAULT && node.DefaultClause) {
             this.unexpected();
@@ -737,8 +728,8 @@ export class StatementParser extends ExpressionParser {
   // ContinueStatement :
   //   `continue` `;`
   //   `continue` [no LineTerminator here] LabelIdentifier `;`
-  parseBreakContinueStatement() {
-    const node = this.startNode();
+  parseBreakContinueStatement(): ParseNode.BreakStatement | ParseNode.ContinueStatement {
+    const node = this.startNode<ParseNode.BreakStatement | ParseNode.ContinueStatement>();
     const isBreak = this.eat(Token.BREAK);
     if (!isBreak) {
       this.expect(Token.CONTINUE);
@@ -760,7 +751,7 @@ export class StatementParser extends ExpressionParser {
     return this.finishNode(node, isBreak ? 'BreakStatement' : 'ContinueStatement');
   }
 
-  verifyBreakContinue(node, isBreak) {
+  verifyBreakContinue(node: ParseNode.Unfinished<ParseNode.BreakStatement | ParseNode.ContinueStatement>, isBreak: boolean) {
     let i = 0;
     for (; i < this.scope.labels.length; i += 1) {
       const label = this.scope.labels[i];
@@ -781,11 +772,11 @@ export class StatementParser extends ExpressionParser {
   // ReturnStatement :
   //   `return` `;`
   //   `return` [no LineTerminator here] Expression `;`
-  parseReturnStatement() {
+  parseReturnStatement(): ParseNode.ReturnStatement {
     if (!this.scope.hasReturn()) {
       this.unexpected();
     }
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.ReturnStatement>();
     this.expect(Token.RETURN);
     if (this.eatSemicolonWithASI()) {
       node.Expression = null;
@@ -798,11 +789,11 @@ export class StatementParser extends ExpressionParser {
 
   // WithStatement :
   //   `with` `(` Expression `)` Statement
-  parseWithStatement() {
+  parseWithStatement(): ParseNode.WithStatement {
     if (this.isStrictMode()) {
       this.raiseEarly('UnexpectedToken');
     }
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.WithStatement>();
     this.expect(Token.WITH);
     this.expect(Token.LPAREN);
     node.Expression = this.parseExpression();
@@ -813,8 +804,8 @@ export class StatementParser extends ExpressionParser {
 
   // ThrowStatement :
   //   `throw` [no LineTerminator here] Expression `;`
-  parseThrowStatement() {
-    const node = this.startNode();
+  parseThrowStatement(): ParseNode.ThrowStatement {
+    const node = this.startNode<ParseNode.ThrowStatement>();
     this.expect(Token.THROW);
     if (this.peek().hadLineTerminatorBefore) {
       this.raise('NewlineAfterThrow', node);
@@ -839,13 +830,13 @@ export class StatementParser extends ExpressionParser {
   // CatchParameter :
   //   BindingIdentifier
   //   BindingPattern
-  parseTryStatement() {
-    const node = this.startNode();
+  parseTryStatement(): ParseNode.TryStatement {
+    const node = this.startNode<ParseNode.TryStatement>();
     this.expect(Token.TRY);
     node.Block = this.parseBlock();
     if (this.eat(Token.CATCH)) {
       this.scope.with({ lexical: true }, () => {
-        const clause = this.startNode();
+        const clause = this.startNode<ParseNode.Catch>();
         if (this.eat(Token.LPAREN)) {
           switch (this.peek().type) {
             case Token.LBRACE:
@@ -879,8 +870,8 @@ export class StatementParser extends ExpressionParser {
   }
 
   // DebuggerStatement : `debugger` `;`
-  parseDebuggerStatement() {
-    const node = this.startNode();
+  parseDebuggerStatement(): ParseNode.DebuggerStatement {
+    const node = this.startNode<ParseNode.DebuggerStatement>();
     this.expect(Token.DEBUGGER);
     this.semicolon();
     return this.finishNode(node, 'DebuggerStatement');
@@ -888,7 +879,7 @@ export class StatementParser extends ExpressionParser {
 
   // ExpressionStatement :
   //   [lookahead != `{`, `function`, `async` [no LineTerminator here] `function`, `class`, `let` `[` ] Expression `;`
-  parseExpressionStatement() {
+  parseExpressionStatement(): ParseNode.ExpressionStatement | ParseNode.LabelledStatement {
     switch (this.peek().type) {
       case Token.LBRACE:
       case Token.FUNCTION:
@@ -905,13 +896,13 @@ export class StatementParser extends ExpressionParser {
         break;
     }
     const startToken = this.peek();
-    const node = this.startNode();
+    const node = this.startNode<ParseNode.ExpressionStatement | ParseNode.LabelledStatement>();
     const expression = this.parseExpression();
     if (expression.type === 'IdentifierReference' && this.eat(Token.COLON)) {
-      expression.type = 'LabelIdentifier';
-      node.LabelIdentifier = expression;
+      const LabelIdentifier = this.repurpose(expression, 'LabelIdentifier') as ParseNode.LabelIdentifier;
+      node.LabelIdentifier = LabelIdentifier;
 
-      if (this.scope.labels.find((l) => l.name === node.LabelIdentifier.name)) {
+      if (this.scope.labels.find((l) => l.name === LabelIdentifier.name)) {
         this.raiseEarly('AlreadyDeclared', node.LabelIdentifier, node.LabelIdentifier.name);
       }
       let type = null;

--- a/src/parser/tokens.mts
+++ b/src/parser/tokens.mts
@@ -1,4 +1,33 @@
-// @ts-nocheck
+/** Coerces a property key into a numeric index */
+type ToIndex<T extends PropertyKey> =
+  T extends number ? ToIndex<`${T}`> :
+  T extends `${bigint}` ? T extends `${infer I extends number}` ? I : never :
+  never;
+
+type ReplaceType<T, U, V> = T extends U ? V : T;
+
+type TokenDefinition = readonly [name: string, value: string | null, precedence?: number];
+
+type TokenArrayToAssignTokenArray<A extends readonly TokenDefinition[]> = {
+  readonly [P in keyof A]: readonly [`ASSIGN_${A[P][0]}`, `${A[P][1]}`, A[P][2]];
+};
+
+type TokenArrayToEnumLike<A extends readonly TokenDefinition[]> = {
+  readonly [I in ToIndex<keyof A> as A[I][0]]: I;
+};
+
+type TokenArrayToElementArray<A extends readonly TokenDefinition[], I extends 0 | 1 | 2, V = undefined> = {
+  readonly [P in keyof A]: ReplaceType<A[P][I], undefined, V>;
+};
+
+type TokenArrayToKeywordsArray<A extends readonly TokenDefinition[]> = readonly {
+  readonly [I in ToIndex<keyof A>]: A[I][1] extends Lowercase<A[I][0]> ? A[I][1] : never;
+}[ToIndex<keyof A>][];
+
+type KeywordsArrayToEnumLike<A extends readonly string[]> = {
+  readonly [P in A[number]]: typeof Token[Uppercase<P> & keyof typeof Token];
+};
+
 const MaybeAssignTokens = [
   // Logical
   ['NULLISH', '??', 3],
@@ -20,7 +49,7 @@ const MaybeAssignTokens = [
   // Unop
   ['ADD', '+', 12],
   ['SUB', '-', 12],
-];
+] as const satisfies readonly TokenDefinition[];
 
 export const RawTokens = [
   // BEGIN PropertyOrCall
@@ -54,7 +83,7 @@ export const RawTokens = [
   ['ARROW', '=>'],
   // BEGIN Assign
   ['ASSIGN', '=', 2],
-  ...MaybeAssignTokens.map((t) => [`ASSIGN_${t[0]}`, `${t[1]}=`, 2]),
+  ...MaybeAssignTokens.map((t) => [`ASSIGN_${t[0]}`, `${t[1]}=`, 2]) as readonly TokenDefinition[] as TokenArrayToAssignTokenArray<typeof MaybeAssignTokens>,
   // END Assign
   // END ArrowOrAssign
 
@@ -138,43 +167,46 @@ export const RawTokens = [
   ['ENUM', 'enum'],
 
   ['ESCAPED_KEYWORD', null],
-];
+] as const satisfies readonly TokenDefinition[];
 
 export const Token = RawTokens
   .reduce((obj, [name], i) => {
     obj[name] = i;
     return obj;
-  }, Object.create(null));
+  }, Object.create(null)) as TokenArrayToEnumLike<typeof RawTokens>;
 
-export const TokenNames = RawTokens.map((r) => r[0]);
+export type Token = typeof Token[keyof typeof Token];
 
-export const TokenValues = RawTokens.map((r) => r[1]);
+export const TokenNames = RawTokens.map((r) => r[0]) as readonly string[] as TokenArrayToElementArray<typeof RawTokens, 0>;
 
-export const TokenPrecedence = RawTokens.map((r) => (r[2] || 0));
+export const TokenValues = RawTokens.map((r) => r[1]) as readonly (string | null)[] as TokenArrayToElementArray<typeof RawTokens, 1>;
+
+export const TokenPrecedence = RawTokens.map((r) => (r[2] || 0)) as readonly number[] as TokenArrayToElementArray<typeof RawTokens, 2, 0>;
 
 const Keywords = RawTokens
   .filter(([name, raw]) => name.toLowerCase() === raw)
-  .map(([, raw]) => raw);
+  .map(([, raw]) => raw!) as TokenArrayToKeywordsArray<typeof RawTokens>;
 
 export const KeywordLookup = Keywords
   .reduce((obj, kw) => {
-    obj[kw] = Token[kw.toUpperCase()];
+    obj[kw] = Token[kw.toUpperCase() as Uppercase<typeof kw>];
     return obj;
-  }, Object.create(null));
+  }, Object.create(null)) as KeywordsArrayToEnumLike<typeof Keywords>;
 
-const KeywordTokens = new Set(Object.values(KeywordLookup));
+const KeywordRaw: ReadonlySet<string> = new Set(Object.keys(KeywordLookup));
+const KeywordTokens: ReadonlySet<number> = new Set(Object.values(KeywordLookup));
 
-const isInRange = (t, l, h) => t >= l && t <= h;
-export const isAutomaticSemicolon = (t) => isInRange(t, Token.SEMICOLON, Token.EOS);
-export const isMember = (t) => isInRange(t, Token.TEMPLATE, Token.LBRACK);
-export const isPropertyOrCall = (t) => isInRange(t, Token.TEMPLATE, Token.LPAREN);
-export const isKeyword = (t) => KeywordTokens.has(t);
-export const isKeywordRaw = (s) => Keywords.includes(s);
+const isInRange = (t: number, l: number, h: number) => t >= l && t <= h;
+export const isAutomaticSemicolon = (t: number) => isInRange(t, Token.SEMICOLON, Token.EOS);
+export const isMember = (t: number) => isInRange(t, Token.TEMPLATE, Token.LBRACK);
+export const isPropertyOrCall = (t: number) => isInRange(t, Token.TEMPLATE, Token.LPAREN);
+export const isKeyword = (t: number): t is typeof KeywordLookup[keyof typeof KeywordLookup] => KeywordTokens.has(t);
+export const isKeywordRaw = (s: string): s is keyof typeof KeywordLookup => KeywordRaw.has(s);
 
-const ReservedWordsStrict = [
+const ReservedWordsStrict: ReadonlySet<string> = new Set([
   'implements', 'interface', 'let',
   'package', 'private', 'protected',
   'public', 'static', 'yield',
-];
+]);
 
-export const isReservedWordStrict = (s) => ReservedWordsStrict.includes(s);
+export const isReservedWordStrict = (s: string) => ReservedWordsStrict.has(s);

--- a/src/runtime-semantics/AsyncFunctionExpression.mts
+++ b/src/runtime-semantics/AsyncFunctionExpression.mts
@@ -3,8 +3,8 @@ import { InstantiateAsyncFunctionExpression } from './all.mjs';
 
 /** https://tc39.es/ecma262/#sec-async-function-definitions-runtime-semantics-evaluation */
 //   AsyncFunctionExpression :
-//     `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-//     `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+//     `async` `function` `(` FormalParameters `)` `{` AsyncBody `}`
+//     `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncBody `}`
 export function Evaluate_AsyncFunctionExpression(AsyncFunctionExpression) {
   // 1. Return InstantiateAsyncFunctionExpression of AsyncFunctionExpression.
   return InstantiateAsyncFunctionExpression(AsyncFunctionExpression);

--- a/src/runtime-semantics/CreateDynamicFunction.mts
+++ b/src/runtime-semantics/CreateDynamicFunction.mts
@@ -57,7 +57,7 @@ export function CreateDynamicFunction(constructor, newTarget, kind, args) {
     // c. Let fallbackProto be "%GeneratorFunction.prototype%".
     fallbackProto = '%GeneratorFunction.prototype%';
   } else if (kind === 'async') { // 9. Else if kind is async, then
-    // a. Let goal be the grammar symbol AsyncFunctionBody.
+    // a. Let goal be the grammar symbol AsyncBody.
     // b. Let parameterGoal be the grammar symbol FormalParameters[~Yield, +Await].
     // c. Let fallbackProto be "%AsyncFunction.prototype%".
     fallbackProto = '%AsyncFunction.prototype%';
@@ -147,7 +147,7 @@ export function CreateDynamicFunction(constructor, newTarget, kind, args) {
         body = f.GeneratorBody;
         break;
       case 'async':
-        body = f.AsyncFunctionBody;
+        body = f.AsyncBody;
         break;
       case 'asyncGenerator':
         body = f.AsyncGeneratorBody;

--- a/src/runtime-semantics/EvaluateBody.mts
+++ b/src/runtime-semantics/EvaluateBody.mts
@@ -112,7 +112,7 @@ export function* EvaluateBody_AsyncGeneratorBody(FunctionBody, functionObject, a
 }
 
 /** https://tc39.es/ecma262/#sec-async-function-definitions-EvaluateBody */
-// AsyncFunctionBody : FunctionBody
+// AsyncBody : FunctionBody
 export function* EvaluateBody_AsyncFunctionBody(FunctionBody, functionObject, argumentsList) {
   // 1. Let promiseCapability be ! NewPromiseCapability(%Promise%).
   const promiseCapability = X(NewPromiseCapability(surroundingAgent.intrinsic('%Promise%')));
@@ -165,7 +165,7 @@ function* EvaluateClassStaticBlockBody({ ClassStaticBlockStatementList }, functi
 // ConciseBody : ExpressionBody
 // GeneratorBody : FunctionBody
 // AsyncGeneratorBody : FunctionBody
-// AsyncFunctionBody : FunctionBody
+// AsyncBody : FunctionBody
 // AsyncConciseBody : ExpressionBody
 // ClassStaticBlockBody : ClassStaticBlockStatementList
 export function EvaluateBody(Body, functionObject, argumentsList) {
@@ -178,7 +178,7 @@ export function EvaluateBody(Body, functionObject, argumentsList) {
       return EvaluateBody_GeneratorBody(Body, functionObject, argumentsList);
     case 'AsyncGeneratorBody':
       return EvaluateBody_AsyncGeneratorBody(Body, functionObject, argumentsList);
-    case 'AsyncFunctionBody':
+    case 'AsyncBody':
       return EvaluateBody_AsyncFunctionBody(Body, functionObject, argumentsList);
     case 'AsyncConciseBody':
       return EvaluateBody_AsyncConciseBody(Body, functionObject, argumentsList);

--- a/src/runtime-semantics/InstantiateAsyncFunctionExpression.mts
+++ b/src/runtime-semantics/InstantiateAsyncFunctionExpression.mts
@@ -13,7 +13,7 @@ import { NewDeclarativeEnvironment } from '../environment.mjs';
 
 /** https://tc39.es/ecma262/#sec-runtime-semantics-instantiateasyncfunctionexpression */
 export function InstantiateAsyncFunctionExpression(AsyncFunctionExpression, name) {
-  const { BindingIdentifier, FormalParameters, AsyncFunctionBody } = AsyncFunctionExpression;
+  const { BindingIdentifier, FormalParameters, AsyncBody } = AsyncFunctionExpression;
   if (BindingIdentifier) {
     // 1. Assert: name is not present.
     Assert(name === undefined);
@@ -29,12 +29,12 @@ export function InstantiateAsyncFunctionExpression(AsyncFunctionExpression, name
     const privateScope = surroundingAgent.runningExecutionContext.PrivateEnvironment;
     // 7. Let sourceText be the source text matched by AsyncFunctionExpression.
     const sourceText = sourceTextMatchedBy(AsyncFunctionExpression);
-    // 8. Let closure be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, sourceText, FormalParameters, AsyncFunctionBody, non-lexical-this, funcEnv, privateScope).
+    // 8. Let closure be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, sourceText, FormalParameters, AsyncBody, non-lexical-this, funcEnv, privateScope).
     const closure = X(OrdinaryFunctionCreate(
       surroundingAgent.intrinsic('%AsyncFunction.prototype%'),
       sourceText,
       FormalParameters,
-      AsyncFunctionBody,
+      AsyncBody,
       'non-lexical-this',
       funcEnv,
       privateScope,
@@ -56,12 +56,12 @@ export function InstantiateAsyncFunctionExpression(AsyncFunctionExpression, name
   const privateScope = surroundingAgent.runningExecutionContext.PrivateEnvironment;
   // 4. Let sourceText be the source text matched by AsyncFunctionExpression.
   const sourceText = sourceTextMatchedBy(AsyncFunctionExpression);
-  // 5. Let closure be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, sourceText, FormalParameters, AsyncFunctionBody, non-lexical-this, scope, privateScope).
+  // 5. Let closure be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, sourceText, FormalParameters, AsyncBody, non-lexical-this, scope, privateScope).
   const closure = X(OrdinaryFunctionCreate(
     surroundingAgent.intrinsic('%AsyncFunction.prototype%'),
     sourceText,
     FormalParameters,
-    AsyncFunctionBody,
+    AsyncBody,
     'non-lexical-this',
     scope,
     privateScope,

--- a/src/runtime-semantics/InstantiateFunctionObject.mts
+++ b/src/runtime-semantics/InstantiateFunctionObject.mts
@@ -62,16 +62,16 @@ export function InstantiateFunctionObject_GeneratorDeclaration(GeneratorDeclarat
 
 /** https://tc39.es/ecma262/#sec-async-function-definitions-InstantiateFunctionObject */
 //  AsyncFunctionDeclaration :
-//    `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-//    `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+//    `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncBody `}`
+//    `async` `function` `(` FormalParameters `)` `{` AsyncBody `}`
 export function InstantiateFunctionObject_AsyncFunctionDeclaration(AsyncFunctionDeclaration, scope, privateScope) {
-  const { BindingIdentifier, FormalParameters, AsyncFunctionBody } = AsyncFunctionDeclaration;
+  const { BindingIdentifier, FormalParameters, AsyncBody } = AsyncFunctionDeclaration;
   // 1. Let name be StringValue of BindingIdentifier.
   const name = BindingIdentifier ? StringValue(BindingIdentifier) : Value('default');
   // 2. Let sourceText be the source text matched by AsyncFunctionDeclaration.
   const sourceText = sourceTextMatchedBy(AsyncFunctionDeclaration);
-  // 3. Let F be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, sourceText, FormalParameters, AsyncFunctionBody, non-lexical-this, scope, privateScope).
-  const F = X(OrdinaryFunctionCreate(surroundingAgent.intrinsic('%AsyncFunction.prototype%'), sourceText, FormalParameters, AsyncFunctionBody, 'non-lexical-this', scope, privateScope));
+  // 3. Let F be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, sourceText, FormalParameters, AsyncBody, non-lexical-this, scope, privateScope).
+  const F = X(OrdinaryFunctionCreate(surroundingAgent.intrinsic('%AsyncFunction.prototype%'), sourceText, FormalParameters, AsyncBody, 'non-lexical-this', scope, privateScope));
   // 4. Perform ! SetFunctionName(F, name).
   SetFunctionName(F, name);
   // 5. Return F.

--- a/src/runtime-semantics/MethodDefinitionEvaluation.mts
+++ b/src/runtime-semantics/MethodDefinitionEvaluation.mts
@@ -159,9 +159,9 @@ function* MethodDefinitionEvaluation_MethodDefinition(MethodDefinition, object, 
 
 /** https://tc39.es/ecma262/#sec-async-function-definitions-MethodDefinitionEvaluation */
 //   AsyncMethod :
-//     `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
+//     `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncBody `}`
 function* MethodDefinitionEvaluation_AsyncMethod(AsyncMethod, object, enumerable) {
-  const { ClassElementName, UniqueFormalParameters, AsyncFunctionBody } = AsyncMethod;
+  const { ClassElementName, UniqueFormalParameters, AsyncBody } = AsyncMethod;
   // 1. Let propKey be the result of evaluating ClassElementName.
   const propKey = yield* Evaluate_PropertyName(ClassElementName);
   // 2. ReturnIfAbrupt(propKey).
@@ -172,8 +172,8 @@ function* MethodDefinitionEvaluation_AsyncMethod(AsyncMethod, object, enumerable
   const privateScope = surroundingAgent.runningExecutionContext.PrivateEnvironment;
   // 5. Let sourceText be the source text matched by AsyncMethod.
   const sourceText = sourceTextMatchedBy(AsyncMethod);
-  // 6. Let closure be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, sourceText, UniqueFormalParameters, AsyncFunctionBody, non-lexical-this, scope, privateScope).
-  const closure = X(OrdinaryFunctionCreate(surroundingAgent.intrinsic('%AsyncFunction.prototype%'), sourceText, UniqueFormalParameters, AsyncFunctionBody, 'non-lexical-this', scope, privateScope));
+  // 6. Let closure be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, sourceText, UniqueFormalParameters, AsyncBody, non-lexical-this, scope, privateScope).
+  const closure = X(OrdinaryFunctionCreate(surroundingAgent.intrinsic('%AsyncFunction.prototype%'), sourceText, UniqueFormalParameters, AsyncBody, 'non-lexical-this', scope, privateScope));
   // 7. Perform ! MakeMethod(closure, object).
   X(MakeMethod(closure, object));
   // 8. Perform ! SetFunctionName(closure, propKey).
@@ -197,7 +197,7 @@ function* MethodDefinitionEvaluation_GeneratorMethod(GeneratorMethod, object, en
   const privateScope = surroundingAgent.runningExecutionContext.PrivateEnvironment;
   // 5. Let sourceText be the source text matched by GeneratorMethod.
   const sourceText = sourceTextMatchedBy(GeneratorMethod);
-  // 6. Let closure be ! OrdinaryFunctionCreate(%GeneratorFunction.prototype%, sourceText, UniqueFormalParameters, AsyncFunctionBody, non-lexical-this, scope, privateScope).
+  // 6. Let closure be ! OrdinaryFunctionCreate(%GeneratorFunction.prototype%, sourceText, UniqueFormalParameters, AsyncBody, non-lexical-this, scope, privateScope).
   const closure = X(OrdinaryFunctionCreate(surroundingAgent.intrinsic('%GeneratorFunction.prototype%'), sourceText, UniqueFormalParameters, GeneratorBody, 'non-lexical-this', scope, privateScope));
   // 7. Perform ! MakeMethod(closure, object).
   X(MakeMethod(closure, object));

--- a/src/runtime-semantics/NamedEvaluation.mts
+++ b/src/runtime-semantics/NamedEvaluation.mts
@@ -30,7 +30,7 @@ function NamedEvaluation_GeneratorExpression(GeneratorExpression, name) {
 
 /** https://tc39.es/ecma262/#sec-async-function-definitions-runtime-semantics-namedevaluation */
 //   AsyncFunctionExpression :
-//     `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+//     `async` `function` `(` FormalParameters `)` `{` AsyncBody `}`
 function NamedEvaluation_AsyncFunctionExpression(AsyncFunctionExpression, name) {
   return InstantiateAsyncFunctionExpression(AsyncFunctionExpression, name);
 }

--- a/src/static-semantics/IsComputedPropertyKey.mts
+++ b/src/static-semantics/IsComputedPropertyKey.mts
@@ -1,5 +1,6 @@
-// @ts-nocheck
-export function IsComputedPropertyKey(node) {
+import type { ParseNode } from '../parser/ParseNode.mjs';
+
+export function IsComputedPropertyKey(node: ParseNode.PropertyNameLike): node is ParseNode.PropertyName {
   return node.type !== 'IdentifierName'
     && node.type !== 'StringLiteral'
     && node.type !== 'NumericLiteral';

--- a/src/static-semantics/LexicallyDeclaredNames.mts
+++ b/src/static-semantics/LexicallyDeclaredNames.mts
@@ -14,7 +14,7 @@ export function LexicallyDeclaredNames(node) {
       return TopLevelLexicallyDeclaredNames(node.StatementList);
     case 'FunctionBody':
     case 'GeneratorBody':
-    case 'AsyncFunctionBody':
+    case 'AsyncBody':
     case 'AsyncGeneratorBody':
       return TopLevelLexicallyDeclaredNames(node.FunctionStatementList);
     case 'ClassStaticBlockBody':

--- a/src/static-semantics/LexicallyScopedDeclarations.mts
+++ b/src/static-semantics/LexicallyScopedDeclarations.mts
@@ -28,7 +28,7 @@ export function LexicallyScopedDeclarations(node) {
       return LexicallyScopedDeclarations(node.ModuleItemList);
     case 'FunctionBody':
     case 'GeneratorBody':
-    case 'AsyncFunctionBody':
+    case 'AsyncBody':
     case 'AsyncGeneratorBody':
       return TopLevelLexicallyScopedDeclarations(node.FunctionStatementList);
     case 'ClassStaticBlockBody':

--- a/src/static-semantics/StringValue.mts
+++ b/src/static-semantics/StringValue.mts
@@ -8,11 +8,11 @@ export function StringValue(node: ParseNode) {
     case 'BindingIdentifier':
     case 'IdentifierReference':
     case 'LabelIdentifier':
-      return Value((node as ParseNode.IdentifierName | ParseNode.BindingIdentifier | ParseNode.IdentifierReference | ParseNode.LabelIdentifier).name);
+      return Value(node.name);
     case 'PrivateIdentifier':
-      return Value(`#${(node as ParseNode.PrivateIdentifier).name}`);
+      return Value(`#${node.name}`);
     case 'StringLiteral':
-      return Value((node as ParseNode.StringLiteral).value);
+      return Value(node.value);
     default:
       throw new OutOfRange('StringValue', node);
   }

--- a/src/static-semantics/StringValue.mts
+++ b/src/static-semantics/StringValue.mts
@@ -1,19 +1,18 @@
-// @ts-nocheck
 import { Value } from '../value.mjs';
 import { OutOfRange } from '../helpers.mjs';
+import type { ParseNode } from '../parser/ParseNode.mjs';
 
-export function StringValue(node) {
+export function StringValue(node: ParseNode) {
   switch (node.type) {
-    case 'Identifier':
     case 'IdentifierName':
     case 'BindingIdentifier':
     case 'IdentifierReference':
     case 'LabelIdentifier':
-      return Value(node.name);
+      return Value((node as ParseNode.IdentifierName | ParseNode.BindingIdentifier | ParseNode.IdentifierReference | ParseNode.LabelIdentifier).name);
     case 'PrivateIdentifier':
-      return Value(`#${node.name}`);
+      return Value(`#${(node as ParseNode.PrivateIdentifier).name}`);
     case 'StringLiteral':
-      return Value(node.value);
+      return Value((node as ParseNode.StringLiteral).value);
     default:
       throw new OutOfRange('StringValue', node);
   }

--- a/src/static-semantics/VarDeclaredNames.mts
+++ b/src/static-semantics/VarDeclaredNames.mts
@@ -91,7 +91,7 @@ export function VarDeclaredNames(node) {
       return TopLevelVarDeclaredNames(node.StatementList);
     case 'FunctionBody':
     case 'GeneratorBody':
-    case 'AsyncFunctionBody':
+    case 'AsyncBody':
     case 'AsyncGeneratorBody':
       return TopLevelVarDeclaredNames(node.FunctionStatementList);
     case 'ClassStaticBlockBody':

--- a/src/static-semantics/VarScopedDeclarations.mts
+++ b/src/static-semantics/VarScopedDeclarations.mts
@@ -103,7 +103,7 @@ export function VarScopedDeclarations(node) {
       return VarScopedDeclarations(node.ModuleItemList);
     case 'FunctionBody':
     case 'GeneratorBody':
-    case 'AsyncFunctionBody':
+    case 'AsyncBody':
     case 'AsyncGeneratorBody':
       return TopLevelVarScopedDeclarations(node.FunctionStatementList);
     case 'ClassStaticBlockBody':


### PR DESCRIPTION
This follows on to #207 by making the parser type safe. This is a direct result of other work I've been doing to implement the Explicit Resource Management proposal into engine262.

The improved types found several potential issues, which have been addressed:
- `ExpressionParser.prototype.parseBracketedDefinition` was incorrectly using `isKeyword` when it should have been using `isKeywordRaw`.
- `ExpressionParser.prototype.parseLeftHandSideExpression` was incorrectly setting `node.arrowInfo.trailingComma` when it should have been setting `node.arrowInfo.hasTrailingComma`.

This PR opted to define specific parse nodes on a `ParseNode` namespace that merges with the base type, rather than introduce a large number of additional types as exports at the top level. If it is preferred that I should flatten the `ParseNode` namespace out to top-level types, I would be happy to do so.

To better capture how nodes are parsed, this PR introduces a somewhat complex `ParseNode.Unfinished<T>` type alias that is intended to capture both the actual state of a node as returned by `startNode()` as well as provide a modicum of type safety over the intended output types. In addition, a `ParseNode.Finished<T, K>` type alias that converts an `Unfinished` to its final type. The `Unfinished` type could be removed, but would require a significant number of complex casts and other refactors throughout the rest of the parser.

To provide better type safety for `Token` and related values in _tokens.mts_, there are a number of other somewhat complex type aliases whose intent is to preserve the exact types for the values produced in that file, without changing the actual underlying runtime code. An alternative to these complex types would be to refactor _tokens.mts_ to use more structured declaration forms like `enum`, but this would require a comprehensive rewrite of the entire file.