### PR TITLE
Switch `IsCallable` and `IsConstructor` to return boolean

### DIFF
--- a/src/abstract-ops/array-objects.mts
+++ b/src/abstract-ops/array-objects.mts
@@ -108,7 +108,7 @@ export function ArraySpeciesCreate(originalArray, length) {
     return Q(ArrayCreate(length));
   }
   let C = Q(Get(originalArray, Value('constructor')));
-  if (IsConstructor(C) === Value.true) {
+  if (IsConstructor(C)) {
     const thisRealm = surroundingAgent.currentRealmRecord;
     const realmC = Q(GetFunctionRealm(C));
     if (thisRealm !== realmC) {
@@ -126,7 +126,7 @@ export function ArraySpeciesCreate(originalArray, length) {
   if (C === Value.undefined) {
     return Q(ArrayCreate(length));
   }
-  if (IsConstructor(C) === Value.false) {
+  if (!IsConstructor(C)) {
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', C);
   }
   return Q(Construct(C, [F(length)]));

--- a/src/abstract-ops/arraybuffer-objects.mts
+++ b/src/abstract-ops/arraybuffer-objects.mts
@@ -77,7 +77,7 @@ export function CloneArrayBuffer(srcBuffer, srcByteOffset, srcLength, cloneConst
   // 1. Assert: Type(srcBuffer) is Object and it has an [[ArrayBufferData]] internal slot.
   Assert(srcBuffer instanceof ObjectValue && 'ArrayBufferData' in srcBuffer);
   // 2. Assert: IsConstructor(cloneConstructor) is true.
-  Assert(IsConstructor(cloneConstructor) === Value.true);
+  Assert(IsConstructor(cloneConstructor));
   // 3. Let targetBuffer be ? AllocateArrayBuffer(cloneConstructor, srcLength).
   const targetBuffer = Q(AllocateArrayBuffer(cloneConstructor, srcLength));
   // 4. If IsDetachedBuffer(srcBuffer) is true, throw a TypeError exception.

--- a/src/abstract-ops/function-operations.mts
+++ b/src/abstract-ops/function-operations.mts
@@ -356,7 +356,7 @@ export function OrdinaryFunctionCreate(functionPrototype, sourceText, ParameterL
 export function MakeConstructor(F, writablePrototype, prototype) {
   Assert(isECMAScriptFunctionObject(F) || F.Call === BuiltinFunctionCall);
   if (isECMAScriptFunctionObject(F)) {
-    Assert(IsConstructor(F) === Value.false);
+    Assert(!IsConstructor(F));
     Assert(X(IsExtensible(F)) === Value.true && X(HasOwnProperty(F, Value('prototype'))) === Value.false);
     F.Construct = surroundingAgent.hostDefinedOptions.boost?.constructFunction || FunctionConstructSlot;
   }

--- a/src/abstract-ops/object-operations.mts
+++ b/src/abstract-ops/object-operations.mts
@@ -151,7 +151,7 @@ export function GetMethod(V, P) {
   if (func === Value.null || func === Value.undefined) {
     return Value.undefined;
   }
-  if (IsCallable(func) === Value.false) {
+  if (!IsCallable(func)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', func);
   }
   return func;
@@ -182,7 +182,7 @@ export function Call(F, V, argumentsList) {
   }
   Assert(argumentsList.every((a) => a instanceof Value));
 
-  if (IsCallable(F) === Value.false) {
+  if (!IsCallable(F)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', F);
   }
 
@@ -197,8 +197,8 @@ export function Construct(F, argumentsList, newTarget) {
   if (!argumentsList) {
     argumentsList = [];
   }
-  Assert(IsConstructor(F) === Value.true);
-  Assert(IsConstructor(newTarget) === Value.true);
+  Assert(IsConstructor(F));
+  Assert(IsConstructor(newTarget));
   return Q(F.Construct(argumentsList, newTarget));
 }
 
@@ -331,7 +331,7 @@ export function Invoke(V, P, argumentsList) {
 
 /** https://tc39.es/ecma262/#sec-ordinaryhasinstance */
 export function OrdinaryHasInstance(C, O) {
-  if (IsCallable(C) === Value.false) {
+  if (!IsCallable(C)) {
     return Value.false;
   }
   if ('BoundTargetFunction' in C) {
@@ -370,7 +370,7 @@ export function SpeciesConstructor(O, defaultConstructor) {
   if (S === Value.undefined || S === Value.null) {
     return defaultConstructor;
   }
-  if (IsConstructor(S) === Value.true) {
+  if (IsConstructor(S)) {
     return S;
   }
   return surroundingAgent.Throw('TypeError', 'SpeciesNotConstructor');
@@ -405,7 +405,7 @@ export function EnumerableOwnPropertyNames(O, kind) {
 
 /** https://tc39.es/ecma262/#sec-getfunctionrealm */
 export function GetFunctionRealm(obj) {
-  Assert(X(IsCallable(obj)) === Value.true);
+  Assert(IsCallable(obj));
   if ('Realm' in obj) {
     return obj.Realm;
   }

--- a/src/abstract-ops/objects.mts
+++ b/src/abstract-ops/objects.mts
@@ -393,7 +393,7 @@ export function OrdinaryCreateFromConstructor(constructor, intrinsicDefaultProto
 export function GetPrototypeFromConstructor(constructor, intrinsicDefaultProto) {
   // Assert: intrinsicDefaultProto is a String value that
   // is this specification's name of an intrinsic object.
-  Assert(IsCallable(constructor) === Value.true);
+  Assert(IsCallable(constructor));
   let proto = Q(Get(constructor, Value('prototype')));
   if (!(proto instanceof ObjectValue)) {
     const realm = Q(GetFunctionRealm(constructor));

--- a/src/abstract-ops/promise-operations.mts
+++ b/src/abstract-ops/promise-operations.mts
@@ -178,7 +178,7 @@ function PromiseResolveFunctions([resolution = Value.undefined]) {
   // 11. Let thenAction be then.[[Value]].
   const thenAction = then.Value;
   // 12. If IsCallable(thenAction) is false, then
-  if (IsCallable(thenAction) === Value.false) {
+  if (!IsCallable(thenAction)) {
     // a. Return FulfillPromise(promise, resolution).
     return FulfillPromise(promise, resolution);
   }
@@ -206,7 +206,7 @@ function FulfillPromise(promise, value) {
 /** https://tc39.es/ecma262/#sec-newpromisecapability */
 export function NewPromiseCapability(C) {
   // 1. If IsConstructor(C) is false, throw a TypeError exception.
-  if (IsConstructor(C) === Value.false) {
+  if (!IsConstructor(C)) {
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', C);
   }
   // 2. NOTE: C is assumed to be a constructor function that supports the parameter conventions of the Promise constructor (see 26.2.3.1).
@@ -234,11 +234,11 @@ export function NewPromiseCapability(C) {
   // 8. Let promise be ? Construct(C, « executor »).
   const promise = Q(Construct(C, [executor]));
   // 9. If IsCallable(promiseCapability.[[Resolve]]) is false, throw a TypeError exception.
-  if (IsCallable(promiseCapability.Resolve) === Value.false) {
+  if (!IsCallable(promiseCapability.Resolve)) {
     return surroundingAgent.Throw('TypeError', 'PromiseResolveFunction', promiseCapability.Resolve);
   }
   // 10. If IsCallable(promiseCapability.[[Reject]]) is false, throw a TypeError exception.
-  if (IsCallable(promiseCapability.Reject) === Value.false) {
+  if (!IsCallable(promiseCapability.Reject)) {
     return surroundingAgent.Throw('TypeError', 'PromiseRejectFunction', promiseCapability.Reject);
   }
   // 11. Set promiseCapability.[[Promise]] to promise.
@@ -378,7 +378,7 @@ export function PerformPromiseThen(promise, onFulfilled, onRejected, resultCapab
   }
   let onFulfilledJobCallback;
   // 3. If IsCallable(onFulfilled) is false, then
-  if (IsCallable(onFulfilled) === Value.false) {
+  if (!IsCallable(onFulfilled)) {
     // a. Let onFulfilledJobCallback be empty.
     onFulfilledJobCallback = undefined;
   } else { // 4. Else,
@@ -387,7 +387,7 @@ export function PerformPromiseThen(promise, onFulfilled, onRejected, resultCapab
   }
   let onRejectedJobCallback;
   // 5. If IsCallable(onRejected) is false, then
-  if (IsCallable(onRejected) === Value.false) {
+  if (!IsCallable(onRejected)) {
     // a. Let onRejectedJobCallback be empty.
     onRejectedJobCallback = undefined;
   } else { // 6. Else,

--- a/src/abstract-ops/proxy-objects.mts
+++ b/src/abstract-ops/proxy-objects.mts
@@ -522,7 +522,7 @@ function ProxyConstruct(argumentsList, newTarget) {
   }
   Assert(handler instanceof ObjectValue);
   const target = O.ProxyTarget;
-  Assert(IsConstructor(target) === Value.true);
+  Assert(IsConstructor(target));
   const trap = Q(GetMethod(handler, Value('construct')));
   if (trap === Value.undefined) {
     return Q(Construct(target, argumentsList, newTarget));
@@ -564,11 +564,11 @@ export function ProxyCreate(target, handler) {
   P.Delete = ProxyDelete;
   P.OwnPropertyKeys = ProxyOwnPropertyKeys;
   // 5. If IsCallable(target) is true, then
-  if (IsCallable(target) === Value.true) {
+  if (IsCallable(target)) {
     /** https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist. */
     P.Call = ProxyCall;
     // b. If IsConstructor(target) is true, then
-    if (IsConstructor(target) === Value.true) {
+    if (IsConstructor(target)) {
       /** https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget. */
       P.Construct = ProxyConstruct;
     }

--- a/src/abstract-ops/spec-types.mts
+++ b/src/abstract-ops/spec-types.mts
@@ -131,7 +131,7 @@ export function ToPropertyDescriptor(Obj) {
   const hasGet = Q(HasProperty(Obj, Value('get')));
   if (hasGet === Value.true) {
     const getter = Q(Get(Obj, Value('get')));
-    if (IsCallable(getter) === Value.false && !(getter instanceof UndefinedValue)) {
+    if (!IsCallable(getter) && !(getter instanceof UndefinedValue)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', getter);
     }
     desc.Get = getter;
@@ -139,7 +139,7 @@ export function ToPropertyDescriptor(Obj) {
   const hasSet = Q(HasProperty(Obj, Value('set')));
   if (hasSet === Value.true) {
     const setter = Q(Get(Obj, Value('set')));
-    if (IsCallable(setter) === Value.false && !(setter instanceof UndefinedValue)) {
+    if (!IsCallable(setter) && !(setter instanceof UndefinedValue)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', setter);
     }
     desc.Set = setter;

--- a/src/abstract-ops/testing-comparison.mts
+++ b/src/abstract-ops/testing-comparison.mts
@@ -70,23 +70,23 @@ export function IsArray(argument) {
 /** https://tc39.es/ecma262/#sec-iscallable */
 export function IsCallable(argument) {
   if (!(argument instanceof ObjectValue)) {
-    return Value.false;
+    return false;
   }
   if ('Call' in argument) {
-    return Value.true;
+    return true;
   }
-  return Value.false;
+  return false;
 }
 
 /** https://tc39.es/ecma262/#sec-isconstructor */
 export function IsConstructor(argument) {
   if (!(argument instanceof ObjectValue)) {
-    return Value.false;
+    return false;
   }
   if ('Construct' in argument) {
-    return Value.true;
+    return true;
   }
-  return Value.false;
+  return false;
 }
 
 /** https://tc39.es/ecma262/#sec-isextensible-o */

--- a/src/abstract-ops/type-conversion.mts
+++ b/src/abstract-ops/type-conversion.mts
@@ -90,7 +90,7 @@ export function OrdinaryToPrimitive(O, hint) {
     // a. Let method be ? Get(O, name).
     const method = Q(Get(O, name));
     // b. If IsCallable(method) is true, then
-    if (IsCallable(method) === Value.true) {
+    if (IsCallable(method)) {
       // i. Let result be ? Call(method, O).
       const result = Q(Call(method, O));
       // ii. If Type(result) is not Object, return result.

--- a/src/engine.mts
+++ b/src/engine.mts
@@ -337,7 +337,7 @@ export function HostEnqueueFinalizationRegistryCleanupJob(fg) {
 /** https://tc39.es/ecma262/#sec-hostmakejobcallback */
 export function HostMakeJobCallback(callback) {
   // 1. Assert: IsCallable(callback) is true.
-  Assert(IsCallable(callback) === Value.true);
+  Assert(IsCallable(callback));
   // 2. Return the JobCallback Record { [[Callback]]: callback, [[HostDefined]]: empty }.
   return { Callback: callback, HostDefined: undefined };
 }
@@ -345,7 +345,7 @@ export function HostMakeJobCallback(callback) {
 /** https://tc39.es/ecma262/#sec-hostcalljobcallback */
 export function HostCallJobCallback(jobCallback, V, argumentsList) {
   // 1. Assert: IsCallable(jobCallback.[[Callback]]) is true.
-  Assert(IsCallable(jobCallback.Callback) === Value.true);
+  Assert(IsCallable(jobCallback.Callback));
   // 1. Return ? Call(jobCallback.[[Callback]], V, argumentsList).
   return Q(Call(jobCallback.Callback, V, argumentsList));
 }

--- a/src/intrinsics/Array.mts
+++ b/src/intrinsics/Array.mts
@@ -105,14 +105,14 @@ function Array_from([items = Value.undefined, mapfn = Value.undefined, thisArg =
   if (mapfn === Value.undefined) {
     mapping = false;
   } else {
-    if (IsCallable(mapfn) === Value.false) {
+    if (!IsCallable(mapfn)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', mapfn);
     }
     mapping = true;
   }
   const usingIterator = Q(GetMethod(items, wellKnownSymbols.iterator));
   if (usingIterator !== Value.undefined) {
-    if (IsConstructor(C) === Value.true) {
+    if (IsConstructor(C)) {
       A = Q(Construct(C));
     } else {
       A = X(ArrayCreate(0));
@@ -145,7 +145,7 @@ function Array_from([items = Value.undefined, mapfn = Value.undefined, thisArg =
   }
   const arrayLike = X(ToObject(items));
   const len = Q(LengthOfArrayLike(arrayLike));
-  if (IsConstructor(C) === Value.true) {
+  if (IsConstructor(C)) {
     A = Q(Construct(C, [F(len)]));
   } else {
     A = Q(ArrayCreate(len));
@@ -178,7 +178,7 @@ function Array_of(items, { thisValue }) {
   // Let items be the List of arguments passed to this function.
   const C = thisValue;
   let A;
-  if (IsConstructor(C) === Value.true) {
+  if (IsConstructor(C)) {
     A = Q(Construct(C, [F(len)]));
   } else {
     A = Q(ArrayCreate(len));

--- a/src/intrinsics/ArrayPrototype.mts
+++ b/src/intrinsics/ArrayPrototype.mts
@@ -171,7 +171,7 @@ function ArrayProto_fill([value = Value.undefined, start = Value.undefined, end 
 function ArrayProto_filter([callbackfn = Value.undefined, thisArg = Value.undefined], { thisValue }) {
   const O = Q(ToObject(thisValue));
   const len = Q(LengthOfArrayLike(O));
-  if (IsCallable(callbackfn) === Value.false) {
+  if (!IsCallable(callbackfn)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
   }
   const A = Q(ArraySpeciesCreate(O, 0));
@@ -200,7 +200,7 @@ function FlattenIntoArray(target, source, sourceLen, start, depth, mapperFunctio
   Assert(sourceLen >= 0);
   Assert(start >= 0);
   // Assert: _depth_ is an integer Number, *+&infin;*, or *-&infin;*.
-  // Assert(mapperFunction === undefined || (X(IsCallable(mapperFunction)) === Value.true && thisArg !== undefined && depth === 1));
+  // Assert(mapperFunction === undefined || (IsCallable(mapperFunction) && thisArg !== undefined && depth === 1));
   let targetIndex = start;
   let sourceIndex = 0;
   while (sourceIndex < sourceLen) {
@@ -249,7 +249,7 @@ function ArrayProto_flat([depth = Value.undefined], { thisValue }) {
 function ArrayProto_flatMap([mapperFunction = Value.undefined, thisArg = Value.undefined], { thisValue }) {
   const O = Q(ToObject(thisValue));
   const sourceLen = Q(LengthOfArrayLike(O));
-  if (X(IsCallable(mapperFunction)) === Value.false) {
+  if (!IsCallable(mapperFunction)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', mapperFunction);
   }
   const A = Q(ArraySpeciesCreate(O, 0));
@@ -267,7 +267,7 @@ function ArrayProto_keys(args, { thisValue }) {
 function ArrayProto_map([callbackfn = Value.undefined, thisArg = Value.undefined], { thisValue }) {
   const O = Q(ToObject(thisValue));
   const len = Q(LengthOfArrayLike(O));
-  if (IsCallable(callbackfn) === Value.false) {
+  if (!IsCallable(callbackfn)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
   }
   const A = Q(ArraySpeciesCreate(O, len));
@@ -389,7 +389,7 @@ function ArrayProto_slice([start = Value.undefined, end = Value.undefined], { th
 
 /** https://tc39.es/ecma262/#sec-array.prototype.sort */
 function ArrayProto_sort([comparefn = Value.undefined], { thisValue }) {
-  if (comparefn !== Value.undefined && IsCallable(comparefn) === Value.false) {
+  if (comparefn !== Value.undefined && !IsCallable(comparefn)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', comparefn);
   }
   const obj = Q(ToObject(thisValue));
@@ -487,7 +487,7 @@ function ArrayProto_splice(args, { thisValue }) {
 function ArrayProto_toString(a, { thisValue }) {
   const array = Q(ToObject(thisValue));
   let func = Q(Get(array, Value('join')));
-  if (IsCallable(func) === Value.false) {
+  if (!IsCallable(func)) {
     func = surroundingAgent.intrinsic('%Object.prototype.toString%');
   }
   return Q(Call(func, array));

--- a/src/intrinsics/ArrayPrototypeShared.mts
+++ b/src/intrinsics/ArrayPrototypeShared.mts
@@ -118,7 +118,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     Q(priorToEvaluatingAlgorithm(thisValue));
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
-    if (IsCallable(callbackFn) === Value.false) {
+    if (!IsCallable(callbackFn)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackFn);
     }
     let k = 0;
@@ -143,7 +143,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     Q(priorToEvaluatingAlgorithm(thisValue));
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
-    if (IsCallable(predicate) === Value.false) {
+    if (!IsCallable(predicate)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', predicate);
     }
     let k = 0;
@@ -165,7 +165,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     Q(priorToEvaluatingAlgorithm(thisValue));
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
-    if (IsCallable(predicate) === Value.false) {
+    if (!IsCallable(predicate)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', predicate);
     }
     let k = 0;
@@ -190,7 +190,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     // 2. Let len be ? LengthOfArrayLike(O).
     const len = Q(objectToLength(O));
     // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-    if (IsCallable(predicate) === Value.false) {
+    if (!IsCallable(predicate)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', predicate);
     }
     // 4. Let k be len - 1.
@@ -223,7 +223,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     // 2. Let len be ? LengthOfArrayLike(O).
     const len = Q(objectToLength(O));
     // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-    if (IsCallable(predicate) === Value.false) {
+    if (!IsCallable(predicate)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', predicate);
     }
     // 4. Let k be len - 1.
@@ -253,7 +253,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     Q(priorToEvaluatingAlgorithm(thisValue));
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
-    if (IsCallable(callbackfn) === Value.false) {
+    if (!IsCallable(callbackfn)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
     }
     let k = 0;
@@ -416,7 +416,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     Q(priorToEvaluatingAlgorithm(thisValue));
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
-    if (IsCallable(callbackfn) === Value.false) {
+    if (!IsCallable(callbackfn)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
     }
     if (len === 0 && initialValue === undefined) {
@@ -458,7 +458,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     Q(priorToEvaluatingAlgorithm(thisValue));
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
-    if (IsCallable(callbackfn) === Value.false) {
+    if (!IsCallable(callbackfn)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
     }
     if (len === 0 && initialValue === undefined) {
@@ -539,7 +539,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     Q(priorToEvaluatingAlgorithm(thisValue));
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
-    if (IsCallable(callbackfn) === Value.false) {
+    if (!IsCallable(callbackfn)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
     }
     let k = 0;

--- a/src/intrinsics/FinalizationRegistry.mts
+++ b/src/intrinsics/FinalizationRegistry.mts
@@ -12,7 +12,7 @@ function FinalizationRegistryConstructor([cleanupCallback = Value.undefined], { 
     return surroundingAgent.Throw('TypeError', 'NotAFunction', 'FinalizationRegistry');
   }
   // 2. If IsCallable(cleanupCallback) is false, throw a TypeError exception.
-  if (IsCallable(cleanupCallback) === Value.false) {
+  if (!IsCallable(cleanupCallback)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', cleanupCallback);
   }
   // 3. Let finalizationGroup be ? OrdinaryCreateFromConstructor(NewTarget, "%FinalizationRegistryPrototype%", « [[Realm]], [[CleanupCallback]], [[Cells]] »).

--- a/src/intrinsics/FinalizationRegistryPrototype.mts
+++ b/src/intrinsics/FinalizationRegistryPrototype.mts
@@ -17,7 +17,7 @@ function FinalizationRegistryProto_cleanupSome([callback = Value.undefined], { t
   // 2. Perform ? RequireInternalSlot(finalizationRegistry, [[Cells]]).
   Q(RequireInternalSlot(finalizationRegistry, 'Cells'));
   // 3. If callback is present and IsCallable(callback) is false, throw a TypeError exception.
-  if (callback !== Value.undefined && IsCallable(callback) === Value.false) {
+  if (callback !== Value.undefined && !IsCallable(callback)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', callback);
   }
   // 4. Perform ? CleanupFinalizationRegistry(finalizationRegistry, callback).

--- a/src/intrinsics/FunctionPrototype.mts
+++ b/src/intrinsics/FunctionPrototype.mts
@@ -42,7 +42,7 @@ function FunctionProto_apply([thisArg = Value.undefined, argArray = Value.undefi
   // 1. Let func be the this value.
   const func = thisValue;
   // 2. If IsCallable(func) is false, throw a TypeError exception.
-  if (IsCallable(func) === Value.false) {
+  if (!IsCallable(func)) {
     return surroundingAgent.Throw('TypeError', 'ThisNotAFunction', func);
   }
   // 3. If argArray is undefined or null, then
@@ -74,7 +74,7 @@ function BoundFunctionExoticObjectConstruct(argumentsList, newTarget) {
   const F = this;
 
   const target = F.BoundTargetFunction;
-  Assert(IsConstructor(target) === Value.true);
+  Assert(IsConstructor(target));
   const boundArgs = F.BoundArguments;
   const args = [...boundArgs, ...argumentsList];
   if (SameValue(F, newTarget) === Value.true) {
@@ -104,7 +104,7 @@ function BoundFunctionCreate(targetFunction, boundThis, boundArgs) {
   // 6. Set obj.[[Call]] as described in 9.4.1.1.
   obj.Call = BoundFunctionExoticObjectCall;
   // 7. If IsConstructor(targetFunction) is true, then
-  if (IsConstructor(targetFunction) === Value.true) {
+  if (IsConstructor(targetFunction)) {
     // a. Set obj.[[Construct]] as described in 9.4.1.2.
     obj.Construct = BoundFunctionExoticObjectConstruct;
   }
@@ -123,7 +123,7 @@ function FunctionProto_bind([thisArg = Value.undefined, ...args], { thisValue })
   // 1. Let Target be the this value.
   const Target = thisValue;
   // 2. If IsCallable(Target) is false, throw a TypeError exception.
-  if (IsCallable(Target) === Value.false) {
+  if (!IsCallable(Target)) {
     return surroundingAgent.Throw('TypeError', 'ThisNotAFunction', Target);
   }
   // 3. Let F be ? BoundFunctionCreate(Target, thisArg, args).
@@ -174,7 +174,7 @@ function FunctionProto_call([thisArg = Value.undefined, ...args], { thisValue })
   // 1. Let func be the this value.
   const func = thisValue;
   // 2. If IsCallable(func) is false, throw a TypeError exception.
-  if (IsCallable(func) === Value.false) {
+  if (!IsCallable(func)) {
     return surroundingAgent.Throw('TypeError', 'ThisNotAFunction', func);
   }
   // 3. Let argList be a new empty List.
@@ -216,7 +216,7 @@ function FunctionProto_toString(args, { thisValue }) {
   // 4. If Type(func) is Object and IsCallable(func) is true, then return an implementation
   //    dependent String source code representation of func. The representation must have
   //    the syntax of a NativeFunction.
-  if (func instanceof ObjectValue && IsCallable(func) === Value.true) {
+  if (func instanceof ObjectValue && IsCallable(func)) {
     return Value('function() { [native code] }');
   }
   // 5. Throw a TypeError exception.

--- a/src/intrinsics/JSON.mts
+++ b/src/intrinsics/JSON.mts
@@ -287,7 +287,7 @@ function JSON_parse([text = Value.undefined, reviver = Value.undefined]) {
          || unfiltered instanceof NullValue
          || unfiltered instanceof ObjectValue);
   // 7. If IsCallable(reviver) is true, then
-  if (IsCallable(reviver) === Value.true) {
+  if (IsCallable(reviver)) {
     // a. Let root be OrdinaryObjectCreate(%Object.prototype%).
     const root = OrdinaryObjectCreate(surroundingAgent.intrinsic('%Object.prototype%'));
     // b. Let rootName be the empty String.
@@ -317,7 +317,7 @@ function SerializeJSONProperty(state, key, holder) {
   let value = Q(Get(holder, key)); // eslint-disable-line no-shadow
   if (value instanceof ObjectValue || value instanceof BigIntValue) {
     const toJSON = Q(GetV(value, Value('toJSON')));
-    if (IsCallable(toJSON) === Value.true) {
+    if (IsCallable(toJSON)) {
       value = Q(Call(toJSON, value, [key]));
     }
   }
@@ -356,7 +356,7 @@ function SerializeJSONProperty(state, key, holder) {
   if (value instanceof BigIntValue) {
     return surroundingAgent.Throw('TypeError', 'CannotJSONSerializeBigInt');
   }
-  if (value instanceof ObjectValue && IsCallable(value) === Value.false) {
+  if (value instanceof ObjectValue && !IsCallable(value)) {
     const isArray = Q(IsArray(value));
     if (isArray === Value.true) {
       return Q(SerializeJSONArray(state, value));
@@ -480,7 +480,7 @@ function JSON_stringify([value = Value.undefined, replacer = Value.undefined, sp
   let PropertyList = Value.undefined;
   let ReplacerFunction = Value.undefined;
   if (replacer instanceof ObjectValue) {
-    if (IsCallable(replacer) === Value.true) {
+    if (IsCallable(replacer)) {
       ReplacerFunction = replacer;
     } else {
       const isArray = Q(IsArray(replacer));

--- a/src/intrinsics/Map.mts
+++ b/src/intrinsics/Map.mts
@@ -23,7 +23,7 @@ import {
 import { bootstrapConstructor } from './bootstrap.mjs';
 
 export function AddEntriesFromIterable(target, iterable, adder) {
-  if (IsCallable(adder) === Value.false) {
+  if (!IsCallable(adder)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', adder);
   }
   Assert(iterable !== undefined && iterable !== Value.undefined && iterable !== Value.null);

--- a/src/intrinsics/MapPrototype.mts
+++ b/src/intrinsics/MapPrototype.mts
@@ -73,7 +73,7 @@ function MapProto_forEach([callbackfn = Value.undefined, thisArg = Value.undefin
   // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
   Q(RequireInternalSlot(M, 'MapData'));
   // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
-  if (IsCallable(callbackfn) === Value.false) {
+  if (!IsCallable(callbackfn)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
   }
   // 4. Let entries be the List that is M.[[MapData]].

--- a/src/intrinsics/ObjectPrototype.mts
+++ b/src/intrinsics/ObjectPrototype.mts
@@ -140,7 +140,7 @@ function ObjectProto__defineGetter__([P = Value.undefined, getter = Value.undefi
   // 1. Let O be ? ToObject(this value).
   const O = Q(ToObject(thisValue));
   // 2. If IsCallable(getter) is false, throw a TypeError exception.
-  if (IsCallable(getter) === Value.false) {
+  if (!IsCallable(getter)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', getter);
   }
   // 3. Let desc be PropertyDescriptor { [[Get]]: getter, [[Enumerable]]: true, [[Configurable]]: true }.
@@ -162,7 +162,7 @@ function ObjectProto__defineSetter__([P = Value.undefined, setter = Value.undefi
   // 1. Let O be ? ToObject(this value).
   const O = Q(ToObject(thisValue));
   // 2. If IsCallable(setter) is false, throw a TypeError exception.
-  if (IsCallable(setter) === Value.false) {
+  if (!IsCallable(setter)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', setter);
   }
   // 3. Let desc be PropertyDescriptor { [[Set]]: setter, [[Enumerable]]: true, [[Configurable]]: true }.

--- a/src/intrinsics/Promise.mts
+++ b/src/intrinsics/Promise.mts
@@ -273,7 +273,7 @@ function PromiseAllSettledRejectElementFunctions([x = Value.undefined]) {
 /** https://tc39.es/ecma262/#sec-performpromiseallsettled */
 function PerformPromiseAllSettled(iteratorRecord, constructor, resultCapability, promiseResolve) {
   // 1. Assert: ! IsConstructor(constructor) is true.
-  Assert(X(IsConstructor(constructor)));
+  Assert(IsConstructor(constructor));
   // 2. Assert: resultCapability is a PromiseCapability Record.
   Assert(resultCapability instanceof PromiseCapabilityRecord);
   // 3. Assert: IsCallable(promiseResolve) is true.

--- a/src/intrinsics/Promise.mts
+++ b/src/intrinsics/Promise.mts
@@ -47,7 +47,7 @@ function PromiseConstructor([executor = Value.undefined], { NewTarget }) {
     return surroundingAgent.Throw('TypeError', 'ConstructorNonCallable', this);
   }
   // 2. If IsCallable(executor) is false, throw a TypeError exception.
-  if (IsCallable(executor) === Value.false) {
+  if (!IsCallable(executor)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', executor);
   }
   // 3. Let promise be ? OrdinaryCreateFromConstructor(NewTarget, "%Promise.prototype%", « [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] »).
@@ -105,11 +105,11 @@ function PromiseAllResolveElementFunctions([x = Value.undefined]) {
 /** https://tc39.es/ecma262/#sec-getpromiseresolve */
 function GetPromiseResolve(promiseConstructor) {
   // 1. Assert: IsConstructor(promiseConstructor) is true.
-  Assert(IsConstructor(promiseConstructor) === Value.true);
+  Assert(IsConstructor(promiseConstructor));
   // 2. Let promiseResolve be ? Get(promiseConstructor, "resolve").
   const promiseResolve = Q(Get(promiseConstructor, Value('resolve')));
   // 3. If IsCallable(promiseResolve) is false, throw a TypeError exception.
-  if (IsCallable(promiseResolve) === Value.false) {
+  if (!IsCallable(promiseResolve)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', promiseResolve);
   }
   // 4. Return promiseResolve.
@@ -119,11 +119,11 @@ function GetPromiseResolve(promiseConstructor) {
 /** https://tc39.es/ecma262/#sec-performpromiseall */
 function PerformPromiseAll(iteratorRecord, constructor, resultCapability, promiseResolve) {
   // 1. Assert: IsConstructor(constructor) is true.
-  Assert(IsConstructor(constructor) === Value.true);
+  Assert(IsConstructor(constructor));
   // 2. Assert: resultCapability is a PromiseCapability Record.
   Assert(resultCapability instanceof PromiseCapabilityRecord);
   // 3. Assert: IsCallable(promiseResolve) is true.
-  Assert(IsCallable(promiseResolve) === Value.true);
+  Assert(IsCallable(promiseResolve));
   // 4. Let values be a new empty List.
   const values = [];
   // 5. Let remainingElementsCount be the Record { [[Value]]: 1 }.
@@ -273,11 +273,11 @@ function PromiseAllSettledRejectElementFunctions([x = Value.undefined]) {
 /** https://tc39.es/ecma262/#sec-performpromiseallsettled */
 function PerformPromiseAllSettled(iteratorRecord, constructor, resultCapability, promiseResolve) {
   // 1. Assert: ! IsConstructor(constructor) is true.
-  Assert(X(IsConstructor(constructor) === Value.true));
+  Assert(X(IsConstructor(constructor)));
   // 2. Assert: resultCapability is a PromiseCapability Record.
   Assert(resultCapability instanceof PromiseCapabilityRecord);
   // 3. Assert: IsCallable(promiseResolve) is true.
-  Assert(IsCallable(promiseResolve) === Value.true);
+  Assert(IsCallable(promiseResolve));
   // 4. Let values be a new empty List.
   const values = [];
   // 5. Let remainingElementsCount be the Record { [[Value]]: 1 }.
@@ -451,11 +451,11 @@ function PromiseAnyRejectElementFunctions([x = Value.undefined]) {
 /** https://tc39.es/ecma262/#sec-performpromiseany */
 function PerformPromiseAny(iteratorRecord, constructor, resultCapability, promiseResolve) {
   // 1. Assert: ! IsConstructor(constructor) is true.
-  Assert(X(IsConstructor(constructor)) === Value.true);
+  Assert(IsConstructor(constructor));
   // 2. Assert: resultCapability is a PromiseCapability Record.
   Assert(resultCapability instanceof PromiseCapabilityRecord);
   // 3. Assert: ! IsCallable(promiseResolve) is true.
-  Assert(X(IsCallable(promiseResolve)) === Value.true);
+  Assert(IsCallable(promiseResolve));
   // 4. Let errors be a new empty List.
   const errors = [];
   // 5. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
@@ -563,11 +563,11 @@ function Promise_any([iterable = Value.undefined], { thisValue }) {
 
 function PerformPromiseRace(iteratorRecord, constructor, resultCapability, promiseResolve) {
   // 1. Assert: IsConstructor(constructor) is true.
-  Assert(IsConstructor(constructor) === Value.true);
+  Assert(IsConstructor(constructor));
   // 2. Assert: resultCapability is a PromiseCapability Record.
   Assert(resultCapability instanceof PromiseCapabilityRecord);
   // 3. Assert: IsCallable(promiseResolve) is true.
-  Assert(IsCallable(promiseResolve) === Value.true);
+  Assert(IsCallable(promiseResolve));
   // 4. Repeat,
   while (true) {
     // a. Let next be IteratorStep(iteratorRecord).

--- a/src/intrinsics/PromisePrototype.mts
+++ b/src/intrinsics/PromisePrototype.mts
@@ -37,11 +37,11 @@ function PromiseProto_finally([onFinally = Value.undefined], { thisValue }) {
   // 3. Let C be ? SpeciesConstructor(promise, %Promise%).
   const C = SpeciesConstructor(promise, surroundingAgent.intrinsic('%Promise%'));
   // 4. Assert: IsConstructor(C) is true.
-  Assert(IsConstructor(C) === Value.true);
+  Assert(IsConstructor(C));
   let thenFinally;
   let catchFinally;
   // 5. If IsCallable(onFinally) is false, then
-  if (IsCallable(onFinally) === Value.false) {
+  if (!IsCallable(onFinally)) {
     // a. Let thenFinally be onFinally.
     thenFinally = onFinally;
     // b. Let catchFinally be onFinally.

--- a/src/intrinsics/Reflect.mts
+++ b/src/intrinsics/Reflect.mts
@@ -19,7 +19,7 @@ import { bootstrapPrototype } from './bootstrap.mjs';
 /** https://tc39.es/ecma262/#sec-reflect.apply */
 function Reflect_apply([target = Value.undefined, thisArgument = Value.undefined, argumentsList = Value.undefined]) {
   // 1. If IsCallable(target) is false, throw a TypeError exception.
-  if (IsCallable(target) === Value.false) {
+  if (!IsCallable(target)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', target);
   }
   // 2. Let args be ? CreateListFromArrayLike(argumentsList).
@@ -33,13 +33,13 @@ function Reflect_apply([target = Value.undefined, thisArgument = Value.undefined
 /** https://tc39.es/ecma262/#sec-reflect.construct */
 function Reflect_construct([target = Value.undefined, argumentsList = Value.undefined, newTarget]) {
   // 1. If IsConstructor(target) is false, throw a TypeError exception.
-  if (IsConstructor(target) === Value.false) {
+  if (!IsConstructor(target)) {
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', target);
   }
   // 2. If newTarget is not present, set newTarget to target.
   if (newTarget === undefined) {
     newTarget = target;
-  } else if (IsConstructor(newTarget) === Value.false) { // 3. Else if IsConstructor(newTarget) is false, throw a TypeError exception.
+  } else if (!IsConstructor(newTarget)) { // 3. Else if IsConstructor(newTarget) is false, throw a TypeError exception.
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', newTarget);
   }
   // 4. Let args be ? CreateListFromArrayLike(argumentsList).

--- a/src/intrinsics/RegExpPrototype.mts
+++ b/src/intrinsics/RegExpPrototype.mts
@@ -58,7 +58,7 @@ export function RegExpExec(R, S) {
   Assert(S instanceof JSStringValue);
 
   const exec = Q(Get(R, Value('exec')));
-  if (IsCallable(exec) === Value.true) {
+  if (IsCallable(exec)) {
     const result = Q(Call(exec, R, [S]));
     if (!(result instanceof ObjectValue) && !(result instanceof NullValue)) {
       return surroundingAgent.Throw('TypeError', 'RegExpExecNotObject', result);
@@ -462,7 +462,7 @@ function RegExpProto_replace([string = Value.undefined, replaceValue = Value.und
   // 5. Let functionalReplace be IsCallable(replaceValue).
   const functionalReplace = IsCallable(replaceValue);
   // 6. If functionalReplace is false, then
-  if (functionalReplace === Value.false) {
+  if (functionalReplace === false) {
     // a. Set replaceValue to ? ToString(replaceValue).
     replaceValue = Q(ToString(replaceValue));
   }
@@ -553,7 +553,7 @@ function RegExpProto_replace([string = Value.undefined, replaceValue = Value.und
     let namedCaptures = Q(Get(result, Value('groups')));
     let replacement;
     // k. If functionalReplace is true, then
-    if (functionalReplace === Value.true) {
+    if (functionalReplace === true) {
       // i. Let replacerArgs be the list-concatenation of « matched », captures, and « 𝔽(position), S ».
       const replacerArgs = [matched, ...captures, F(position), S];
       // ii. If namedCaptures is not undefined, then

--- a/src/intrinsics/Set.mts
+++ b/src/intrinsics/Set.mts
@@ -30,7 +30,7 @@ function SetConstructor([iterable = Value.undefined], { NewTarget }) {
   // 5. Let adder be ? Get(set, "add").
   const adder = Q(Get(set, Value('add')));
   // 6. If IsCallable(adder) is false, throw a TypeError exception.
-  if (IsCallable(adder) === Value.false) {
+  if (!IsCallable(adder)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', adder);
   }
   // 7. Let iteratorRecord be ? GetIterator(iterable).

--- a/src/intrinsics/SetPrototype.mts
+++ b/src/intrinsics/SetPrototype.mts
@@ -97,7 +97,7 @@ function SetProto_forEach([callbackfn = Value.undefined, thisArg = Value.undefin
   // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
   Q(RequireInternalSlot(S, 'SetData'));
   // 3. If IsCallable(callbackfn) is false, throw a TypeError exception
-  if (IsCallable(callbackfn) === Value.false) {
+  if (!IsCallable(callbackfn)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
   }
   // 4. Let entries be the List that is S.[[SetData]].

--- a/src/intrinsics/StringPrototype.mts
+++ b/src/intrinsics/StringPrototype.mts
@@ -357,7 +357,7 @@ function StringProto_replace([searchValue = Value.undefined, replaceValue = Valu
   const string = Q(ToString(O));
   const searchString = Q(ToString(searchValue));
   const functionalReplace = IsCallable(replaceValue);
-  if (functionalReplace === Value.false) {
+  if (functionalReplace === false) {
     replaceValue = Q(ToString(replaceValue));
   }
   const pos = string.stringValue().indexOf(searchString.stringValue());
@@ -366,7 +366,7 @@ function StringProto_replace([searchValue = Value.undefined, replaceValue = Valu
     return string;
   }
   let replStr;
-  if (functionalReplace === Value.true) {
+  if (functionalReplace === true) {
     const replValue = Q(Call(replaceValue, Value.undefined, [matched, F(pos), string]));
     replStr = Q(ToString(replValue));
   } else {
@@ -412,7 +412,7 @@ function StringProto_replaceAll([searchValue = Value.undefined, replaceValue = V
   // 5. Let functionalReplace be IsCallable(replaceValue).
   const functionalReplace = IsCallable(replaceValue);
   // 6. If functionalReplace is false, then
-  if (functionalReplace === Value.false) {
+  if (functionalReplace === false) {
     // a. Let replaceValue be ? ToString(replaceValue).
     replaceValue = Q(ToString(replaceValue));
   }
@@ -439,7 +439,7 @@ function StringProto_replaceAll([searchValue = Value.undefined, replaceValue = V
   for (position of matchPositions) {
     let replacement;
     // a. If functionalReplace is true, then
-    if (functionalReplace === Value.true) {
+    if (functionalReplace === true) {
       // i. Let replacement be ? ToString(? Call(replaceValue, undefined, « searchString, 𝔽(position), string »).
       replacement = Q(ToString(Q(Call(replaceValue, Value.undefined, [searchString, F(position), string]))));
     } else { // b. Else,

--- a/src/intrinsics/TypedArray.mts
+++ b/src/intrinsics/TypedArray.mts
@@ -30,7 +30,7 @@ function TypedArray_from([source = Value.undefined, mapfn = Value.undefined, thi
   // 1. Let C be the this value.
   const C = thisValue;
   // 2. If IsConstructor(C) is false, throw a TypeError exception.
-  if (IsConstructor(C) === Value.false) {
+  if (!IsConstructor(C)) {
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', C);
   }
   // 3. If mapfn is undefined, let mapping be false.
@@ -39,7 +39,7 @@ function TypedArray_from([source = Value.undefined, mapfn = Value.undefined, thi
     mapping = false;
   } else {
     // a. If IsCallable(mapfn) is false, throw a TypeError exception.
-    if (IsCallable(mapfn) === Value.false) {
+    if (!IsCallable(mapfn)) {
       return surroundingAgent.Throw('TypeError', 'NotAFunction', mapfn);
     }
     // b. Let mapping be true.
@@ -109,7 +109,7 @@ function TypedArray_of(items, { thisValue }) {
   // 3. Let C be the this value.
   const C = thisValue;
   // 4. If IsConstructor(C) is false, throw a TypeError exception.
-  if (IsConstructor(C) === Value.false) {
+  if (!IsConstructor(C)) {
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', C);
   }
   // 5. Let newObj be ? TypedArrayCreate(C, « 𝔽(len) »).

--- a/src/intrinsics/TypedArrayPrototype.mts
+++ b/src/intrinsics/TypedArrayPrototype.mts
@@ -258,7 +258,7 @@ function TypedArrayProto_filter([callbackfn = Value.undefined, thisArg = Value.u
   // 3. Let len be O.[[ArrayLength]].
   const len = O.ArrayLength;
   // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-  if (IsCallable(callbackfn) === Value.false) {
+  if (!IsCallable(callbackfn)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
   }
   // 5. Let kept be a new empty List.
@@ -339,7 +339,7 @@ function TypedArrayProto_map([callbackfn = Value.undefined, thisArg = Value.unde
   // 3. Let len be O.[[ArrayLength]].
   const len = O.ArrayLength;
   // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-  if (IsCallable(callbackfn) === Value.false) {
+  if (!IsCallable(callbackfn)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
   }
   // 5. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(len) »).
@@ -628,7 +628,7 @@ function TypedArrayProto_slice([start = Value.undefined, end = Value.undefined],
 /** https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort */
 function TypedArrayProto_sort([comparefn = Value.undefined], { thisValue }) {
   // 1. If comparefn is not undefined and IsCallable(comparefn) is false, throw a TypeError exception.
-  if (comparefn !== Value.undefined && IsCallable(comparefn) === Value.false) {
+  if (comparefn !== Value.undefined && !IsCallable(comparefn)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', comparefn);
   }
   // 2. Let obj be the this value.

--- a/src/intrinsics/WeakSet.mts
+++ b/src/intrinsics/WeakSet.mts
@@ -30,7 +30,7 @@ function WeakSetConstructor([iterable = Value.undefined], { NewTarget }) {
   // 5. Let adder be ? Get(set, "add").
   const adder = Q(Get(set, Value('add')));
   // 6. If IsCallable(adder) is false, throw a TypeError exception.
-  if (IsCallable(adder) === Value.false) {
+  if (!IsCallable(adder)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', adder);
   }
   // 7. Let iteratorRecord be ? GetIterator(iterable).

--- a/src/runtime-semantics/ClassDefinitionEvaluation.mts
+++ b/src/runtime-semantics/ClassDefinitionEvaluation.mts
@@ -120,7 +120,7 @@ export function* ClassDefinitionEvaluation(ClassTail, classBinding, className) {
       protoParent = Value.null;
       // ii. Let constructorParent be %Function.prototype%.
       constructorParent = surroundingAgent.intrinsic('%Function.prototype%');
-    } else if (IsConstructor(superclass) === Value.false) {
+    } else if (!IsConstructor(superclass)) {
       // f. Else if IsConstructor(superclass) is false, throw a TypeError exception.
       return surroundingAgent.Throw('TypeError', 'NotAConstructor', superclass);
     } else { // g. Else,
@@ -168,7 +168,7 @@ export function* ClassDefinitionEvaluation(ClassTail, classBinding, className) {
         // 2. Let func be ! F.[[GetPrototypeOf]]().
         const func = X(F.GetPrototypeOf());
         // 3. If IsConstructor(func) is false, throw a TypeError exception.
-        if (IsConstructor(func) === Value.false) {
+        if (!IsConstructor(func)) {
           return surroundingAgent.Throw('TypeError', 'NotAConstructor', func);
         }
         // 4. Let result be ? Construct(func, args, NewTarget).

--- a/src/runtime-semantics/EvaluateCall.mts
+++ b/src/runtime-semantics/EvaluateCall.mts
@@ -43,7 +43,7 @@ export function* EvaluateCall(func, ref, args, tailPosition) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', func);
   }
   // 5. If IsCallable(func) is false, throw a TypeError exception.
-  if (IsCallable(func) === Value.false) {
+  if (!IsCallable(func)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', func);
   }
   // 6. If tailPosition is true, perform PrepareForTailCall().

--- a/src/runtime-semantics/NewExpression.mts
+++ b/src/runtime-semantics/NewExpression.mts
@@ -29,7 +29,7 @@ function* EvaluateNew(constructExpr, args) {
     argList = Q(yield* ArgumentListEvaluation(args));
   }
   // 7. If IsConstructor(constructor) is false, throw a TypeError exception.
-  if (IsConstructor(constructor) === Value.false) {
+  if (!IsConstructor(constructor)) {
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', constructor);
   }
   // 8. Return ? Construct(constructor, argList).

--- a/src/runtime-semantics/RelationalExpression.mts
+++ b/src/runtime-semantics/RelationalExpression.mts
@@ -39,7 +39,7 @@ export function InstanceofOperator(V, target) {
     return X(ToBoolean(Q(Call(instOfHandler, target, [V]))));
   }
   // 4. If IsCallable(target) is false, throw a TypeError exception.
-  if (IsCallable(target) === Value.false) {
+  if (!IsCallable(target)) {
     return surroundingAgent.Throw('TypeError', 'NotAFunction', target);
   }
   // 5. Return ? OrdinaryHasInstance(target, V).

--- a/src/runtime-semantics/SuperCall.mts
+++ b/src/runtime-semantics/SuperCall.mts
@@ -26,7 +26,7 @@ export function* Evaluate_SuperCall({ Arguments }) {
   // 4. Let argList be ? ArgumentListEvaluation of Arguments.
   const argList = Q(yield* ArgumentListEvaluation(Arguments));
   // 5. If IsConstructor(func) is false, throw a TypeError exception.
-  if (IsConstructor(func) === Value.false) {
+  if (!IsConstructor(func)) {
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', func);
   }
   // 6. Let result be ? Construct(func, argList, newTarget).

--- a/src/runtime-semantics/UnaryExpression.mts
+++ b/src/runtime-semantics/UnaryExpression.mts
@@ -105,7 +105,7 @@ function* Evaluate_UnaryExpression_Typeof({ UnaryExpression }) {
   } else if (val instanceof SymbolValue) {
     return new JSStringValue('symbol');
   } else if (val instanceof ObjectValue) {
-    if (IsCallable(val) === Value.true) {
+    if (IsCallable(val)) {
       return new JSStringValue('function');
     }
     return new JSStringValue('object');

--- a/test/test262/test262.js
+++ b/test/test262/test262.js
@@ -260,7 +260,7 @@ if (!process.send) {
       return false;
     }
     const ctor = ctorDesc.Value;
-    if (!(ctor instanceof ObjectValue) || IsCallable(ctor) !== Value.true) {
+    if (!(ctor instanceof ObjectValue) || !IsCallable(ctor)) {
       return false;
     }
     const namePropDesc = ctor.properties.get(Value('name'));


### PR DESCRIPTION
This changes the behavior of `IsCallable` and `IsConstructor` to return `boolean` instead of `BooleanValue` so that they can be turned into type guards in a future type-safety PR.