### PR TITLE
Prefer 𝔽, Z, and ℝ shorthand for numbers, add lint rules with fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,9 @@ module.exports = {
   rules: {
     '@engine262/no-use-in-def': 'error',
     '@engine262/valid-feature': 'error',
+    '@engine262/number-value': 'error',
+    '@engine262/bigint-value': 'error',
+    '@engine262/mathematical-value': 'error',
     'arrow-parens': ['error', 'always'],
     'brace-style': ['error', '1tbs', { allowSingleLine: false }],
     'curly': ['error', 'all'],

--- a/inspector/context.js
+++ b/inspector/context.js
@@ -83,7 +83,7 @@ class InspectorContext {
         break;
       case 'Number': {
         result.type = 'number';
-        const v = object.numberValue();
+        const v = object.numberValue(); // eslint-disable-line @engine262/mathematical-value
         if (!Number.isFinite(v)) {
           result.unserializableValue = v.toString();
         } else {
@@ -97,7 +97,7 @@ class InspectorContext {
         break;
       case 'BigInt':
         result.type = 'bigint';
-        result.unserializableValue = `${object.bigintValue().toString()}n`;
+        result.unserializableValue = `${object.bigintValue().toString()}n`; // eslint-disable-line @engine262/mathematical-value
         break;
       case 'Symbol':
         result.type = 'symbol';
@@ -262,7 +262,7 @@ class InspectorContext {
             break;
           case 'Number': {
             descriptor.type = 'number';
-            descriptor.value = desc.Value.numberValue().toString();
+            descriptor.value = desc.Value.numberValue().toString(); // eslint-disable-line @engine262/mathematical-value
             break;
           }
           case 'Boolean':
@@ -271,7 +271,7 @@ class InspectorContext {
             break;
           case 'BigInt':
             descriptor.type = 'bigint';
-            descriptor.value = `${desc.Value.bigintValue().toString()}n`;
+            descriptor.value = `${desc.Value.bigintValue().toString()}n`; // eslint-disable-line @engine262/mathematical-value
             break;
           case 'Symbol': {
             descriptor.type = 'symbol';

--- a/src/abstract-ops/arguments-operations.mts
+++ b/src/abstract-ops/arguments-operations.mts
@@ -27,7 +27,7 @@ import {
   HasOwnProperty,
   IsAccessorDescriptor,
   IsDataDescriptor,
-  F,
+  𝔽,
 } from './all.mjs';
 
 // This file covers abstract operations defined in
@@ -124,7 +124,7 @@ export function CreateUnmappedArgumentsObject(argumentsList) {
   const obj = OrdinaryObjectCreate(surroundingAgent.intrinsic('%Object.prototype%'), ['ParameterMap']);
   obj.ParameterMap = Value.undefined;
   DefinePropertyOrThrow(obj, Value('length'), Descriptor({
-    Value: F(len),
+    Value: 𝔽(len),
     Writable: Value.true,
     Enumerable: Value.false,
     Configurable: Value.true,
@@ -132,7 +132,7 @@ export function CreateUnmappedArgumentsObject(argumentsList) {
   let index = 0;
   while (index < len) {
     const val = argumentsList[index];
-    X(CreateDataProperty(obj, X(ToString(F(index))), val));
+    X(CreateDataProperty(obj, X(ToString(𝔽(index))), val));
     index += 1;
   }
   X(DefinePropertyOrThrow(obj, wellKnownSymbols.iterator, Descriptor({
@@ -193,11 +193,11 @@ export function CreateMappedArgumentsObject(func, formals, argumentsList, env) {
   let index = 0;
   while (index < len) {
     const val = argumentsList[index];
-    X(CreateDataProperty(obj, X(ToString(F(index))), val));
+    X(CreateDataProperty(obj, X(ToString(𝔽(index))), val));
     index += 1;
   }
   X(DefinePropertyOrThrow(obj, Value('length'), Descriptor({
-    Value: F(len),
+    Value: 𝔽(len),
     Writable: Value.true,
     Enumerable: Value.false,
     Configurable: Value.true,
@@ -211,7 +211,7 @@ export function CreateMappedArgumentsObject(func, formals, argumentsList, env) {
       if (index < len) {
         const g = MakeArgGetter(name, env);
         const p = MakeArgSetter(name, env);
-        X(map.DefineOwnProperty(X(ToString(F(index))), Descriptor({
+        X(map.DefineOwnProperty(X(ToString(𝔽(index))), Descriptor({
           Set: p,
           Get: g,
           Enumerable: Value.false,

--- a/src/abstract-ops/array-objects.mts
+++ b/src/abstract-ops/array-objects.mts
@@ -34,7 +34,7 @@ import {
   isArrayIndex,
   isNonNegativeInteger,
   Yield,
-  F,
+  𝔽, ℝ,
 } from './all.mjs';
 
 /** https://tc39.es/ecma262/#sec-array-exotic-objects-defineownproperty-p-desc */
@@ -50,15 +50,15 @@ function ArrayDefineOwnProperty(P, Desc) {
     Assert(oldLenDesc.Configurable === Value.false);
     const oldLen = oldLenDesc.Value;
     const index = X(ToUint32(P));
-    if (index.numberValue() >= oldLen.numberValue() && oldLenDesc.Writable === Value.false) {
+    if (ℝ(index) >= ℝ(oldLen) && oldLenDesc.Writable === Value.false) {
       return Value.false;
     }
     const succeeded = X(OrdinaryDefineOwnProperty(A, P, Desc));
     if (succeeded === Value.false) {
       return Value.false;
     }
-    if (index.numberValue() >= oldLen.numberValue()) {
-      oldLenDesc.Value = F(index.numberValue() + 1);
+    if (ℝ(index) >= ℝ(oldLen)) {
+      oldLenDesc.Value = 𝔽(ℝ(index) + 1);
       const succeeded = OrdinaryDefineOwnProperty(A, Value('length'), oldLenDesc); // eslint-disable-line no-shadow
       Assert(succeeded === Value.true);
     }
@@ -88,7 +88,7 @@ export function ArrayCreate(length, proto) {
   A.DefineOwnProperty = ArrayDefineOwnProperty;
 
   X(OrdinaryDefineOwnProperty(A, Value('length'), Descriptor({
-    Value: F(length),
+    Value: 𝔽(length),
     Writable: Value.true,
     Enumerable: Value.false,
     Configurable: Value.false,
@@ -129,7 +129,7 @@ export function ArraySpeciesCreate(originalArray, length) {
   if (IsConstructor(C) === Value.false) {
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', C);
   }
-  return Q(Construct(C, [F(length)]));
+  return Q(Construct(C, [𝔽(length)]));
 }
 
 /** https://tc39.es/ecma262/#sec-arraysetlength */
@@ -138,16 +138,16 @@ export function ArraySetLength(A, Desc) {
     return OrdinaryDefineOwnProperty(A, Value('length'), Desc);
   }
   const newLenDesc = Descriptor({ ...Desc });
-  const newLen = Q(ToUint32(Desc.Value)).numberValue();
-  const numberLen = Q(ToNumber(Desc.Value)).numberValue();
+  const newLen = ℝ(Q(ToUint32(Desc.Value)));
+  const numberLen = ℝ(Q(ToNumber(Desc.Value)));
   if (newLen !== numberLen) {
     return surroundingAgent.Throw('RangeError', 'InvalidArrayLength', Desc.Value);
   }
-  newLenDesc.Value = F(newLen);
+  newLenDesc.Value = 𝔽(newLen);
   const oldLenDesc = OrdinaryGetOwnProperty(A, Value('length'));
   Assert(X(IsDataDescriptor(oldLenDesc)));
   Assert(oldLenDesc.Configurable === Value.false);
-  const oldLen = oldLenDesc.Value.numberValue();
+  const oldLen = ℝ(oldLenDesc.Value);
   if (newLen >= oldLen) {
     return OrdinaryDefineOwnProperty(A, Value('length'), newLenDesc);
   }
@@ -175,7 +175,7 @@ export function ArraySetLength(A, Desc) {
   for (const P of keys) {
     const deleteSucceeded = X(A.Delete(P));
     if (deleteSucceeded === Value.false) {
-      newLenDesc.Value = F(X(ToUint32(P)).numberValue() + 1);
+      newLenDesc.Value = 𝔽(ℝ(X(ToUint32(P))) + 1);
       if (newWritable === false) {
         newLenDesc.Writable = Value.false;
       }
@@ -206,15 +206,15 @@ export function IsConcatSpreadable(O) {
 export function SortCompare(x, y, comparefn) {
   // 1. If x and y are both undefined, return +0𝔽.
   if (x === Value.undefined && y === Value.undefined) {
-    return F(+0);
+    return 𝔽(+0);
   }
   // 2. If x is undefined, return 1𝔽.
   if (x === Value.undefined) {
-    return F(1);
+    return 𝔽(1);
   }
   // 3. If y is undefined, return -1𝔽.
   if (y === Value.undefined) {
-    return F(-1);
+    return 𝔽(-1);
   }
   // 4. If comparefn is not undefined, then
   if (comparefn !== Value.undefined) {
@@ -222,7 +222,7 @@ export function SortCompare(x, y, comparefn) {
     const v = Q(ToNumber(Q(Call(comparefn, Value.undefined, [x, y]))));
     // b. If v is NaN, return +0𝔽.
     if (v.isNaN()) {
-      return F(+0);
+      return 𝔽(+0);
     }
     // c. Return v.
     return v;
@@ -235,16 +235,16 @@ export function SortCompare(x, y, comparefn) {
   const xSmaller = AbstractRelationalComparison(xString, yString);
   // 8. If xSmaller is true, return -1𝔽.
   if (xSmaller === Value.true) {
-    return F(-1);
+    return 𝔽(-1);
   }
   // 9. Let ySmaller be the result of performing Abstract Relational Comparison yString < xString.
   const ySmaller = AbstractRelationalComparison(yString, xString);
   // 10. If ySmaller is true, return 1𝔽.
   if (ySmaller === Value.true) {
-    return F(1);
+    return 𝔽(1);
   }
   // 11. Return +0𝔽.
-  return F(+0);
+  return 𝔽(+0);
 }
 
 /** https://tc39.es/ecma262/#sec-createarrayiterator */
@@ -278,10 +278,10 @@ export function CreateArrayIterator(array, kind) {
       }
       // iv. If kind is key, perform ? Yield(𝔽(index)).
       if (kind === 'key') {
-        Q(yield* Yield(F(index)));
+        Q(yield* Yield(𝔽(index)));
       } else { // v. Else,
         // 1. Let elementKey be ! ToString(𝔽(index)).
-        const elementKey = X(ToString(F(index)));
+        const elementKey = X(ToString(𝔽(index)));
         // 2. Let elementValue be ? Get(array, elementKey).
         const elementValue = Q(Get(array, elementKey));
         // 3. If kind is value, perform ? Yield(elementValue).
@@ -291,7 +291,7 @@ export function CreateArrayIterator(array, kind) {
           // a. Assert: kind is key+value.
           Assert(kind === 'key+value');
           // b. Perform ? Yield(! CreateArrayFromList(« 𝔽(index), elementValue »)).
-          Q(yield* Yield(X(CreateArrayFromList([F(index), elementValue]))));
+          Q(yield* Yield(X(CreateArrayFromList([𝔽(index), elementValue]))));
         }
       }
       // vi. Set index to index + 1.

--- a/src/abstract-ops/arraybuffer-objects.mts
+++ b/src/abstract-ops/arraybuffer-objects.mts
@@ -9,8 +9,8 @@ import {
   isNonNegativeInteger, CreateByteDataBlock,
   SameValue, IsConstructor, CopyDataBlockBytes,
   typedArrayInfoByType,
-  F,
-  Z,
+  𝔽,
+  ℤ, ℝ,
 } from './all.mjs';
 
 /** https://tc39.es/ecma262/#sec-allocatearraybuffer */
@@ -116,7 +116,7 @@ export function RawBytesToNumeric(type, rawBytes, isLittleEndian) {
   const dataViewType = type === 'Uint8C' ? 'Uint8' : type;
   Object.assign(throwawayArray, rawBytes);
   const result = throwawayDataView[`get${dataViewType}`](0, isLittleEndian === Value.true);
-  return IsBigIntElementType(type) === Value.true ? Z(result) : F(result);
+  return IsBigIntElementType(type) === Value.true ? ℤ(result) : 𝔽(result);
 }
 
 /** https://tc39.es/ecma262/#sec-getvaluefrombuffer */
@@ -156,17 +156,17 @@ export function NumericToRawBytes(type, value, isLittleEndian) {
   let rawBytes;
   // One day, we will write our own IEEE 754 and two's complement encoder…
   if (type === 'Float32') {
-    if (Number.isNaN(value.numberValue())) {
+    if (Number.isNaN(ℝ(value))) {
       rawBytes = isLittleEndian ? [...float32NaNLE] : [...float32NaNBE];
     } else {
-      throwawayDataView.setFloat32(0, value.numberValue(), isLittleEndian);
+      throwawayDataView.setFloat32(0, ℝ(value), isLittleEndian);
       rawBytes = [...throwawayArray.subarray(0, 4)];
     }
   } else if (type === 'Float64') {
-    if (Number.isNaN(value.numberValue())) {
+    if (Number.isNaN(ℝ(value))) {
       rawBytes = isLittleEndian ? [...float64NaNLE] : [...float64NaNBE];
     } else {
-      throwawayDataView.setFloat64(0, value.numberValue(), isLittleEndian);
+      throwawayDataView.setFloat64(0, ℝ(value), isLittleEndian);
       rawBytes = [...throwawayArray.subarray(0, 8)];
     }
   } else {
@@ -177,7 +177,7 @@ export function NumericToRawBytes(type, value, isLittleEndian) {
     // c. Let intValue be convOp(value) treated as a mathematical value, whether the result is a BigInt or Number.
     const intValue = X(convOp(value));
     const dataViewType = type === 'Uint8C' ? 'Uint8' : type;
-    throwawayDataView[`set${dataViewType}`](0, intValue.bigintValue ? intValue.bigintValue() : intValue.numberValue(), isLittleEndian);
+    throwawayDataView[`set${dataViewType}`](0, intValue.bigintValue ? ℝ(intValue) : ℝ(intValue), isLittleEndian);
     rawBytes = [...throwawayArray.subarray(0, n)];
   }
   return rawBytes;

--- a/src/abstract-ops/data-types-and-values.mts
+++ b/src/abstract-ops/data-types-and-values.mts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { JSStringValue, Value } from '../value.mjs';
 import { X } from '../completion.mjs';
-import { CanonicalNumericIndexString } from './all.mjs';
+import { CanonicalNumericIndexString, ℝ } from './all.mjs';
 
 // This file covers predicates defined in
 /** https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values */
@@ -15,10 +15,10 @@ export function isIntegerIndex(V) {
   if (numeric === Value.undefined) {
     return false;
   }
-  if (Object.is(numeric.numberValue(), +0)) {
+  if (Object.is(ℝ(numeric), +0)) {
     return true;
   }
-  return numeric.numberValue() > 0 && Number.isSafeInteger(numeric.numberValue());
+  return ℝ(numeric) > 0 && Number.isSafeInteger(ℝ(numeric));
 }
 
 // 6.1.7 #array-index
@@ -30,13 +30,13 @@ export function isArrayIndex(V) {
   if (numeric === Value.undefined) {
     return false;
   }
-  if (!Number.isInteger(numeric.numberValue())) {
+  if (!Number.isInteger(ℝ(numeric))) {
     return false;
   }
-  if (Object.is(numeric.numberValue(), +0)) {
+  if (Object.is(ℝ(numeric), +0)) {
     return true;
   }
-  return numeric.numberValue() > 0 && numeric.numberValue() < (2 ** 32) - 1;
+  return ℝ(numeric) > 0 && ℝ(numeric) < (2 ** 32) - 1;
 }
 
 export function isNonNegativeInteger(argument) {

--- a/src/abstract-ops/date-objects.mts
+++ b/src/abstract-ops/date-objects.mts
@@ -5,7 +5,7 @@
 import { X } from '../completion.mjs';
 import {
   ToIntegerOrInfinity,
-  F,
+  𝔽, ℝ,
 } from './all.mjs';
 
 const mod = (n, m) => {
@@ -23,130 +23,130 @@ export const msPerDay = msPerHour * HoursPerDay;
 
 /** https://tc39.es/ecma262/#sec-day-number-and-time-within-day */
 export function Day(t) {
-  return F(Math.floor(t.numberValue() / msPerDay));
+  return 𝔽(Math.floor(ℝ(t) / msPerDay));
 }
 
 export function TimeWithinDay(t) {
-  return F(mod(t.numberValue(), msPerDay));
+  return 𝔽(mod(ℝ(t), msPerDay));
 }
 
 /** https://tc39.es/ecma262/#sec-year-number */
 export function DaysInYear(y) {
-  y = y.numberValue();
+  y = ℝ(y);
   if (mod(y, 4) !== 0) {
-    return F(365);
+    return 𝔽(365);
   }
   if (mod(y, 4) === 0 && mod(y, 100) !== 0) {
-    return F(366);
+    return 𝔽(366);
   }
   if (mod(y, 100) === 0 && mod(y, 400) !== 0) {
-    return F(365);
+    return 𝔽(365);
   }
   if (mod(y, 400) === 0) {
-    return F(366);
+    return 𝔽(366);
   }
 }
 
 export function DayFromYear(y) {
-  y = y.numberValue();
-  return F(365 * (y - 1970) + Math.floor((y - 1969) / 4) - Math.floor((y - 1901) / 100) + Math.floor((y - 1601) / 400));
+  y = ℝ(y);
+  return 𝔽(365 * (y - 1970) + Math.floor((y - 1969) / 4) - Math.floor((y - 1901) / 100) + Math.floor((y - 1601) / 400));
 }
 
 export function TimeFromYear(y) {
-  return F(msPerDay * DayFromYear(y).numberValue());
+  return 𝔽(msPerDay * ℝ(DayFromYear(y)));
 }
 
 export const msPerAverageYear = 12 * 30.436875 * msPerDay;
 
 export function YearFromTime(t) {
-  t = t.numberValue();
+  t = ℝ(t);
   let year = Math.floor((t + msPerAverageYear / 2) / msPerAverageYear) + 1970;
-  if (TimeFromYear(F(year)).numberValue() > t) {
+  if (ℝ(TimeFromYear(𝔽(year))) > t) {
     year -= 1;
   }
-  return F(year);
+  return 𝔽(year);
 }
 
 export function InLeapYear(t) {
-  if (DaysInYear(YearFromTime(t)).numberValue() === 365) {
-    return F(+0);
+  if (ℝ(DaysInYear(YearFromTime(t))) === 365) {
+    return 𝔽(+0);
   }
-  if (DaysInYear(YearFromTime(t)).numberValue() === 366) {
-    return F(1);
+  if (ℝ(DaysInYear(YearFromTime(t))) === 366) {
+    return 𝔽(1);
   }
 }
 
 /** https://tc39.es/ecma262/#sec-month-number */
 export function MonthFromTime(t) {
-  const dayWithinYear = DayWithinYear(t).numberValue();
-  const inLeapYear = InLeapYear(t).numberValue();
+  const dayWithinYear = ℝ(DayWithinYear(t));
+  const inLeapYear = ℝ(InLeapYear(t));
   if (dayWithinYear >= 0 && dayWithinYear < 31) {
-    return F(+0);
+    return 𝔽(+0);
   }
   if (dayWithinYear >= 31 && dayWithinYear < 59 + inLeapYear) {
-    return F(1);
+    return 𝔽(1);
   }
   if (dayWithinYear >= 59 + inLeapYear && dayWithinYear < 90 + inLeapYear) {
-    return F(2);
+    return 𝔽(2);
   }
   if (dayWithinYear >= 90 + inLeapYear && dayWithinYear < 120 + inLeapYear) {
-    return F(3);
+    return 𝔽(3);
   }
   if (dayWithinYear >= 120 + inLeapYear && dayWithinYear < 151 + inLeapYear) {
-    return F(4);
+    return 𝔽(4);
   }
   if (dayWithinYear >= 151 + inLeapYear && dayWithinYear < 181 + inLeapYear) {
-    return F(5);
+    return 𝔽(5);
   }
   if (dayWithinYear >= 181 + inLeapYear && dayWithinYear < 212 + inLeapYear) {
-    return F(6);
+    return 𝔽(6);
   }
   if (dayWithinYear >= 212 + inLeapYear && dayWithinYear < 243 + inLeapYear) {
-    return F(7);
+    return 𝔽(7);
   }
   if (dayWithinYear >= 243 + inLeapYear && dayWithinYear < 273 + inLeapYear) {
-    return F(8);
+    return 𝔽(8);
   }
   if (dayWithinYear >= 273 + inLeapYear && dayWithinYear < 304 + inLeapYear) {
-    return F(9);
+    return 𝔽(9);
   }
   if (dayWithinYear >= 304 + inLeapYear && dayWithinYear < 334 + inLeapYear) {
-    return F(10);
+    return 𝔽(10);
   }
   if (dayWithinYear >= 334 + inLeapYear && dayWithinYear < 365 + inLeapYear) {
-    return F(11);
+    return 𝔽(11);
   }
 }
 
 export function DayWithinYear(t) {
-  return F(Day(t).numberValue() - DayFromYear(YearFromTime(t)).numberValue());
+  return 𝔽(ℝ(Day(t)) - ℝ(DayFromYear(YearFromTime(t))));
 }
 
 /** https://tc39.es/ecma262/#sec-date-number */
 export function DateFromTime(t) {
-  const dayWithinYear = DayWithinYear(t).numberValue();
-  const monthFromTime = MonthFromTime(t).numberValue();
-  const inLeapYear = InLeapYear(t).numberValue();
+  const dayWithinYear = ℝ(DayWithinYear(t));
+  const monthFromTime = ℝ(MonthFromTime(t));
+  const inLeapYear = ℝ(InLeapYear(t));
   switch (monthFromTime) {
-    case 0: return F(dayWithinYear + 1);
-    case 1: return F(dayWithinYear - 30);
-    case 2: return F(dayWithinYear - 58 - inLeapYear);
-    case 3: return F(dayWithinYear - 89 - inLeapYear);
-    case 4: return F(dayWithinYear - 119 - inLeapYear);
-    case 5: return F(dayWithinYear - 150 - inLeapYear);
-    case 6: return F(dayWithinYear - 180 - inLeapYear);
-    case 7: return F(dayWithinYear - 211 - inLeapYear);
-    case 8: return F(dayWithinYear - 242 - inLeapYear);
-    case 9: return F(dayWithinYear - 272 - inLeapYear);
-    case 10: return F(dayWithinYear - 303 - inLeapYear);
-    case 11: return F(dayWithinYear - 333 - inLeapYear);
+    case 0: return 𝔽(dayWithinYear + 1);
+    case 1: return 𝔽(dayWithinYear - 30);
+    case 2: return 𝔽(dayWithinYear - 58 - inLeapYear);
+    case 3: return 𝔽(dayWithinYear - 89 - inLeapYear);
+    case 4: return 𝔽(dayWithinYear - 119 - inLeapYear);
+    case 5: return 𝔽(dayWithinYear - 150 - inLeapYear);
+    case 6: return 𝔽(dayWithinYear - 180 - inLeapYear);
+    case 7: return 𝔽(dayWithinYear - 211 - inLeapYear);
+    case 8: return 𝔽(dayWithinYear - 242 - inLeapYear);
+    case 9: return 𝔽(dayWithinYear - 272 - inLeapYear);
+    case 10: return 𝔽(dayWithinYear - 303 - inLeapYear);
+    case 11: return 𝔽(dayWithinYear - 333 - inLeapYear);
     default: // Unreachable
   }
 }
 
 /** https://tc39.es/ecma262/#sec-week-day */
 export function WeekDay(t) {
-  return F(mod(Day(t).numberValue() + 4, 7));
+  return 𝔽(mod(ℝ(Day(t)) + 4, 7));
 }
 
 /** https://tc39.es/ecma262/#sec-local-time-zone-adjustment */
@@ -157,79 +157,79 @@ export function LocalTZA(_t, _isUTC) {
 
 /** https://tc39.es/ecma262/#sec-localtime */
 export function LocalTime(t) {
-  return F(t.numberValue() + LocalTZA(t, true));
+  return 𝔽(ℝ(t) + LocalTZA(t, true));
 }
 
 /** https://tc39.es/ecma262/#sec-utc-t */
 export function UTC(t) {
-  return F(t.numberValue() - LocalTZA(t, false));
+  return 𝔽(ℝ(t) - LocalTZA(t, false));
 }
 
 /** https://tc39.es/ecma262/#sec-hours-minutes-second-and-milliseconds */
 export function HourFromTime(t) {
-  return F(mod(Math.floor(t.numberValue() / msPerHour), HoursPerDay));
+  return 𝔽(mod(Math.floor(ℝ(t) / msPerHour), HoursPerDay));
 }
 
 export function MinFromTime(t) {
-  return F(mod(Math.floor(t.numberValue() / msPerMinute), MinutesPerHour));
+  return 𝔽(mod(Math.floor(ℝ(t) / msPerMinute), MinutesPerHour));
 }
 
 export function SecFromTime(t) {
-  return F(mod(Math.floor(t.numberValue() / msPerSecond), SecondsPerMinute));
+  return 𝔽(mod(Math.floor(ℝ(t) / msPerSecond), SecondsPerMinute));
 }
 
 export function msFromTime(t) {
-  return F(mod(t.numberValue(), msPerSecond));
+  return 𝔽(mod(ℝ(t), msPerSecond));
 }
 
 /** https://tc39.es/ecma262/#sec-maketime */
 export function MakeTime(hour, min, sec, ms) {
-  if (!Number.isFinite(hour.numberValue()) || !Number.isFinite(min.numberValue()) || !Number.isFinite(sec.numberValue()) || !Number.isFinite(ms.numberValue())) {
-    return F(NaN);
+  if (!Number.isFinite(ℝ(hour)) || !Number.isFinite(ℝ(min)) || !Number.isFinite(ℝ(sec)) || !Number.isFinite(ℝ(ms))) {
+    return 𝔽(NaN);
   }
   const h = X(ToIntegerOrInfinity(hour));
   const m = X(ToIntegerOrInfinity(min));
   const s = X(ToIntegerOrInfinity(sec));
   const milli = X(ToIntegerOrInfinity(ms));
   const t = h * msPerHour + m * msPerMinute + s * msPerSecond + milli;
-  return F(t);
+  return 𝔽(t);
 }
 
 const daysWithinYearToEndOfMonth = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365];
 
 /** https://tc39.es/ecma262/#sec-makeday */
 export function MakeDay(year, month, date) {
-  if (!Number.isFinite(year.numberValue()) || !Number.isFinite(month.numberValue()) || !Number.isFinite(date.numberValue())) {
-    return F(NaN);
+  if (!Number.isFinite(ℝ(year)) || !Number.isFinite(ℝ(month)) || !Number.isFinite(ℝ(date))) {
+    return 𝔽(NaN);
   }
   const y = X(ToIntegerOrInfinity(year));
   const m = X(ToIntegerOrInfinity(month));
   const dt = X(ToIntegerOrInfinity(date));
   const ym = y + Math.floor(m / 12);
   const mn = mod(m, 12);
-  const ymday = DayFromYear(F(ym + (mn > 1 ? 1 : 0))).numberValue() - 365 * (mn > 1 ? 1 : 0) + daysWithinYearToEndOfMonth[mn];
-  const t = F(ymday * msPerDay);
-  return F(Day(t).numberValue() + dt - 1);
+  const ymday = ℝ(DayFromYear(𝔽(ym + (mn > 1 ? 1 : 0)))) - 365 * (mn > 1 ? 1 : 0) + daysWithinYearToEndOfMonth[mn];
+  const t = 𝔽(ymday * msPerDay);
+  return 𝔽(ℝ(Day(t)) + dt - 1);
 }
 
 /** https://tc39.es/ecma262/#sec-makedate */
 export function MakeDate(day, time) {
-  if (!Number.isFinite(day.numberValue()) || !Number.isFinite(time.numberValue())) {
-    return F(NaN);
+  if (!Number.isFinite(ℝ(day)) || !Number.isFinite(ℝ(time))) {
+    return 𝔽(NaN);
   }
-  return F(day.numberValue() * msPerDay + time.numberValue());
+  return 𝔽(ℝ(day) * msPerDay + ℝ(time));
 }
 
 /** https://tc39.es/ecma262/#sec-timeclip */
 export function TimeClip(time) {
   // 1. If time is not finite, return NaN.
   if (!time.isFinite()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   // 2. If abs(ℝ(time)) > 8.64 × 1015, return NaN.
-  if (Math.abs(time.numberValue()) > 8.64e15) {
-    return F(NaN);
+  if (Math.abs(ℝ(time)) > 8.64e15) {
+    return 𝔽(NaN);
   }
   // 3. Return 𝔽(! ToIntegerOrInfinity(time)).
-  return F(X(ToIntegerOrInfinity(time)));
+  return 𝔽(X(ToIntegerOrInfinity(time)));
 }

--- a/src/abstract-ops/function-operations.mts
+++ b/src/abstract-ops/function-operations.mts
@@ -46,7 +46,7 @@ import {
   isNonNegativeInteger,
   isStrictModeCode,
   Realm,
-  F as toNumberValue,
+  𝔽,
 } from './all.mjs';
 
 // This file covers abstract operations defined in
@@ -447,7 +447,7 @@ export function SetFunctionLength(F, length) {
   Assert(IsExtensible(F) === Value.true && HasOwnProperty(F, Value('length')) === Value.false);
   // 2. Return ! DefinePropertyOrThrow(F, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
   return X(DefinePropertyOrThrow(F, Value('length'), Descriptor({
-    Value: toNumberValue(length),
+    Value: 𝔽(length),
     Writable: Value.false,
     Enumerable: Value.false,
     Configurable: Value.true,

--- a/src/abstract-ops/integer-indexed-objects.mts
+++ b/src/abstract-ops/integer-indexed-objects.mts
@@ -24,7 +24,7 @@ import {
   ToBigInt,
   isIntegerIndex,
   typedArrayInfoByName,
-  F,
+  𝔽, ℝ,
 } from './all.mjs';
 
 export function isIntegerIndexedExoticObject(O) {
@@ -223,7 +223,7 @@ export function IntegerIndexedOwnPropertyKeys() {
   // 4. For each integer i starting with 0 such that i < len, in ascending order, do
   for (let i = 0; i < len; i += 1) {
     // a. Add ! ToString(𝔽(i)) as the last element of keys.
-    keys.push(X(ToString(F(i))));
+    keys.push(X(ToString(𝔽(i))));
   }
   // 5. For each own property key P of O such that Type(P) is String and P is not an integer index, in ascending chronological order of property creation, do
   for (const P of O.properties.keys()) {
@@ -268,7 +268,7 @@ export function IntegerIndexedElementGet(O, index) {
   // 8. Let elementSize be the Element Size value specified in Table 61 for arrayTypeName.
   const elementSize = typedArrayInfoByName[arrayTypeName].ElementSize;
   // 9. Let indexedPosition be (ℝ(index) × elementSize) + offset.
-  const indexedPosition = (index.numberValue() * elementSize) + offset;
+  const indexedPosition = (ℝ(index) * elementSize) + offset;
   // 10. Let elementType be the Element Type value in Table 61 for arrayTypeName.
   const elementType = typedArrayInfoByName[arrayTypeName].ElementType;
   // 11. Return GetValueFromBuffer(buffer, indexedPosition, elementType, true, Unordered).
@@ -306,7 +306,7 @@ export function IntegerIndexedElementSet(O, index, value) {
   // 10. Let elementSize be the Element Size value specified in Table 61 for arrayTypeName.
   const elementSize = typedArrayInfoByName[arrayTypeName].ElementSize;
   // 11. Let indexedPosition be (ℝ(index) × elementSize) + offset.
-  const indexedPosition = (index.numberValue() * elementSize) + offset;
+  const indexedPosition = (ℝ(index) * elementSize) + offset;
   // 12. Let elementType be the Element Type value in Table 61 for arrayTypeName.
   const elementType = typedArrayInfoByName[arrayTypeName].ElementType;
   // 13. Perform SetValueInBuffer(buffer, indexedPosition, elementType, numValue, true, Unordered).

--- a/src/abstract-ops/module-namespace-exotic-objects.mts
+++ b/src/abstract-ops/module-namespace-exotic-objects.mts
@@ -23,7 +23,7 @@ import {
   OrdinaryGet,
   OrdinaryDelete,
   OrdinaryOwnPropertyKeys,
-  GetModuleNamespace,
+  GetModuleNamespace, ℝ,
 } from './all.mjs';
 
 
@@ -201,7 +201,7 @@ export function ModuleNamespaceCreate(module, exports) {
   // 9. Let sortedExports be a new List containing the same values as the list exports where the values are ordered as if an Array of the same values had been sorted using Array.prototype.sort using undefined as comparefn.
   const sortedExports = [...exports].sort((x, y) => {
     const result = X(SortCompare(x, y, Value.undefined));
-    return result.numberValue();
+    return ℝ(result);
   });
   // 10. Set M.[[Exports]] to sortedExports.
   M.Exports = new ValueSet(sortedExports);

--- a/src/abstract-ops/object-operations.mts
+++ b/src/abstract-ops/object-operations.mts
@@ -29,7 +29,7 @@ import {
   ToObject,
   ToString,
   isProxyExoticObject,
-  F as toNumberValue,
+  𝔽, ℝ,
 } from './all.mjs';
 
 
@@ -268,7 +268,7 @@ export function CreateArrayFromList(elements) {
   // 4. For each element e of elements, do
   for (const e of elements) {
     // a. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(n)), e).
-    X(CreateDataPropertyOrThrow(array, X(ToString(toNumberValue(n))), e));
+    X(CreateDataPropertyOrThrow(array, X(ToString(𝔽(n))), e));
     // b. Set n to n + 1.
     n += 1;
   }
@@ -281,7 +281,7 @@ export function LengthOfArrayLike(obj) {
   // 1. Assert: Type(obj) is Object.
   Assert(obj instanceof ObjectValue);
   // 2. Return ℝ(? ToLength(? Get(obj, "length"))).
-  return Q(ToLength(Q(Get(obj, Value('length'))))).numberValue();
+  return ℝ(Q(ToLength(Q(Get(obj, Value('length'))))));
 }
 
 /** https://tc39.es/ecma262/#sec-createlistfromarraylike */
@@ -303,7 +303,7 @@ export function CreateListFromArrayLike(obj, elementTypes) {
   // 6. Repeat, while index < len,
   while (index < len) {
     // a. Let indexName be ! ToString(𝔽(index)).
-    const indexName = X(ToString(toNumberValue(index)));
+    const indexName = X(ToString(𝔽(index)));
     // b. Let next be ? Get(obj, indexName).
     const next = Q(Get(obj, indexName));
     // c. If Type(next) is not an element of elementTypes, throw a TypeError exception.

--- a/src/abstract-ops/realms.mts
+++ b/src/abstract-ops/realms.mts
@@ -83,7 +83,7 @@ import { bootstrapFinalizationRegistry } from '../intrinsics/FinalizationRegistr
 import {
   Assert,
   DefinePropertyOrThrow,
-  F as toNumberValue,
+  𝔽,
   OrdinaryObjectCreate,
 } from './all.mjs';
 
@@ -279,8 +279,8 @@ export function SetDefaultGlobalBindings(realmRec) {
 
   // Value Properties of the Global Object
   [
-    ['Infinity', toNumberValue(Infinity)],
-    ['NaN', toNumberValue(NaN)],
+    ['Infinity', 𝔽(Infinity)],
+    ['NaN', 𝔽(NaN)],
     ['undefined', Value.undefined],
   ].forEach(([name, value]) => {
     Q(DefinePropertyOrThrow(global, Value(name), Descriptor({

--- a/src/abstract-ops/regexp-objects.mts
+++ b/src/abstract-ops/regexp-objects.mts
@@ -18,7 +18,7 @@ import {
   SameValue,
   Set,
   ToString,
-  F as toNumberValue,
+  𝔽,
 } from './all.mjs';
 
 /** https://tc39.es/ecma262/#sec-regexpalloc */
@@ -81,7 +81,7 @@ export function RegExpInitialize(obj, pattern, flags) {
   const evaluatePattern = surroundingAgent.hostDefinedOptions.boost?.evaluatePattern || Evaluate_Pattern;
   obj.RegExpMatcher = evaluatePattern(parseResult, F.stringValue());
   // 15. Perform ? Set(obj, "lastIndex", +0𝔽, true).
-  Q(Set(obj, Value('lastIndex'), toNumberValue(+0), Value.true));
+  Q(Set(obj, Value('lastIndex'), 𝔽(+0), Value.true));
   // 16. Return obj.
   return obj;
 }
@@ -207,8 +207,8 @@ export function GetMatchIndexPair(S, match) {
   Assert(match.EndIndex >= match.StartIndex && match.EndIndex <= S.stringValue().length);
   // 1. Return CreateArrayFromList(« 𝔽(match.[[StartIndex]]), 𝔽(match.[[EndIndex]]) »).
   return CreateArrayFromList([
-    toNumberValue(match.StartIndex),
-    toNumberValue(match.EndIndex),
+    𝔽(match.StartIndex),
+    𝔽(match.EndIndex),
   ]);
 }
 
@@ -255,7 +255,7 @@ export function MakeMatchIndicesIndexPairArray(S, indices, groupNames, hasGroups
       matchIndicesArray = Value.undefined;
     }
     // d. Perform ! CreateDataProperty(A, ! ToString(𝔽(i)), matchIndicesArray).
-    X(CreateDataPropertyOrThrow(A, X(ToString(toNumberValue(i))), matchIndicesArray));
+    X(CreateDataPropertyOrThrow(A, X(ToString(𝔽(i))), matchIndicesArray));
     // e. If i > 0 and groupNames[i - 1] is not undefined, then
     if (i > 0 && groupNames[i - 1] !== Value.undefined) {
       // i. Perform ! CreateDataProperty(groups, groupNames[i - 1], matchIndicesArray).

--- a/src/abstract-ops/spec-types.mts
+++ b/src/abstract-ops/spec-types.mts
@@ -28,11 +28,29 @@ export function F(x) {
   return new NumberValue(x);
 }
 
+export { F as 𝔽 };
+
 // #ℤ
 export function Z(x) {
   Assert(typeof x === 'bigint');
   return new BigIntValue(x);
 }
+
+export { Z as ℤ };
+
+// #ℝ
+export function R(x: NumberValue): number;
+export function R(x: BigIntValue): bigint;
+export function R(x: BigIntValue | NumberValue): bigint | number;
+export function R(x) {
+  if (x instanceof BigIntValue) {
+    return x.bigintValue(); // eslint-disable-line @engine262/mathematical-value
+  }
+  Assert(x instanceof NumberValue);
+  return x.numberValue(); // eslint-disable-line @engine262/mathematical-value
+}
+
+export { R as ℝ };
 
 // 6.2.5.1 IsAccessorDescriptor
 export function IsAccessorDescriptor(Desc) {

--- a/src/abstract-ops/string-objects.mts
+++ b/src/abstract-ops/string-objects.mts
@@ -21,7 +21,7 @@ import {
   ToIntegerOrInfinity,
   ToString,
   isArrayIndex,
-  F,
+  𝔽, ℝ,
 } from './all.mjs';
 
 function StringExoticGetOwnProperty(P) {
@@ -55,7 +55,7 @@ function StringExoticOwnPropertyKeys() {
   // 5. For each non-negative integer i starting with 0 such that i < len, in ascending order, do
   for (let i = 0; i < len; i += 1) {
     // a. Add ! ToString(𝔽(i)) as the last element of keys.
-    keys.push(X(ToString(F(i))));
+    keys.push(X(ToString(𝔽(i))));
   }
 
   // For each own property key P of O such that P is an array index and
@@ -111,7 +111,7 @@ export function StringCreate(value, prototype) {
   const length = value.stringValue().length;
   // 9. Perform ! DefinePropertyOrThrow(S, "length", PropertyDescriptor { [[Value]]: length, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }).
   X(DefinePropertyOrThrow(S, Value('length'), Descriptor({
-    Value: F(length),
+    Value: 𝔽(length),
     Writable: Value.false,
     Enumerable: Value.false,
     Configurable: Value.false,
@@ -134,16 +134,16 @@ export function StringGetOwnProperty(S, P) {
   if (IsIntegralNumber(index) === Value.false) {
     return Value.undefined;
   }
-  if (Object.is(index.numberValue(), -0)) {
+  if (Object.is(ℝ(index), -0)) {
     return Value.undefined;
   }
   const str = S.StringData;
   Assert(str instanceof JSStringValue);
   const len = str.stringValue().length;
-  if (index.numberValue() < 0 || len <= index.numberValue()) {
+  if (ℝ(index) < 0 || len <= ℝ(index)) {
     return Value.undefined;
   }
-  const resultStr = str.stringValue()[index.numberValue()];
+  const resultStr = str.stringValue()[ℝ(index)];
   return Descriptor({
     Value: Value(resultStr),
     Writable: Value.false,

--- a/src/abstract-ops/testing-comparison.mts
+++ b/src/abstract-ops/testing-comparison.mts
@@ -23,7 +23,7 @@ import {
   ToPrimitive,
   StringToBigInt,
   isProxyExoticObject,
-  isArrayExoticObject,
+  isArrayExoticObject, ℝ,
 } from './all.mjs';
 
 // This file covers abstract operations defined in
@@ -103,7 +103,7 @@ export function IsIntegralNumber(argument) {
   if (argument.isNaN() || argument.isInfinity()) {
     return Value.false;
   }
-  if (Math.floor(Math.abs(argument.numberValue())) !== Math.abs(argument.numberValue())) {
+  if (Math.floor(Math.abs(ℝ(argument))) !== Math.abs(ℝ(argument))) {
     return Value.false;
   }
   return Value.true;
@@ -291,16 +291,16 @@ export function AbstractRelationalComparison(x, y, LeftFirst = true) {
       return Value.undefined;
     }
     // h. If nx is -∞ or ny is +∞, return true.
-    if ((nx.numberValue && nx.numberValue() === -Infinity) || (ny.numberValue && ny.numberValue() === +Infinity)) {
+    if ((nx.numberValue && ℝ(nx) === -Infinity) || (ny.numberValue && ℝ(ny) === +Infinity)) {
       return Value.true;
     }
     // i. If nx is +∞ or ny is -∞, return false.
-    if ((nx.numberValue && nx.numberValue() === +Infinity) || (ny.numberValue && ny.numberValue() === -Infinity)) {
+    if ((nx.numberValue && ℝ(nx) === +Infinity) || (ny.numberValue && ℝ(ny) === -Infinity)) {
       return Value.false;
     }
     // j. If the mathematical value of nx is less than the mathematical value of ny, return true; otherwise return false.
-    const a = nx.numberValue ? nx.numberValue() : nx.bigintValue();
-    const b = ny.numberValue ? ny.numberValue() : ny.bigintValue();
+    const a = nx.numberValue ? ℝ(nx) : ℝ(nx);
+    const b = ny.numberValue ? ℝ(ny) : ℝ(ny);
     return a < b ? Value.true : Value.false;
   }
 }
@@ -366,8 +366,8 @@ export function AbstractEqualityComparison(x, y) {
       return Value.false;
     }
     // b. If the mathematical value of x is equal to the mathematical value of y, return true; otherwise return false.
-    const a = (x.numberValue ? x.numberValue() : x.bigintValue());
-    const b = (y.numberValue ? y.numberValue() : y.bigintValue());
+    const a = (x.numberValue ? ℝ(x) : ℝ(x));
+    const b = (y.numberValue ? ℝ(y) : ℝ(y));
     return a == b ? Value.true : Value.false; // eslint-disable-line eqeqeq
   }
   // 13. Return false.
@@ -398,7 +398,7 @@ export function IsValidIntegerIndex(O, index) {
   if (IsIntegralNumber(index) === Value.false) {
     return Value.false;
   }
-  index = index.numberValue();
+  index = ℝ(index);
   if (Object.is(index, -0)) {
     return Value.false;
   }

--- a/src/abstract-ops/type-conversion.mts
+++ b/src/abstract-ops/type-conversion.mts
@@ -24,8 +24,8 @@ import {
   OrdinaryObjectCreate,
   SameValue,
   StringCreate,
-  Z,
-  F,
+  ℤ,
+  𝔽, ℝ,
 } from './all.mjs';
 
 /** https://tc39.es/ecma262/#sec-toprimitive */
@@ -116,7 +116,7 @@ export function ToBoolean(argument) {
     return argument;
   } else if (argument instanceof NumberValue) {
     // If argument is +0𝔽, -0𝔽, or NaN, return false; otherwise return true.
-    if (argument.numberValue() === 0 || argument.isNaN()) {
+    if (ℝ(argument) === 0 || argument.isNaN()) {
       return Value.false;
     }
     return Value.true;
@@ -131,7 +131,7 @@ export function ToBoolean(argument) {
     return Value.true;
   } else if (argument instanceof BigIntValue) {
     // If argument is 0ℤ, return false; otherwise return true.
-    if (argument.bigintValue() === 0n) {
+    if (ℝ(argument) === 0n) {
       return Value.false;
     }
     return Value.true;
@@ -158,17 +158,17 @@ export function ToNumeric(value) {
 export function ToNumber(argument) {
   if (argument instanceof UndefinedValue) {
     // Return NaN.
-    return F(NaN);
+    return 𝔽(NaN);
   } else if (argument instanceof NullValue) {
     // Return +0𝔽.
-    return F(+0);
+    return 𝔽(+0);
   } else if (argument instanceof BooleanValue) {
     // If argument is true, return 1𝔽.
     if (argument === Value.true) {
-      return F(1);
+      return 𝔽(1);
     }
     // If argument is false, return +0𝔽.
-    return F(+0);
+    return 𝔽(+0);
   } else if (argument instanceof NumberValue) {
     // Return argument (no conversion).
     return argument;
@@ -199,18 +199,18 @@ export function ToIntegerOrInfinity(argument) {
   // 1. Let number be ? ToNumber(argument).
   const number = Q(ToNumber(argument));
   // 2. If number is NaN, +0𝔽, or -0𝔽, return 0.
-  if (number.isNaN() || number.numberValue() === 0) {
+  if (number.isNaN() || ℝ(number) === 0) {
     return +0;
   }
   // 3. If number is +∞𝔽, return +∞.
   // 4. If number is -∞𝔽, return -∞.
   if (!number.isFinite()) {
-    return number.numberValue();
+    return ℝ(number);
   }
   // 4. Let integer be floor(abs(ℝ(number))).
-  let integer = Math.floor(Math.abs(number.numberValue()));
+  let integer = Math.floor(Math.abs(ℝ(number)));
   // 5. If number < +0𝔽, set integer to -integer.
-  if (number.numberValue() < 0 && integer !== 0) {
+  if (ℝ(number) < 0 && integer !== 0) {
     integer = -integer;
   }
   // 6. Return integer.
@@ -220,140 +220,140 @@ export function ToIntegerOrInfinity(argument) {
 /** https://tc39.es/ecma262/#sec-toint32 */
 export function ToInt32(argument) {
   // 1. Let number be ? ToNumber(argument).
-  const number = Q(ToNumber(argument)).numberValue();
+  const number = Q(ToNumber(argument));
   // 2. If number is NaN, +0𝔽, -0𝔽, +∞𝔽, or -∞𝔽, return +0𝔽.
-  if (Number.isNaN(number) || number === 0 || !Number.isFinite(number)) {
-    return F(+0);
+  if (number.isNaN() || ℝ(number) === 0 || !number.isFinite()) {
+    return 𝔽(+0);
   }
   // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(ℝ(number))).
-  const int = Math.sign(number) * Math.floor(Math.abs(number));
+  const int = Math.sign(ℝ(number)) * Math.floor(Math.abs(ℝ(number)));
   // 4. Let int32bit be int modulo 2^32.
   const int32bit = mod(int, 2 ** 32);
   // 5. If int32bit ≥ 2^31, return 𝔽(int32bit - 2^32); otherwise return 𝔽(int32bit).
   if (int32bit >= (2 ** 31)) {
-    return F(int32bit - (2 ** 32));
+    return 𝔽(int32bit - (2 ** 32));
   }
-  return F(int32bit);
+  return 𝔽(int32bit);
 }
 
 /** https://tc39.es/ecma262/#sec-touint32 */
 export function ToUint32(argument) {
   // 1. Let number be ? ToNumber(argument).
-  const number = Q(ToNumber(argument)).numberValue();
+  const number = Q(ToNumber(argument));
   // 2. If number is NaN, +0𝔽, -0𝔽, +∞𝔽, or -∞𝔽, return +0𝔽.
-  if (Number.isNaN(number) || number === 0 || !Number.isFinite(number)) {
-    return F(+0);
+  if (number.isNaN() || ℝ(number) === 0 || !number.isFinite()) {
+    return 𝔽(+0);
   }
   // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(ℝ(number))).
-  const int = Math.sign(number) * Math.floor(Math.abs(number));
+  const int = Math.sign(ℝ(number)) * Math.floor(Math.abs(ℝ(number)));
   // 4. Let int32bit be int modulo 2^32.
   const int32bit = mod(int, 2 ** 32);
   // 5. Return 𝔽(int32bit).
-  return F(int32bit);
+  return 𝔽(int32bit);
 }
 
 /** https://tc39.es/ecma262/#sec-toint16 */
 export function ToInt16(argument) {
   // 1. Let number be ? ToNumber(argument).
-  const number = Q(ToNumber(argument)).numberValue();
+  const number = Q(ToNumber(argument));
   // 2. If number is NaN, +0𝔽, -0𝔽, +∞𝔽, or -∞𝔽, return +0𝔽.
-  if (Number.isNaN(number) || number === 0 || !Number.isFinite(number)) {
-    return F(+0);
+  if (number.isNaN() || ℝ(number) === 0 || !number.isFinite()) {
+    return 𝔽(+0);
   }
   // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(ℝ(number))).
-  const int = Math.sign(number) * Math.floor(Math.abs(number));
+  const int = Math.sign(ℝ(number)) * Math.floor(Math.abs(ℝ(number)));
   // 4. Let int16bit be int modulo 2^16.
   const int16bit = mod(int, 2 ** 16);
   // 5. If int16bit ≥ 2^31, return 𝔽(int16bit - 2^32); otherwise return 𝔽(int16bit).
   if (int16bit >= (2 ** 15)) {
-    return F(int16bit - (2 ** 16));
+    return 𝔽(int16bit - (2 ** 16));
   }
-  return F(int16bit);
+  return 𝔽(int16bit);
 }
 
 /** https://tc39.es/ecma262/#sec-touint16 */
 export function ToUint16(argument) {
   // 1. Let number be ? ToNumber(argument).
-  const number = Q(ToNumber(argument)).numberValue();
+  const number = Q(ToNumber(argument));
   // 2. If number is NaN, +0𝔽, -0𝔽, +∞𝔽, or -∞𝔽, return +0𝔽.
-  if (Number.isNaN(number) || number === 0 || !Number.isFinite(number)) {
-    return F(+0);
+  if (number.isNaN() || ℝ(number) === 0 || !number.isFinite()) {
+    return 𝔽(+0);
   }
   // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(ℝ(number))).
-  const int = Math.sign(number) * Math.floor(Math.abs(number));
+  const int = Math.sign(ℝ(number)) * Math.floor(Math.abs(ℝ(number)));
   // 4. Let int16bit be int modulo 2^16.
   const int16bit = mod(int, 2 ** 16);
   // 5. Return 𝔽(int16bit).
-  return F(int16bit);
+  return 𝔽(int16bit);
 }
 
 /** https://tc39.es/ecma262/#sec-toint8 */
 export function ToInt8(argument) {
   // 1. Let number be ? ToNumber(argument).
-  const number = Q(ToNumber(argument)).numberValue();
+  const number = Q(ToNumber(argument));
   // 2. If number is NaN, +0𝔽, -0𝔽, +∞𝔽, or -∞𝔽, return +0𝔽.
-  if (Number.isNaN(number) || number === 0 || !Number.isFinite(number)) {
-    return F(+0);
+  if (number.isNaN() || ℝ(number) === 0 || !number.isFinite()) {
+    return 𝔽(+0);
   }
   // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(ℝ(number))).
-  const int = Math.sign(number) * Math.floor(Math.abs(number));
+  const int = Math.sign(ℝ(number)) * Math.floor(Math.abs(ℝ(number)));
   // 4. Let int8bit be int modulo 2^8.
   const int8bit = mod(int, 2 ** 8);
   // 5. If int8bit ≥ 2^7, return 𝔽(int8bit - 2^8); otherwise return 𝔽(int8bit).
   if (int8bit >= (2 ** 7)) {
-    return F(int8bit - (2 ** 8));
+    return 𝔽(int8bit - (2 ** 8));
   }
-  return F(int8bit);
+  return 𝔽(int8bit);
 }
 
 /** https://tc39.es/ecma262/#sec-touint8 */
 export function ToUint8(argument) {
   // 1. Let number be ? ToNumber(argument).
-  const number = Q(ToNumber(argument)).numberValue();
+  const number = Q(ToNumber(argument));
   // 2. If number is NaN, +0𝔽, -0𝔽, +∞𝔽, or -∞𝔽, return +0𝔽.
-  if (Number.isNaN(number) || number === 0 || !Number.isFinite(number)) {
-    return F(+0);
+  if (number.isNaN() || ℝ(number) === 0 || !number.isFinite()) {
+    return 𝔽(+0);
   }
   // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(ℝ(number))).
-  const int = Math.sign(number) * Math.floor(Math.abs(number));
+  const int = Math.sign(ℝ(number)) * Math.floor(Math.abs(ℝ(number)));
   // 4. Let int8bit be int modulo 2^8.
   const int8bit = mod(int, 2 ** 8);
   // 5. Return 𝔽(int8bit).
-  return F(int8bit);
+  return 𝔽(int8bit);
 }
 
 /** https://tc39.es/ecma262/#sec-touint8clamp */
 export function ToUint8Clamp(argument) {
   // 1. Let number be ? ToNumber(argument).
-  const number = Q(ToNumber(argument)).numberValue();
+  const number = Q(ToNumber(argument));
   // 2. If number is NaN, return +0𝔽.
-  if (Number.isNaN(number)) {
-    return F(+0);
+  if (number.isNaN()) {
+    return 𝔽(+0);
   }
   // 3. If ℝ(number) ≤ 0, return +0𝔽.
-  if (number <= 0) {
-    return F(+0);
+  if (ℝ(number) <= 0) {
+    return 𝔽(+0);
   }
   // 4. If ℝ(number) ≥ 255, return 255𝔽.
-  if (number >= 255) {
-    return F(255);
+  if (ℝ(number) >= 255) {
+    return 𝔽(255);
   }
   // 5. Let f be floor(ℝ(number)).
-  const f = Math.floor(number);
+  const f = Math.floor(ℝ(number));
   // 6. If f + 0.5 < ℝ(number), return 𝔽(f + 1).
-  if (f + 0.5 < number) {
-    return F(f + 1);
+  if (f + 0.5 < ℝ(number)) {
+    return 𝔽(f + 1);
   }
   // 7. If ℝ(number) < f + 0.5, return 𝔽(f).
-  if (number < f + 0.5) {
-    return F(f);
+  if (ℝ(number) < f + 0.5) {
+    return 𝔽(f);
   }
   // 8. If f is odd, return 𝔽(f + 1).
   if (f % 2 === 1) {
-    return F(f + 1);
+    return 𝔽(f + 1);
   }
   // 9. Return 𝔽(f).
-  return F(f);
+  return 𝔽(f);
 }
 
 /** https://tc39.es/ecma262/#sec-tobigint */
@@ -370,9 +370,9 @@ export function ToBigInt(argument) {
   } else if (prim instanceof BooleanValue) {
     // Return 1ℤ if prim is true and 0ℤ if prim is false.
     if (prim === Value.true) {
-      return Z(1n);
+      return ℤ(1n);
     }
-    return Z(0n);
+    return ℤ(0n);
   } else if (prim instanceof BigIntValue) {
     // Return prim.
     return prim;
@@ -402,7 +402,7 @@ export function StringToBigInt(argument) {
   // 2. If the MV is NaN, return NaN, otherwise return the BigInt which exactly corresponds to the MV, rather than rounding to a Number.
   // TODO: Adapt nearley grammar for this.
   try {
-    return Z(BigInt(argument.stringValue()));
+    return ℤ(BigInt(argument.stringValue()));
   } catch {
     return NaN;
   }
@@ -413,12 +413,12 @@ export function ToBigInt64(argument) {
   // 1. Let n be ? ToBigInt(argument).
   const n = Q(ToBigInt(argument));
   // 2. Let int64bit be ℝ(n) modulo 2^64.
-  const int64bit = n.bigintValue() % (2n ** 64n);
+  const int64bit = ℝ(n) % (2n ** 64n);
   // 3. If int64bit ≥ 2^63, return ℤ(int64bit - 2^64); otherwise return ℤ(int64bit).
   if (int64bit >= 2n ** 63n) {
-    return Z(int64bit - (2n ** 64n));
+    return ℤ(int64bit - (2n ** 64n));
   }
-  return Z(int64bit);
+  return ℤ(int64bit);
 }
 
 /** https://tc39.es/ecma262/#sec-tobiguint64 */
@@ -426,9 +426,9 @@ export function ToBigUint64(argument) {
   // 1. Let n be ? ToBigInt(argument).
   const n = Q(ToBigInt(argument));
   // 2. Let int64bit be ℝ(n) modulo 2^64.
-  const int64bit = n.bigintValue() % (2n ** 64n);
+  const int64bit = ℝ(n) % (2n ** 64n);
   // 3. Return ℤ(int64bit).
-  return Z(int64bit);
+  return ℤ(int64bit);
 }
 
 /** https://tc39.es/ecma262/#sec-tostring */
@@ -521,10 +521,10 @@ export function ToLength(argument) {
   const len = Q(ToIntegerOrInfinity(argument));
   // 2. If len ≤ 0, return +0𝔽.
   if (len <= 0) {
-    return F(+0);
+    return 𝔽(+0);
   }
   // 3. Return 𝔽(min(len, 253 - 1)).
-  return F(Math.min(len, (2 ** 53) - 1));
+  return 𝔽(Math.min(len, (2 ** 53) - 1));
 }
 
 /** https://tc39.es/ecma262/#sec-canonicalnumericindexstring */
@@ -533,7 +533,7 @@ export function CanonicalNumericIndexString(argument) {
   Assert(argument instanceof JSStringValue);
   // 2. If argument is "-0", return -0𝔽.
   if (argument.stringValue() === '-0') {
-    return F(-0);
+    return 𝔽(-0);
   }
   // 3. Let n be ! ToNumber(argument).
   const n = X(ToNumber(argument));
@@ -553,9 +553,9 @@ export function ToIndex(value) {
     return 0;
   } else {
     // a. Let integerIndex be 𝔽(? ToIntegerOrInfinity(value)).
-    const integerIndex = F(Q(ToIntegerOrInfinity(value)));
+    const integerIndex = 𝔽(Q(ToIntegerOrInfinity(value)));
     // b. If integerIndex < +0𝔽, throw a RangeError exception.
-    if (integerIndex.numberValue() < 0) {
+    if (ℝ(integerIndex) < 0) {
       return surroundingAgent.Throw('RangeError', 'NegativeIndex', 'Index');
     }
     // c. Let index be ! ToLength(integerIndex).
@@ -565,6 +565,6 @@ export function ToIndex(value) {
       return surroundingAgent.Throw('RangeError', 'OutOfRange', 'Index');
     }
     // e. Return ℝ(index).
-    return index.numberValue();
+    return ℝ(index);
   }
 }

--- a/src/abstract-ops/typedarray-objects.mts
+++ b/src/abstract-ops/typedarray-objects.mts
@@ -23,7 +23,7 @@ import {
   isNonNegativeInteger,
   IntegerIndexedObjectCreate,
   GetPrototypeFromConstructor,
-  AllocateArrayBuffer,
+  AllocateArrayBuffer, ℝ,
 } from './all.mjs';
 
 export const typedArrayInfoByName = {
@@ -125,7 +125,7 @@ export function TypedArrayCreate(constructor, argumentList) {
   // 3. If argumentList is a List of a single Number, then
   if (argumentList.length === 1 && argumentList[0] instanceof NumberValue) {
     // a. If newTypedArray.[[ArrayLength]] < argumentList[0], throw a TypeError exception.
-    if (newTypedArray.ArrayLength < argumentList[0].numberValue()) {
+    if (newTypedArray.ArrayLength < ℝ(argumentList[0])) {
       return surroundingAgent.Throw('TypeError', 'TypedArrayTooSmall');
     }
   }

--- a/src/helpers.mts
+++ b/src/helpers.mts
@@ -4,7 +4,7 @@ import {
   Value, Descriptor, JSStringValue, NumberValue, ObjectValue, UndefinedValue, NullValue,
 } from './value.mjs';
 import {
-  ToString, DefinePropertyOrThrow, CreateBuiltinFunction,
+  ToString, DefinePropertyOrThrow, CreateBuiltinFunction, ℝ,
 } from './abstract-ops/all.mjs';
 import { Completion, X } from './completion.mjs';
 
@@ -14,7 +14,7 @@ function convertValueForKey<T>(key: JSStringValue | NumberValue | T): string | n
   if (key instanceof JSStringValue) {
     return key.stringValue();
   } else if (key instanceof NumberValue) {
-    return key.numberValue();
+    return ℝ(key);
   }
   return key;
 }

--- a/src/inspect.mts
+++ b/src/inspect.mts
@@ -5,7 +5,7 @@ import {
 } from './value.mjs';
 import {
   Call, IsArray, Get, LengthOfArrayLike,
-  EscapeRegExpPattern,
+  EscapeRegExpPattern, ℝ,
 } from './abstract-ops/all.mjs';
 import { Q, X } from './completion.mjs';
 
@@ -58,13 +58,13 @@ const INSPECTORS = {
   Undefined: () => 'undefined',
   Boolean: (v) => v.boolean.toString(),
   Number: (v) => {
-    const n = v.numberValue();
+    const n = ℝ(v);
     if (n === 0 && Object.is(n, -0)) {
       return '-0';
     }
     return n.toString();
   },
-  BigInt: (v) => `${v.bigintValue()}n`,
+  BigInt: (v) => `${ℝ(v)}n`,
   String: (v) => {
     const s = JSON.stringify(v.stringValue()).slice(1, -1);
     return `'${s}'`;
@@ -109,7 +109,7 @@ const INSPECTORS = {
     }
 
     if ('DateValue' in v) {
-      const d = new Date(v.DateValue.numberValue());
+      const d = new Date(ℝ(v.DateValue));
       if (Number.isNaN(d.getTime())) {
         return '[Date Invalid]';
       }

--- a/src/intrinsics/Array.mts
+++ b/src/intrinsics/Array.mts
@@ -29,7 +29,7 @@ import {
   ToObject,
   ToString,
   ToUint32,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import {
   NumberValue,
@@ -64,10 +64,10 @@ function ArrayConstructor(argumentsList, { NewTarget }) {
     if (!(len instanceof NumberValue)) {
       const defineStatus = X(CreateDataProperty(array, Value('0'), len));
       Assert(defineStatus === Value.true);
-      intLen = F(1);
+      intLen = 𝔽(1);
     } else {
       intLen = X(ToUint32(len));
-      if (intLen.numberValue() !== len.numberValue()) {
+      if (ℝ(intLen) !== ℝ(len)) {
         return surroundingAgent.Throw('RangeError', 'InvalidArrayLength', len);
       }
     }
@@ -84,13 +84,13 @@ function ArrayConstructor(argumentsList, { NewTarget }) {
     const array = ArrayCreate(0, proto);
     let k = 0;
     while (k < numberOfArgs) {
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const itemK = items[k];
       const defineStatus = X(CreateDataProperty(array, Pk, itemK));
       Assert(defineStatus === Value.true);
       k += 1;
     }
-    Assert(X(Get(array, Value('length'))).numberValue() === numberOfArgs);
+    Assert(ℝ(X(Get(array, Value('length')))) === numberOfArgs);
     return array;
   }
 
@@ -124,16 +124,16 @@ function Array_from([items = Value.undefined, mapfn = Value.undefined, thisArg =
         const error = ThrowCompletion(surroundingAgent.Throw('TypeError', 'ArrayPastSafeLength').Value);
         return Q(IteratorClose(iteratorRecord, error));
       }
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const next = Q(IteratorStep(iteratorRecord));
       if (next === Value.false) {
-        Q(Set(A, Value('length'), F(k), Value.true));
+        Q(Set(A, Value('length'), 𝔽(k), Value.true));
         return A;
       }
       const nextValue = Q(IteratorValue(next));
       let mappedValue;
       if (mapping) {
-        mappedValue = Call(mapfn, thisArg, [nextValue, F(k)]);
+        mappedValue = Call(mapfn, thisArg, [nextValue, 𝔽(k)]);
         IfAbruptCloseIterator(mappedValue, iteratorRecord);
       } else {
         mappedValue = nextValue;
@@ -146,24 +146,24 @@ function Array_from([items = Value.undefined, mapfn = Value.undefined, thisArg =
   const arrayLike = X(ToObject(items));
   const len = Q(LengthOfArrayLike(arrayLike));
   if (IsConstructor(C) === Value.true) {
-    A = Q(Construct(C, [F(len)]));
+    A = Q(Construct(C, [𝔽(len)]));
   } else {
     A = Q(ArrayCreate(len));
   }
   let k = 0;
   while (k < len) {
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     const kValue = Q(Get(arrayLike, Pk));
     let mappedValue;
     if (mapping === true) {
-      mappedValue = Q(Call(mapfn, thisArg, [kValue, F(k)]));
+      mappedValue = Q(Call(mapfn, thisArg, [kValue, 𝔽(k)]));
     } else {
       mappedValue = kValue;
     }
     Q(CreateDataPropertyOrThrow(A, Pk, mappedValue));
     k += 1;
   }
-  Q(Set(A, Value('length'), F(len), Value.true));
+  Q(Set(A, Value('length'), 𝔽(len), Value.true));
   return A;
 }
 
@@ -179,18 +179,18 @@ function Array_of(items, { thisValue }) {
   const C = thisValue;
   let A;
   if (IsConstructor(C) === Value.true) {
-    A = Q(Construct(C, [F(len)]));
+    A = Q(Construct(C, [𝔽(len)]));
   } else {
     A = Q(ArrayCreate(len));
   }
   let k = 0;
   while (k < len) {
     const kValue = items[k];
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     Q(CreateDataPropertyOrThrow(A, Pk, kValue));
     k += 1;
   }
-  Q(Set(A, Value('length'), F(len), Value.true));
+  Q(Set(A, Value('length'), 𝔽(len), Value.true));
   return A;
 }
 

--- a/src/intrinsics/ArrayBufferPrototype.mts
+++ b/src/intrinsics/ArrayBufferPrototype.mts
@@ -5,7 +5,7 @@ import { Q } from '../completion.mjs';
 import {
   RequireInternalSlot, IsDetachedBuffer, IsSharedArrayBuffer,
   SpeciesConstructor, Construct, ToIntegerOrInfinity, SameValue, CopyDataBlockBytes,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
@@ -21,12 +21,12 @@ function ArrayBufferProto_byteLength(args, { thisValue }) {
   }
   // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
   if (IsDetachedBuffer(O) === Value.true) {
-    return F(+0);
+    return 𝔽(+0);
   }
   // 5. Let length be O.[[ArrayBufferByteLength]].
   const length = O.ArrayBufferByteLength;
   // 6. Return length.
-  return F(length);
+  return 𝔽(length);
 }
 
 /** https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice */
@@ -73,7 +73,7 @@ function ArrayBufferProto_slice([start = Value.undefined, end = Value.undefined]
   // 11. Let ctor be ? SpeciesConstructor(O, %ArrayBuffer%).
   const ctor = Q(SpeciesConstructor(O, surroundingAgent.intrinsic('%ArrayBuffer%')));
   // 12. Let new be ? Construct(ctor, « newLen »).
-  const newO = Q(Construct(ctor, [F(newLen)]));
+  const newO = Q(Construct(ctor, [𝔽(newLen)]));
   // 13. Perform ? RequireInternalSlot(new, [[ArrayBufferData]]).
   Q(RequireInternalSlot(newO, 'ArrayBufferData'));
   // 14. If IsSharedArrayBuffer(new) is true, throw a TypeError exception.

--- a/src/intrinsics/ArrayPrototype.mts
+++ b/src/intrinsics/ArrayPrototype.mts
@@ -29,7 +29,7 @@ import {
   ToIntegerOrInfinity,
   ToObject,
   ToString,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { assignProps } from './bootstrap.mjs';
@@ -51,11 +51,11 @@ function ArrayProto_concat(args, { thisValue }) {
         return surroundingAgent.Throw('TypeError', 'ArrayPastSafeLength');
       }
       while (k < len) {
-        const P = X(ToString(F(k)));
+        const P = X(ToString(𝔽(k)));
         const exists = Q(HasProperty(E, P));
         if (exists === Value.true) {
           const subElement = Q(Get(E, P));
-          const nStr = X(ToString(F(n)));
+          const nStr = X(ToString(𝔽(n)));
           Q(CreateDataPropertyOrThrow(A, nStr, subElement));
         }
         n += 1;
@@ -65,12 +65,12 @@ function ArrayProto_concat(args, { thisValue }) {
       if (n >= (2 ** 53) - 1) {
         return surroundingAgent.Throw('TypeError', 'ArrayPastSafeLength');
       }
-      const nStr = X(ToString(F(n)));
+      const nStr = X(ToString(𝔽(n)));
       Q(CreateDataPropertyOrThrow(A, nStr, E));
       n += 1;
     }
   }
-  Q(Set(A, Value('length'), F(n), Value.true));
+  Q(Set(A, Value('length'), 𝔽(n), Value.true));
   return A;
 }
 
@@ -114,8 +114,8 @@ function ArrayProto_copyWithin([target = Value.undefined, start = Value.undefine
     direction = 1;
   }
   while (count > 0) {
-    const fromKey = X(ToString(F(from)));
-    const toKey = X(ToString(F(to)));
+    const fromKey = X(ToString(𝔽(from)));
+    const toKey = X(ToString(𝔽(to)));
     const fromPresent = Q(HasProperty(O, fromKey));
     if (fromPresent === Value.true) {
       const fromVal = Q(Get(O, fromKey));
@@ -160,7 +160,7 @@ function ArrayProto_fill([value = Value.undefined, start = Value.undefined, end 
     final = Math.min(relativeEnd, len);
   }
   while (k < final) {
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     Q(Set(O, Pk, value, Value.true));
     k += 1;
   }
@@ -178,13 +178,13 @@ function ArrayProto_filter([callbackfn = Value.undefined, thisArg = Value.undefi
   let k = 0;
   let to = 0;
   while (k < len) {
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     const kPresent = Q(HasProperty(O, Pk));
     if (kPresent === Value.true) {
       const kValue = Q(Get(O, Pk));
-      const selected = ToBoolean(Q(Call(callbackfn, thisArg, [kValue, F(k), O])));
+      const selected = ToBoolean(Q(Call(callbackfn, thisArg, [kValue, 𝔽(k), O])));
       if (selected === Value.true) {
-        Q(CreateDataPropertyOrThrow(A, X(ToString(F(to))), kValue));
+        Q(CreateDataPropertyOrThrow(A, X(ToString(𝔽(to))), kValue));
         to += 1;
       }
     }
@@ -204,13 +204,13 @@ function FlattenIntoArray(target, source, sourceLen, start, depth, mapperFunctio
   let targetIndex = start;
   let sourceIndex = 0;
   while (sourceIndex < sourceLen) {
-    const P = X(ToString(F(sourceIndex)));
+    const P = X(ToString(𝔽(sourceIndex)));
     const exists = Q(HasProperty(source, P));
     if (exists === Value.true) {
       let element = Q(Get(source, P));
       if (mapperFunction) {
         Assert(thisArg);
-        element = Q(Call(mapperFunction, thisArg, [element, F(sourceIndex), source]));
+        element = Q(Call(mapperFunction, thisArg, [element, 𝔽(sourceIndex), source]));
       }
       let shouldFlatten = Value.false;
       if (depth > 0) {
@@ -223,7 +223,7 @@ function FlattenIntoArray(target, source, sourceLen, start, depth, mapperFunctio
         if (targetIndex >= (2 ** 53) - 1) {
           return surroundingAgent.Throw('TypeError', 'OutOfRange', targetIndex);
         }
-        Q(CreateDataPropertyOrThrow(target, X(ToString(F(targetIndex))), element));
+        Q(CreateDataPropertyOrThrow(target, X(ToString(𝔽(targetIndex))), element));
         targetIndex += 1;
       }
     }
@@ -273,11 +273,11 @@ function ArrayProto_map([callbackfn = Value.undefined, thisArg = Value.undefined
   const A = Q(ArraySpeciesCreate(O, len));
   let k = 0;
   while (k < len) {
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     const kPresent = Q(HasProperty(O, Pk));
     if (kPresent === Value.true) {
       const kValue = Q(Get(O, Pk));
-      const mappedValue = Q(Call(callbackfn, thisArg, [kValue, F(k), O]));
+      const mappedValue = Q(Call(callbackfn, thisArg, [kValue, 𝔽(k), O]));
       Q(CreateDataPropertyOrThrow(A, Pk, mappedValue));
     }
     k += 1;
@@ -290,14 +290,14 @@ function ArrayProto_pop(args, { thisValue }) {
   const O = Q(ToObject(thisValue));
   const len = Q(LengthOfArrayLike(O));
   if (len === 0) {
-    Q(Set(O, Value('length'), F(+0), Value.true));
+    Q(Set(O, Value('length'), 𝔽(+0), Value.true));
     return Value.undefined;
   } else {
     const newLen = len - 1;
-    const index = Q(ToString(F(newLen)));
+    const index = Q(ToString(𝔽(newLen)));
     const element = Q(Get(O, index));
     Q(DeletePropertyOrThrow(O, index));
-    Q(Set(O, Value('length'), F(newLen), Value.true));
+    Q(Set(O, Value('length'), 𝔽(newLen), Value.true));
     return element;
   }
 }
@@ -312,11 +312,11 @@ function ArrayProto_push(items, { thisValue }) {
   }
   while (items.length > 0) {
     const E = items.shift();
-    Q(Set(O, X(ToString(F(len))), E, Value.true));
+    Q(Set(O, X(ToString(𝔽(len))), E, Value.true));
     len += 1;
   }
-  Q(Set(O, Value('length'), F(len), Value.true));
-  return F(len);
+  Q(Set(O, Value('length'), 𝔽(len), Value.true));
+  return 𝔽(len);
 }
 
 /** https://tc39.es/ecma262/#sec-array.prototype.shift */
@@ -324,14 +324,14 @@ function ArrayProto_shift(args, { thisValue }) {
   const O = Q(ToObject(thisValue));
   const len = Q(LengthOfArrayLike(O));
   if (len === 0) {
-    Q(Set(O, Value('length'), F(+0), Value.true));
+    Q(Set(O, Value('length'), 𝔽(+0), Value.true));
     return Value.undefined;
   }
   const first = Q(Get(O, Value('0')));
   let k = 1;
   while (k < len) {
-    const from = X(ToString(F(k)));
-    const to = X(ToString(F(k - 1)));
+    const from = X(ToString(𝔽(k)));
+    const to = X(ToString(𝔽(k - 1)));
     const fromPresent = Q(HasProperty(O, from));
     if (fromPresent === Value.true) {
       const fromVal = Q(Get(O, from));
@@ -341,8 +341,8 @@ function ArrayProto_shift(args, { thisValue }) {
     }
     k += 1;
   }
-  Q(DeletePropertyOrThrow(O, X(ToString(F(len - 1)))));
-  Q(Set(O, Value('length'), F(len - 1), Value.true));
+  Q(DeletePropertyOrThrow(O, X(ToString(𝔽(len - 1)))));
+  Q(Set(O, Value('length'), 𝔽(len - 1), Value.true));
   return first;
 }
 
@@ -373,17 +373,17 @@ function ArrayProto_slice([start = Value.undefined, end = Value.undefined], { th
   const A = Q(ArraySpeciesCreate(O, count));
   let n = 0;
   while (k < final) {
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     const kPresent = Q(HasProperty(O, Pk));
     if (kPresent === Value.true) {
       const kValue = Q(Get(O, Pk));
-      const nStr = X(ToString(F(n)));
+      const nStr = X(ToString(𝔽(n)));
       Q(CreateDataPropertyOrThrow(A, nStr, kValue));
     }
     k += 1;
     n += 1;
   }
-  Q(Set(A, Value('length'), F(n), Value.true));
+  Q(Set(A, Value('length'), 𝔽(n), Value.true));
   return A;
 }
 
@@ -429,21 +429,21 @@ function ArrayProto_splice(args, { thisValue }) {
   const A = Q(ArraySpeciesCreate(O, actualDeleteCount));
   let k = 0;
   while (k < actualDeleteCount) {
-    const from = X(ToString(F(actualStart + k)));
+    const from = X(ToString(𝔽(actualStart + k)));
     const fromPresent = Q(HasProperty(O, from));
     if (fromPresent === Value.true) {
       const fromValue = Q(Get(O, from));
-      Q(CreateDataPropertyOrThrow(A, X(ToString(F(k))), fromValue));
+      Q(CreateDataPropertyOrThrow(A, X(ToString(𝔽(k))), fromValue));
     }
     k += 1;
   }
-  Q(Set(A, Value('length'), F(actualDeleteCount), Value.true));
+  Q(Set(A, Value('length'), 𝔽(actualDeleteCount), Value.true));
   const itemCount = items.length;
   if (itemCount < actualDeleteCount) {
     k = actualStart;
     while (k < len - actualDeleteCount) {
-      const from = X(ToString(F(k + actualDeleteCount)));
-      const to = X(ToString(F(k + itemCount)));
+      const from = X(ToString(𝔽(k + actualDeleteCount)));
+      const to = X(ToString(𝔽(k + itemCount)));
       const fromPresent = Q(HasProperty(O, from));
       if (fromPresent === Value.true) {
         const fromValue = Q(Get(O, from));
@@ -455,14 +455,14 @@ function ArrayProto_splice(args, { thisValue }) {
     }
     k = len;
     while (k > len - actualDeleteCount + itemCount) {
-      Q(DeletePropertyOrThrow(O, X(ToString(F(k - 1)))));
+      Q(DeletePropertyOrThrow(O, X(ToString(𝔽(k - 1)))));
       k -= 1;
     }
   } else if (itemCount > actualDeleteCount) {
     k = len - actualDeleteCount;
     while (k > actualStart) {
-      const from = X(ToString(F(k + actualDeleteCount - 1)));
-      const to = X(ToString(F(k + itemCount - 1)));
+      const from = X(ToString(𝔽(k + actualDeleteCount - 1)));
+      const to = X(ToString(𝔽(k + itemCount - 1)));
       const fromPresent = Q(HasProperty(O, from));
       if (fromPresent === Value.true) {
         const fromValue = Q(Get(O, from));
@@ -476,10 +476,10 @@ function ArrayProto_splice(args, { thisValue }) {
   k = actualStart;
   while (items.length > 0) {
     const E = items.shift();
-    Q(Set(O, X(ToString(F(k))), E, Value.true));
+    Q(Set(O, X(ToString(𝔽(k))), E, Value.true));
     k += 1;
   }
-  Q(Set(O, Value('length'), F(len - actualDeleteCount + itemCount), Value.true));
+  Q(Set(O, Value('length'), 𝔽(len - actualDeleteCount + itemCount), Value.true));
   return A;
 }
 
@@ -504,8 +504,8 @@ function ArrayProto_unshift(args, { thisValue }) {
     }
     let k = len;
     while (k > 0) {
-      const from = X(ToString(F(k - 1)));
-      const to = X(ToString(F(k + argCount - 1)));
+      const from = X(ToString(𝔽(k - 1)));
+      const to = X(ToString(𝔽(k + argCount - 1)));
       const fromPresent = Q(HasProperty(O, from));
       if (fromPresent === Value.true) {
         const fromValue = Q(Get(O, from));
@@ -519,13 +519,13 @@ function ArrayProto_unshift(args, { thisValue }) {
     const items = args;
     while (items.length !== 0) {
       const E = items.shift();
-      const jStr = X(ToString(F(j)));
+      const jStr = X(ToString(𝔽(j)));
       Q(Set(O, jStr, E, Value.true));
       j += 1;
     }
   }
-  Q(Set(O, Value('length'), F(len + argCount), Value.true));
-  return F(len + argCount);
+  Q(Set(O, Value('length'), 𝔽(len + argCount), Value.true));
+  return 𝔽(len + argCount);
 }
 
 /** https://tc39.es/ecma262/#sec-array.prototype.values */
@@ -556,7 +556,7 @@ function ArrayProto_at([index = Value.undefined], { thisValue }) {
     return Value.undefined;
   }
   // 7. Return ? Get(O, ! ToString(k)).
-  return Q(Get(O, X(ToString(F(k)))));
+  return Q(Get(O, X(ToString(𝔽(k)))));
 }
 
 export function bootstrapArrayPrototype(realmRec) {

--- a/src/intrinsics/ArrayPrototypeShared.mts
+++ b/src/intrinsics/ArrayPrototypeShared.mts
@@ -14,7 +14,7 @@ import {
   ToIntegerOrInfinity,
   ToObject,
   ToString,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { surroundingAgent } from '../engine.mjs';
@@ -34,7 +34,7 @@ export function ArrayProto_sortBody(obj, len, SortCompare, internalMethodsRestri
   const items = [];
   let k = 0;
   while (k < len) {
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     if (internalMethodsRestricted) {
       items.push(Q(Get(obj, Pk)));
     } else {
@@ -73,7 +73,7 @@ export function ArrayProto_sortBody(obj, len, SortCompare, internalMethodsRestri
         let r = 0;
         let o = start;
         while (l < sizeLeft && r < sizeRight) {
-          const cmp = Q(SortCompare(lBuffer[l], rBuffer[r])).numberValue();
+          const cmp = ℝ(Q(SortCompare(lBuffer[l], rBuffer[r])));
           if (cmp <= 0) {
             items[o] = lBuffer[l];
             o += 1;
@@ -100,11 +100,11 @@ export function ArrayProto_sortBody(obj, len, SortCompare, internalMethodsRestri
 
   let j = 0;
   while (j < itemCount) {
-    Q(Set(obj, X(ToString(F(j))), items[j], Value.true));
+    Q(Set(obj, X(ToString(𝔽(j))), items[j], Value.true));
     j += 1;
   }
   while (j < len) {
-    Q(DeletePropertyOrThrow(obj, X(ToString(F(j)))));
+    Q(DeletePropertyOrThrow(obj, X(ToString(𝔽(j)))));
     j += 1;
   }
 
@@ -123,11 +123,11 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     }
     let k = 0;
     while (k < len) {
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const kPresent = Q(HasProperty(O, Pk));
       if (kPresent === Value.true) {
         const kValue = Q(Get(O, Pk));
-        const testResult = ToBoolean(Q(Call(callbackFn, thisArg, [kValue, F(k), O])));
+        const testResult = ToBoolean(Q(Call(callbackFn, thisArg, [kValue, 𝔽(k), O])));
         if (testResult === Value.false) {
           return Value.false;
         }
@@ -148,9 +148,9 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     }
     let k = 0;
     while (k < len) {
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const kValue = Q(Get(O, Pk));
-      const testResult = ToBoolean(Q(Call(predicate, thisArg, [kValue, F(k), O])));
+      const testResult = ToBoolean(Q(Call(predicate, thisArg, [kValue, 𝔽(k), O])));
       if (testResult === Value.true) {
         return kValue;
       }
@@ -170,15 +170,15 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     }
     let k = 0;
     while (k < len) {
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const kValue = Q(Get(O, Pk));
-      const testResult = ToBoolean(Q(Call(predicate, thisArg, [kValue, F(k), O])));
+      const testResult = ToBoolean(Q(Call(predicate, thisArg, [kValue, 𝔽(k), O])));
       if (testResult === Value.true) {
-        return F(k);
+        return 𝔽(k);
       }
       k += 1;
     }
-    return F(-1);
+    return 𝔽(-1);
   }
 
   /** https://tc39.es/ecma262/#sec-array.prototype.findlast */
@@ -198,11 +198,11 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     // 5. Repeat, while k ≥ 0,
     while (k >= 0) {
       // a. Let Pk be ! ToString(𝔽(k)).
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       // b. Let kValue be ? Get(O, Pk).
       const kValue = Q(Get(O, Pk));
       // c. Let testResult be ToBoolean(? Call(predicate, thisArg, « kValue, 𝔽(k), O »)).
-      const testResult = ToBoolean(Q(Call(predicate, thisArg, [kValue, F(k), O])));
+      const testResult = ToBoolean(Q(Call(predicate, thisArg, [kValue, 𝔽(k), O])));
       // d. If testResult is true, return kValue.
       if (testResult === Value.true) {
         return kValue;
@@ -231,20 +231,20 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     // 5. Repeat, while k ≥ 0,
     while (k >= 0) {
       // a. Let Pk be ! ToString(𝔽(k)).
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       // b. Let kValue be ? Get(O, Pk).
       const kValue = Q(Get(O, Pk));
       // c. Let testResult be ToBoolean(? Call(predicate, thisArg, « kValue, 𝔽(k), O »)).
-      const testResult = ToBoolean(Q(Call(predicate, thisArg, [kValue, F(k), O])));
+      const testResult = ToBoolean(Q(Call(predicate, thisArg, [kValue, 𝔽(k), O])));
       // d. If testResult is true, return 𝔽(k).
       if (testResult === Value.true) {
-        return F(k);
+        return 𝔽(k);
       }
       // e. Set k to k - 1.
       k -= 1;
     }
     // 6. Return Return -1𝔽.
-    return F(-1);
+    return 𝔽(-1);
   }
 
   /** https://tc39.es/ecma262/#sec-array.prototype.foreach */
@@ -258,11 +258,11 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     }
     let k = 0;
     while (k < len) {
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const kPresent = Q(HasProperty(O, Pk));
       if (kPresent === Value.true) {
         const kValue = Q(Get(O, Pk));
-        Q(Call(callbackfn, thisArg, [kValue, F(k), O]));
+        Q(Call(callbackfn, thisArg, [kValue, 𝔽(k), O]));
       }
       k += 1;
     }
@@ -292,7 +292,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
       }
     }
     while (k < len) {
-      const kStr = X(ToString(F(k)));
+      const kStr = X(ToString(𝔽(k)));
       const elementK = Q(Get(O, kStr));
       if (SameValueZero(searchElement, elementK) === Value.true) {
         return Value.true;
@@ -309,14 +309,14 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
     if (len === 0) {
-      return F(-1);
+      return 𝔽(-1);
     }
     const n = Q(ToIntegerOrInfinity(fromIndex));
     if (fromIndex === Value.undefined) {
       Assert(n === 0);
     }
     if (n >= len) {
-      return F(-1);
+      return 𝔽(-1);
     }
     let k;
     if (n >= 0) {
@@ -328,18 +328,18 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
       }
     }
     while (k < len) {
-      const kStr = X(ToString(F(k)));
+      const kStr = X(ToString(𝔽(k)));
       const kPresent = Q(HasProperty(O, kStr));
       if (kPresent === Value.true) {
         const elementK = Q(Get(O, kStr));
         const same = StrictEqualityComparison(searchElement, elementK);
         if (same === Value.true) {
-          return F(k);
+          return 𝔽(k);
         }
       }
       k += 1;
     }
-    return F(-1);
+    return 𝔽(-1);
   }
 
   /** https://tc39.es/ecma262/#sec-array.prototype.join */
@@ -360,7 +360,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
       if (k > 0) {
         R = `${R}${sep}`;
       }
-      const kStr = X(ToString(F(k)));
+      const kStr = X(ToString(𝔽(k)));
       const element = Q(Get(O, kStr));
       let next;
       if (element instanceof UndefinedValue || element instanceof NullValue) {
@@ -381,7 +381,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     const O = Q(ToObject(thisValue));
     const len = Q(objectToLength(O));
     if (len === 0) {
-      return F(-1);
+      return 𝔽(-1);
     }
     let n;
     if (fromIndex !== undefined) {
@@ -396,18 +396,18 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
       k = len + n;
     }
     while (k >= 0) {
-      const kStr = X(ToString(F(k)));
+      const kStr = X(ToString(𝔽(k)));
       const kPresent = Q(HasProperty(O, kStr));
       if (kPresent === Value.true) {
         const elementK = Q(Get(O, kStr));
         const same = StrictEqualityComparison(searchElement, elementK);
         if (same === Value.true) {
-          return F(k);
+          return 𝔽(k);
         }
       }
       k -= 1;
     }
-    return F(-1);
+    return 𝔽(-1);
   }
 
   /** https://tc39.es/ecma262/#sec-array.prototype.reduce */
@@ -429,7 +429,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     } else {
       let kPresent = false;
       while (kPresent === false && k < len) {
-        const Pk = X(ToString(F(k)));
+        const Pk = X(ToString(𝔽(k)));
         kPresent = Q(HasProperty(O, Pk)) === Value.true;
         if (kPresent === true) {
           accumulator = Q(Get(O, Pk));
@@ -441,11 +441,11 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
       }
     }
     while (k < len) {
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const kPresent = Q(HasProperty(O, Pk));
       if (kPresent === Value.true) {
         const kValue = Q(Get(O, Pk));
-        accumulator = Q(Call(callbackfn, Value.undefined, [accumulator, kValue, F(k), O]));
+        accumulator = Q(Call(callbackfn, Value.undefined, [accumulator, kValue, 𝔽(k), O]));
       }
       k += 1;
     }
@@ -471,7 +471,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     } else {
       let kPresent = false;
       while (kPresent === false && k >= 0) {
-        const Pk = X(ToString(F(k)));
+        const Pk = X(ToString(𝔽(k)));
         kPresent = Q(HasProperty(O, Pk)) === Value.true;
         if (kPresent === true) {
           accumulator = Q(Get(O, Pk));
@@ -483,11 +483,11 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
       }
     }
     while (k >= 0) {
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const kPresent = Q(HasProperty(O, Pk));
       if (kPresent === Value.true) {
         const kValue = Q(Get(O, Pk));
-        accumulator = Q(Call(callbackfn, Value.undefined, [accumulator, kValue, F(k), O]));
+        accumulator = Q(Call(callbackfn, Value.undefined, [accumulator, kValue, 𝔽(k), O]));
       }
       k -= 1;
     }
@@ -504,8 +504,8 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     let lower = 0;
     while (lower !== middle) {
       const upper = len - lower - 1;
-      const upperP = X(ToString(F(upper)));
-      const lowerP = X(ToString(F(lower)));
+      const upperP = X(ToString(𝔽(upper)));
+      const lowerP = X(ToString(𝔽(lower)));
       const lowerExists = Q(HasProperty(O, lowerP));
       let lowerValue;
       let upperValue;
@@ -544,11 +544,11 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
     }
     let k = 0;
     while (k < len) {
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const kPresent = Q(HasProperty(O, Pk));
       if (kPresent === Value.true) {
         const kValue = Q(Get(O, Pk));
-        const testResult = ToBoolean(Q(Call(callbackfn, thisArg, [kValue, F(k), O])));
+        const testResult = ToBoolean(Q(Call(callbackfn, thisArg, [kValue, 𝔽(k), O])));
         if (testResult === Value.true) {
           return Value.true;
         }
@@ -571,7 +571,7 @@ export function bootstrapArrayPrototypeShared(realmRec, proto, priorToEvaluating
       if (k > 0) {
         R = `${R}${separator}`;
       }
-      const kStr = X(ToString(F(k)));
+      const kStr = X(ToString(𝔽(k)));
       const nextElement = Q(Get(array, kStr));
       if (nextElement !== Value.undefined && nextElement !== Value.null) {
         const S = Q(ToString(Q(Invoke(nextElement, Value('toLocaleString'))))).stringValue();

--- a/src/intrinsics/BigInt.mts
+++ b/src/intrinsics/BigInt.mts
@@ -5,7 +5,7 @@ import {
   ToBigInt,
   ToIndex,
   ToPrimitive,
-  Z,
+  ℤ, ℝ,
 } from '../abstract-ops/all.mjs';
 import { NumberToBigInt } from '../runtime-semantics/all.mjs';
 import { Q } from '../completion.mjs';
@@ -36,7 +36,7 @@ function BigInt_asIntN([bits = Value.undefined, bigint = Value.undefined]) {
   bigint = Q(ToBigInt(bigint));
   // 3. Let mod be the BigInt value that represents bigint modulo 2bits.
   // 4. If mod ≥ 2^bits - 1, return mod - 2^bits; otherwise, return mod.
-  return Z(BigInt.asIntN(bits, bigint.bigintValue()));
+  return ℤ(BigInt.asIntN(bits, ℝ(bigint)));
 }
 
 /** https://tc39.es/ecma262/#sec-bigint.asuintn */
@@ -47,7 +47,7 @@ function BigInt_asUintN([bits = Value.undefined, bigint = Value.undefined]) {
   bigint = Q(ToBigInt(bigint));
   // 3. Let mod be ℝ(bigint) modulo 2 ** bits.
   // 4. If mod ≥ 2 ** (bits - 1), return Z(mod - 2 ** bits); otherwise, return Z(mod).
-  return Z(BigInt.asUintN(bits, bigint.bigintValue()));
+  return ℤ(BigInt.asUintN(bits, ℝ(bigint)));
 }
 
 export function bootstrapBigInt(realmRec) {

--- a/src/intrinsics/BigIntPrototype.mts
+++ b/src/intrinsics/BigIntPrototype.mts
@@ -3,7 +3,9 @@ import { surroundingAgent } from '../engine.mjs';
 import {
   ObjectValue, BigIntValue, Value,
 } from '../value.mjs';
-import { Assert, ToIntegerOrInfinity, ToString } from '../abstract-ops/all.mjs';
+import {
+  Assert, ToIntegerOrInfinity, ToString, ℝ,
+} from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
@@ -57,7 +59,7 @@ function BigIntProto_toString([radix], { thisValue }) {
   //    algorithm is implementation-dependent, however the algorithm should be a
   //    generalization of that specified in 6.1.6.2.23.
   // TODO: Implementation stringification
-  return Value(x.bigintValue().toString(radixNumber));
+  return Value(ℝ(x).toString(radixNumber));
 }
 
 /** https://tc39.es/ecma262/#sec-bigint.prototype.tostring */

--- a/src/intrinsics/DataViewPrototype.mts
+++ b/src/intrinsics/DataViewPrototype.mts
@@ -5,7 +5,7 @@ import {
   SetViewValue,
   IsDetachedBuffer,
   RequireInternalSlot,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import { Q } from '../completion.mjs';
 import { surroundingAgent } from '../engine.mjs';
@@ -43,7 +43,7 @@ function DataViewProto_byteLength(args, { thisValue }) {
   // 6. Let size be O.[[ByteLength]].
   const size = O.ByteLength;
   // 7. Return 𝔽(size).
-  return F(size);
+  return 𝔽(size);
 }
 
 /** https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset */
@@ -63,7 +63,7 @@ function DataViewProto_byteOffset(args, { thisValue }) {
   // 6. Let offset be O.[[ByteOffset]].
   const offset = O.ByteOffset;
   // 7. Return 𝔽(offset).
-  return F(offset);
+  return 𝔽(offset);
 }
 
 /** https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64 */

--- a/src/intrinsics/Date.mts
+++ b/src/intrinsics/Date.mts
@@ -11,7 +11,7 @@ import {
   MakeTime,
   UTC,
   TimeClip,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import { Value, JSStringValue, ObjectValue } from '../value.mjs';
 import {
@@ -30,7 +30,7 @@ function DateConstructor(args, { NewTarget }) {
     Assert(numberOfArgs >= 2);
     if (NewTarget === Value.undefined) {
       const now = Date.now();
-      return ToDateString(F(now));
+      return ToDateString(𝔽(now));
     } else {
       const y = Q(ToNumber(year));
       const m = Q(ToNumber(month));
@@ -38,39 +38,39 @@ function DateConstructor(args, { NewTarget }) {
       if (date !== undefined) {
         dt = Q(ToNumber(date));
       } else {
-        dt = F(1);
+        dt = 𝔽(1);
       }
       let h;
       if (hours !== undefined) {
         h = Q(ToNumber(hours));
       } else {
-        h = F(+0);
+        h = 𝔽(+0);
       }
       let min;
       if (minutes !== undefined) {
         min = Q(ToNumber(minutes));
       } else {
-        min = F(+0);
+        min = 𝔽(+0);
       }
       let s;
       if (seconds !== undefined) {
         s = Q(ToNumber(seconds));
       } else {
-        s = F(+0);
+        s = 𝔽(+0);
       }
       let milli;
       if (ms !== undefined) {
         milli = Q(ToNumber(ms));
       } else {
-        milli = F(+0);
+        milli = 𝔽(+0);
       }
       let yr;
       if (y.isNaN()) {
-        yr = F(NaN);
+        yr = 𝔽(NaN);
       } else {
         const yi = X(ToIntegerOrInfinity(y));
         if (yi >= 0 && yi <= 99) {
-          yr = F(1900 + yi);
+          yr = 𝔽(1900 + yi);
         } else {
           yr = y;
         }
@@ -86,7 +86,7 @@ function DateConstructor(args, { NewTarget }) {
     Assert(numberOfArgs === 1);
     if (NewTarget === Value.undefined) {
       const now = Date.now();
-      return ToDateString(F(now));
+      return ToDateString(𝔽(now));
     } else {
       let tv;
       if (value instanceof ObjectValue && 'DateValue' in value) {
@@ -109,10 +109,10 @@ function DateConstructor(args, { NewTarget }) {
     Assert(numberOfArgs === 0);
     if (NewTarget === Value.undefined) {
       const now = Date.now();
-      return ToDateString(F(now));
+      return ToDateString(𝔽(now));
     } else {
       const O = Q(OrdinaryCreateFromConstructor(NewTarget, '%Date.prototype%', ['DateValue']));
-      O.DateValue = F(Date.now());
+      O.DateValue = 𝔽(Date.now());
       return O;
     }
   }
@@ -121,7 +121,7 @@ function DateConstructor(args, { NewTarget }) {
 /** https://tc39.es/ecma262/#sec-date.now */
 function Date_now() {
   const now = Date.now();
-  return F(now);
+  return 𝔽(now);
 }
 
 /** https://tc39.es/ecma262/#sec-date.parse */
@@ -140,46 +140,46 @@ function Date_UTC([year = Value.undefined, month, date, hours, minutes, seconds,
   if (month !== undefined) {
     m = Q(ToNumber(month));
   } else {
-    m = F(+0);
+    m = 𝔽(+0);
   }
   let dt;
   if (date !== undefined) {
     dt = Q(ToNumber(date));
   } else {
-    dt = F(1);
+    dt = 𝔽(1);
   }
   let h;
   if (hours !== undefined) {
     h = Q(ToNumber(hours));
   } else {
-    h = F(+0);
+    h = 𝔽(+0);
   }
   let min;
   if (minutes !== undefined) {
     min = Q(ToNumber(minutes));
   } else {
-    min = F(+0);
+    min = 𝔽(+0);
   }
   let s;
   if (seconds !== undefined) {
     s = Q(ToNumber(seconds));
   } else {
-    s = F(+0);
+    s = 𝔽(+0);
   }
   let milli;
   if (ms !== undefined) {
     milli = Q(ToNumber(ms));
   } else {
-    milli = F(+0);
+    milli = 𝔽(+0);
   }
 
   let yr;
   if (y.isNaN()) {
-    yr = F(NaN);
+    yr = 𝔽(NaN);
   } else {
     const yi = X(ToIntegerOrInfinity(y));
     if (yi >= 0 && yi <= 99) {
-      yr = F(1900 + yi);
+      yr = 𝔽(1900 + yi);
     } else {
       yr = y;
     }
@@ -192,7 +192,7 @@ function parseDate(dateTimeString) {
   /** https://tc39.es/ecma262/#sec-date-time-string-format */
   // TODO: implement parsing without the host.
   const parsed = Date.parse(dateTimeString.stringValue());
-  return F(parsed);
+  return 𝔽(parsed);
 }
 
 export function bootstrapDate(realmRec) {

--- a/src/intrinsics/DatePrototype.mts
+++ b/src/intrinsics/DatePrototype.mts
@@ -25,7 +25,7 @@ import {
   UTC,
   WeekDay,
   YearFromTime,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import {
   JSStringValue,
@@ -50,7 +50,7 @@ export function thisTimeValue(value) {
 function DateProto_getDate(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return DateFromTime(LocalTime(t));
 }
@@ -59,7 +59,7 @@ function DateProto_getDate(args, { thisValue }) {
 function DateProto_getDay(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return WeekDay(LocalTime(t));
 }
@@ -68,7 +68,7 @@ function DateProto_getDay(args, { thisValue }) {
 function DateProto_getFullYear(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return YearFromTime(LocalTime(t));
 }
@@ -77,7 +77,7 @@ function DateProto_getFullYear(args, { thisValue }) {
 function DateProto_getHours(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return HourFromTime(LocalTime(t));
 }
@@ -86,7 +86,7 @@ function DateProto_getHours(args, { thisValue }) {
 function DateProto_getMilliseconds(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return msFromTime(LocalTime(t));
 }
@@ -95,7 +95,7 @@ function DateProto_getMilliseconds(args, { thisValue }) {
 function DateProto_getMinutes(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return MinFromTime(LocalTime(t));
 }
@@ -104,7 +104,7 @@ function DateProto_getMinutes(args, { thisValue }) {
 function DateProto_getMonth(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return MonthFromTime(LocalTime(t));
 }
@@ -113,7 +113,7 @@ function DateProto_getMonth(args, { thisValue }) {
 function DateProto_getSeconds(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return SecFromTime(LocalTime(t));
 }
@@ -127,16 +127,16 @@ function DateProto_getTime(args, { thisValue }) {
 function DateProto_getTimezoneOffset(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
-  return F((t.numberValue() - LocalTime(t).numberValue()) / msPerMinute);
+  return 𝔽((ℝ(t) - ℝ(LocalTime(t))) / msPerMinute);
 }
 
 /** https://tc39.es/ecma262/#sec-date.prototype.getutcdate */
 function DateProto_getUTCDate(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return DateFromTime(t);
 }
@@ -145,7 +145,7 @@ function DateProto_getUTCDate(args, { thisValue }) {
 function DateProto_getUTCDay(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return WeekDay(t);
 }
@@ -154,7 +154,7 @@ function DateProto_getUTCDay(args, { thisValue }) {
 function DateProto_getUTCFullYear(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return YearFromTime(t);
 }
@@ -163,7 +163,7 @@ function DateProto_getUTCFullYear(args, { thisValue }) {
 function DateProto_getUTCHours(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return HourFromTime(t);
 }
@@ -172,7 +172,7 @@ function DateProto_getUTCHours(args, { thisValue }) {
 function DateProto_getUTCMilliseconds(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return msFromTime(t);
 }
@@ -181,7 +181,7 @@ function DateProto_getUTCMilliseconds(args, { thisValue }) {
 function DateProto_getUTCMinutes(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return MinFromTime(t);
 }
@@ -190,7 +190,7 @@ function DateProto_getUTCMinutes(args, { thisValue }) {
 function DateProto_getUTCMonth(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return MonthFromTime(t);
 }
@@ -199,7 +199,7 @@ function DateProto_getUTCMonth(args, { thisValue }) {
 function DateProto_getUTCSeconds(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   return SecFromTime(t);
 }
@@ -217,7 +217,7 @@ function DateProto_setDate([date = Value.undefined], { thisValue }) {
 /** https://tc39.es/ecma262/#sec-date.prototype.setfullyear */
 function DateProto_setFullYear([year = Value.undefined, month, date], { thisValue }) {
   let t = Q(thisTimeValue(thisValue));
-  t = t.isNaN() ? F(+0) : LocalTime(t);
+  t = t.isNaN() ? 𝔽(+0) : LocalTime(t);
   const y = Q(ToNumber(year));
   let m;
   if (month !== undefined) {
@@ -360,7 +360,7 @@ function DateProto_setUTCDate([date = Value.undefined], { thisValue }) {
 function DateProto_setUTCFullYear([year = Value.undefined, month, date], { thisValue }) {
   let t = Q(thisTimeValue(thisValue));
   if (t.isNaN()) {
-    t = F(+0);
+    t = 𝔽(+0);
   }
   const y = Q(ToNumber(year));
   let m;
@@ -490,16 +490,16 @@ function DateProto_toDateString(args, { thisValue }) {
 /** https://tc39.es/ecma262/#sec-date.prototype.toisostring */
 function DateProto_toISOString(args, { thisValue }) {
   const t = Q(thisTimeValue(thisValue));
-  if (!Number.isFinite(t.numberValue())) {
+  if (!Number.isFinite(ℝ(t))) {
     return surroundingAgent.Throw('RangeError', 'DateInvalidTime');
   }
-  const year = YearFromTime(t).numberValue();
-  const month = MonthFromTime(t).numberValue() + 1;
-  const date = DateFromTime(t).numberValue();
-  const hour = HourFromTime(t).numberValue();
-  const min = MinFromTime(t).numberValue();
-  const sec = SecFromTime(t).numberValue();
-  const ms = msFromTime(t).numberValue();
+  const year = ℝ(YearFromTime(t));
+  const month = ℝ(MonthFromTime(t)) + 1;
+  const date = ℝ(DateFromTime(t));
+  const hour = ℝ(HourFromTime(t));
+  const min = ℝ(MinFromTime(t));
+  const sec = ℝ(SecFromTime(t));
+  const ms = ℝ(msFromTime(t));
 
   // TODO: figure out if there can be invalid years.
   let YYYY = String(year);
@@ -520,7 +520,7 @@ function DateProto_toISOString(args, { thisValue }) {
 function DateProto_toJSON(args, { thisValue }) {
   const O = Q(ToObject(thisValue));
   const tv = Q(ToPrimitive(O, 'number'));
-  if (tv instanceof NumberValue && !Number.isFinite(tv.numberValue())) {
+  if (tv instanceof NumberValue && !Number.isFinite(ℝ(tv))) {
     return Value.null;
   }
   return Q(Invoke(O, Value('toISOString')));
@@ -554,9 +554,9 @@ function DateProto_toString(args, { thisValue }) {
 function TimeString(tv) {
   Assert(tv instanceof NumberValue);
   Assert(!tv.isNaN());
-  const hour = String(HourFromTime(tv).numberValue()).padStart(2, '0');
-  const minute = String(MinFromTime(tv).numberValue()).padStart(2, '0');
-  const second = String(SecFromTime(tv).numberValue()).padStart(2, '0');
+  const hour = String(ℝ(HourFromTime(tv))).padStart(2, '0');
+  const minute = String(ℝ(MinFromTime(tv))).padStart(2, '0');
+  const second = String(ℝ(SecFromTime(tv))).padStart(2, '0');
   return Value(`${hour}:${minute}:${second} GMT`);
 }
 
@@ -569,13 +569,13 @@ const monthsOfTheYear = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
 function DateString(tv) {
   Assert(tv instanceof NumberValue);
   Assert(!tv.isNaN());
-  const weekday = daysOfTheWeek[WeekDay(tv).numberValue()];
-  const month = monthsOfTheYear[MonthFromTime(tv).numberValue()];
-  const day = String(DateFromTime(tv).numberValue()).padStart(2, '0');
-  const yv = YearFromTime(tv).numberValue();
+  const weekday = daysOfTheWeek[ℝ(WeekDay(tv))];
+  const month = monthsOfTheYear[ℝ(MonthFromTime(tv))];
+  const day = String(ℝ(DateFromTime(tv))).padStart(2, '0');
+  const yv = ℝ(YearFromTime(tv));
   const yearSign = yv >= 0 ? '' : '-';
   const year = Value(String(Math.abs(yv)));
-  const paddedYear = X(StringPad(year, F(4), Value('0'), 'start')).stringValue();
+  const paddedYear = X(StringPad(year, 𝔽(4), Value('0'), 'start')).stringValue();
   return Value(`${weekday} ${month} ${day} ${yearSign}${paddedYear}`);
 }
 
@@ -585,8 +585,8 @@ export function TimeZoneString(tv) {
   Assert(!tv.isNaN());
   const offset = LocalTZA(tv, true);
   const offsetSign = offset >= 0 ? '+' : '-';
-  const offsetMin = String(MinFromTime(F(Math.abs(offset))).numberValue()).padStart(2, '0');
-  const offsetHour = String(HourFromTime(F(Math.abs(offset))).numberValue()).padStart(2, '0');
+  const offsetMin = String(ℝ(MinFromTime(𝔽(Math.abs(offset))))).padStart(2, '0');
+  const offsetHour = String(ℝ(HourFromTime(𝔽(Math.abs(offset))))).padStart(2, '0');
   const tzName = '';
   return Value(`${offsetSign}${offsetHour}${offsetMin}${tzName}`);
 }
@@ -625,13 +625,13 @@ function DateProto_toUTCString(args, { thisValue }) {
   if (tv.isNaN()) {
     return Value('Invalid Date');
   }
-  const weekday = daysOfTheWeek[WeekDay(tv).numberValue()];
-  const month = monthsOfTheYear[MonthFromTime(tv).numberValue()];
-  const day = String(DateFromTime(tv).numberValue()).padStart(2, '0');
-  const yv = YearFromTime(tv).numberValue();
+  const weekday = daysOfTheWeek[ℝ(WeekDay(tv))];
+  const month = monthsOfTheYear[ℝ(MonthFromTime(tv))];
+  const day = String(ℝ(DateFromTime(tv))).padStart(2, '0');
+  const yv = ℝ(YearFromTime(tv));
   const yearSign = yv >= 0 ? '' : '-';
   const year = Value(String(Math.abs(yv)));
-  const paddedYear = X(StringPad(year, F(4), Value('0'), 'start')).stringValue();
+  const paddedYear = X(StringPad(year, 𝔽(4), Value('0'), 'start')).stringValue();
   return Value(`${weekday}, ${day} ${month} ${yearSign}${paddedYear} ${TimeString(tv).stringValue()}`);
 }
 

--- a/src/intrinsics/FunctionPrototype.mts
+++ b/src/intrinsics/FunctionPrototype.mts
@@ -19,7 +19,7 @@ import {
   SetFunctionName,
   ToIntegerOrInfinity,
   CreateBuiltinFunction,
-  MakeBasicObject,
+  MakeBasicObject, ℝ,
 } from '../abstract-ops/all.mjs';
 import {
   JSStringValue,
@@ -139,9 +139,9 @@ function FunctionProto_bind([thisArg = Value.undefined, ...args], { thisValue })
     // b. If Type(targetLen) is Number, then
     if (targetLen instanceof NumberValue) {
       // i. If targetLen is +∞𝔽, set L to +∞.
-      if (targetLen.numberValue() === +Infinity) {
+      if (ℝ(targetLen) === +Infinity) {
         L = +Infinity;
-      } else if (targetLen.numberValue() === -Infinity) { // ii. Else if targetLen is -∞𝔽, set L to 0.
+      } else if (ℝ(targetLen) === -Infinity) { // ii. Else if targetLen is -∞𝔽, set L to 0.
         L = 0;
       } else { // iii. Else,
         // 1. Set targetLen to ! ToIntegerOrInfinity(targetLen).

--- a/src/intrinsics/JSON.mts
+++ b/src/intrinsics/JSON.mts
@@ -37,7 +37,7 @@ import {
   Q, X,
 } from '../completion.mjs';
 import { ValueSet, kInternal } from '../helpers.mjs';
-import { BigIntValue, evaluateScript, F } from '../api.mjs';
+import { BigIntValue, evaluateScript, 𝔽 } from '../api.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
 const WHITESPACE = [' ', '\t', '\r', '\n'];
@@ -241,7 +241,7 @@ function InternalizeJSONProperty(holder, name, reviver) {
       let I = 0;
       const len = Q(LengthOfArrayLike(val));
       while (I < len) {
-        const Istr = X(ToString(F(I)));
+        const Istr = X(ToString(𝔽(I)));
         const newElement = Q(InternalizeJSONProperty(val, Istr, reviver));
         if (newElement instanceof UndefinedValue) {
           Q(val.Delete(Istr));
@@ -446,7 +446,7 @@ function SerializeJSONArray(state, value) {
   const len = Q(LengthOfArrayLike(value));
   let index = 0;
   while (index < len) {
-    const indexStr = X(ToString(F(index)));
+    const indexStr = X(ToString(𝔽(index)));
     const strP = Q(SerializeJSONProperty(state, indexStr, value));
     if (strP === Value.undefined) {
       partial.push('null');
@@ -489,7 +489,7 @@ function JSON_stringify([value = Value.undefined, replacer = Value.undefined, sp
         const len = Q(LengthOfArrayLike(replacer));
         let k = 0;
         while (k < len) {
-          const vStr = X(ToString(F(k)));
+          const vStr = X(ToString(𝔽(k)));
           const v = Q(Get(replacer, vStr));
           let item = Value.undefined;
           if (v instanceof JSStringValue) {

--- a/src/intrinsics/MapPrototype.mts
+++ b/src/intrinsics/MapPrototype.mts
@@ -2,10 +2,10 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
   Call,
-  F,
+  𝔽,
   IsCallable,
   RequireInternalSlot,
-  SameValueZero,
+  SameValueZero, ℝ,
 } from '../abstract-ops/all.mjs';
 import {
   NumberValue,
@@ -156,8 +156,8 @@ function MapProto_set([key = Value.undefined, value = Value.undefined], { thisVa
     }
   }
   // 5. If key is -0𝔽, set key to +0𝔽.
-  if (key instanceof NumberValue && Object.is(key.numberValue(), -0)) {
-    key = F(+0);
+  if (key instanceof NumberValue && Object.is(ℝ(key), -0)) {
+    key = 𝔽(+0);
   }
   // 6. Let p be the Record { [[Key]]: key, [[Value]]: value }.
   const p = { Key: key, Value: value };
@@ -185,7 +185,7 @@ function MapProto_sizeGetter(args, { thisValue }) {
     }
   }
   // 6. Return 𝔽(count).
-  return F(count);
+  return 𝔽(count);
 }
 
 /** https://tc39.es/ecma262/#sec-map.prototype.values */

--- a/src/intrinsics/Math.mts
+++ b/src/intrinsics/Math.mts
@@ -8,7 +8,7 @@ import {
 import {
   CreateBuiltinFunction,
   ToNumber,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
@@ -18,14 +18,14 @@ function Math_abs([x = Value.undefined]) {
   const n = Q(ToNumber(x));
   if (n.isNaN()) {
     return n;
-  } else if (Object.is(n.numberValue(), -0)) {
-    return F(+0);
+  } else if (Object.is(ℝ(n), -0)) {
+    return 𝔽(+0);
   } else if (n.isInfinity()) {
-    return F(Infinity);
+    return 𝔽(Infinity);
   }
 
-  if (n.numberValue() < 0) {
-    return F(-n.numberValue());
+  if (ℝ(n) < 0) {
+    return 𝔽(-ℝ(n));
   }
   return n;
 }
@@ -35,15 +35,15 @@ function Math_acos([x = Value.undefined]) {
   const n = Q(ToNumber(x));
   if (n.isNaN()) {
     return n;
-  } else if (n.numberValue() > 1) {
-    return F(NaN);
-  } else if (n.numberValue() < -1) {
-    return F(NaN);
-  } else if (n.numberValue() === 1) {
-    return F(+0);
+  } else if (ℝ(n) > 1) {
+    return 𝔽(NaN);
+  } else if (ℝ(n) < -1) {
+    return 𝔽(NaN);
+  } else if (ℝ(n) === 1) {
+    return 𝔽(+0);
   }
 
-  return F(Math.acos(n.numberValue()));
+  return 𝔽(Math.acos(ℝ(n)));
 }
 
 /** https://tc39.es/ecma262/#sec-math.pow */
@@ -95,7 +95,7 @@ function Math_random() {
   // Convert to double in [0, 1) range
   big64View[0] = (s0 >> 12n) | 0x3FF0000000000000n;
   const result = floatView[0] - 1;
-  return F(result);
+  return 𝔽(result);
 }
 
 /** https://tc39.es/ecma262/#sec-math-object */
@@ -111,7 +111,7 @@ export function bootstrapMath(realmRec) {
     ['PI', 3.141592653589793],
     ['SQRT1_2', 0.7071067811865476],
     ['SQRT2', 1.4142135623730951],
-  ].map(([name, value]) => [name, F(value), undefined, readonly]);
+  ].map(([name, value]) => [name, 𝔽(value), undefined, readonly]);
   // @@toStringTag is handled in the bootstrapPrototype() call.
 
   const mathObj = bootstrapPrototype(realmRec, [
@@ -161,9 +161,9 @@ export function bootstrapMath(realmRec) {
     /** https://tc39.es/ecma262/#sec-function-properties-of-the-math-object */
     const method = (args) => {
       for (let i = 0; i < args.length; i += 1) {
-        args[i] = Q(ToNumber(args[i])).numberValue();
+        args[i] = ℝ(Q(ToNumber(args[i])));
       }
-      return F(Math[name](...args));
+      return 𝔽(Math[name](...args));
     };
     const func = CreateBuiltinFunction(method, length, Value(name), [], realmRec);
     mathObj.DefineOwnProperty(Value(name), Descriptor({

--- a/src/intrinsics/Number.mts
+++ b/src/intrinsics/Number.mts
@@ -3,7 +3,7 @@ import {
   IsIntegralNumber,
   OrdinaryCreateFromConstructor,
   ToNumeric,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import {
   Descriptor,
@@ -20,12 +20,12 @@ function NumberConstructor([value], { NewTarget }) {
   if (value !== undefined) {
     const prim = Q(ToNumeric(value));
     if (prim instanceof BigIntValue) {
-      n = F(Number(prim.bigintValue()));
+      n = 𝔽(Number(ℝ(prim)));
     } else {
       n = prim;
     }
   } else {
-    n = F(+0);
+    n = 𝔽(+0);
   }
   if (NewTarget === Value.undefined) {
     return n;
@@ -71,7 +71,7 @@ function Number_isSafeInteger([number = Value.undefined]) {
   }
 
   if (X(IsIntegralNumber(number)) === Value.true) {
-    if (Math.abs(number.numberValue()) <= (2 ** 53) - 1) {
+    if (Math.abs(ℝ(number)) <= (2 ** 53) - 1) {
       return Value.true;
     }
   }
@@ -86,14 +86,14 @@ export function bootstrapNumber(realmRec) {
     Configurable: Value.false,
   };
   const numberConstructor = bootstrapConstructor(realmRec, NumberConstructor, 'Number', 1, realmRec.Intrinsics['%Number.prototype%'], [
-    ['EPSILON', F(Number.EPSILON), undefined, override],
-    ['MAX_SAFE_INTEGER', F(Number.MAX_SAFE_INTEGER), undefined, override],
-    ['MAX_VALUE', F(Number.MAX_VALUE), undefined, override],
-    ['MIN_SAFE_INTEGER', F(Number.MIN_SAFE_INTEGER), undefined, override],
-    ['MIN_VALUE', F(Number.MIN_VALUE), undefined, override],
-    ['NaN', F(NaN), undefined, override],
-    ['NEGATIVE_INFINITY', F(-Infinity), undefined, override],
-    ['POSITIVE_INFINITY', F(+Infinity), undefined, override],
+    ['EPSILON', 𝔽(Number.EPSILON), undefined, override],
+    ['MAX_SAFE_INTEGER', 𝔽(Number.MAX_SAFE_INTEGER), undefined, override],
+    ['MAX_VALUE', 𝔽(Number.MAX_VALUE), undefined, override],
+    ['MIN_SAFE_INTEGER', 𝔽(Number.MIN_SAFE_INTEGER), undefined, override],
+    ['MIN_VALUE', 𝔽(Number.MIN_VALUE), undefined, override],
+    ['NaN', 𝔽(NaN), undefined, override],
+    ['NEGATIVE_INFINITY', 𝔽(-Infinity), undefined, override],
+    ['POSITIVE_INFINITY', 𝔽(+Infinity), undefined, override],
 
     ['isFinite', Number_isFinite, 1],
     ['isInteger', Number_isInteger, 1],

--- a/src/intrinsics/NumberPrototype.mts
+++ b/src/intrinsics/NumberPrototype.mts
@@ -8,7 +8,7 @@ import {
   Assert,
   ToIntegerOrInfinity,
   ToString,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import { surroundingAgent } from '../engine.mjs';
 import { Q, X } from '../completion.mjs';
@@ -37,7 +37,7 @@ function NumberProto_toExponential([fractionDigits = Value.undefined], { thisVal
   if (f < 0 || f > 100) {
     return surroundingAgent.Throw('RangeError', 'NumberFormatRange', 'toExponential');
   }
-  return Value(x.numberValue().toExponential(fractionDigits === Value.undefined ? undefined : f));
+  return Value(ℝ(x).toExponential(fractionDigits === Value.undefined ? undefined : f));
 }
 
 /** https://tc39.es/ecma262/#sec-number.prototype.tofixed */
@@ -51,7 +51,7 @@ function NumberProto_toFixed([fractionDigits = Value.undefined], { thisValue }) 
   if (!x.isFinite()) {
     return X(NumberValue.toString(x));
   }
-  return Value(x.numberValue().toFixed(f));
+  return Value(ℝ(x).toFixed(f));
 }
 
 /** https://tc39.es/ecma262/#sec-number.prototype.tolocalestring */
@@ -72,7 +72,7 @@ function NumberProto_toPrecision([precision = Value.undefined], { thisValue }) {
   if (p < 1 || p > 100) {
     return surroundingAgent.Throw('RangeError', 'NumberFormatRange', 'toPrecision');
   }
-  return Value(x.numberValue().toPrecision(p));
+  return Value(ℝ(x).toPrecision(p));
 }
 
 /** https://tc39.es/ecma262/#sec-number.prototype.tostring */
@@ -95,7 +95,7 @@ function NumberProto_toString([radix = Value.undefined], { thisValue }) {
   // used for digits with values 10 through 35. The precise algorithm
   // is implementation-dependent, however the algorithm should be a
   // generalization of that specified in 7.1.12.1.
-  return Value(x.numberValue().toString(radixNumber));
+  return Value(ℝ(x).toString(radixNumber));
 }
 
 /** https://tc39.es/ecma262/#sec-number.prototype.valueof */
@@ -113,7 +113,7 @@ export function bootstrapNumberPrototype(realmRec) {
     ['valueOf', NumberProto_valueOf, 0],
   ], realmRec.Intrinsics['%Object.prototype%']);
 
-  proto.NumberData = F(+0);
+  proto.NumberData = 𝔽(+0);
 
   realmRec.Intrinsics['%Number.prototype%'] = proto;
 }

--- a/src/intrinsics/RegExpPrototype.mts
+++ b/src/intrinsics/RegExpPrototype.mts
@@ -35,7 +35,7 @@ import {
   ToString,
   ToUint32,
   RegExpHasFlag,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import { RegExpState as State, GetSubstitution } from '../runtime-semantics/all.mjs';
 import { CodePointAt } from '../static-semantics/all.mjs';
@@ -78,7 +78,7 @@ export function RegExpBuiltinExec(R, S) {
   // 3. Let length be the number of code units in S.
   const length = S.stringValue().length;
   // 4. Let lastIndex be ? ℝ(ToLength(? Get(R, "lastIndex"))).
-  let lastIndex = Q(ToLength(Q(Get(R, Value('lastIndex'))))).numberValue();
+  let lastIndex = ℝ(Q(ToLength(Q(Get(R, Value('lastIndex'))))));
   // 5. Let flags be R.[[OriginalFlags]].
   const flags = R.OriginalFlags.stringValue();
   // 6. If flags contains "g", let global be true; else let global be false.
@@ -105,7 +105,7 @@ export function RegExpBuiltinExec(R, S) {
       // i. If global is true or sticky is true, then
       if (global || sticky) {
         // 1. Perform ? Set(R, "lastIndex", +0𝔽, true).
-        Q(Set(R, Value('lastIndex'), F(+0), Value.true));
+        Q(Set(R, Value('lastIndex'), 𝔽(+0), Value.true));
       }
       // ii. Return null.
       return Value.null;
@@ -117,7 +117,7 @@ export function RegExpBuiltinExec(R, S) {
       // i. If sticky is true, then
       if (sticky) {
         // 1. Perform ? Set(R, "lastIndex", +0𝔽, true).
-        Q(Set(R, Value('lastIndex'), F(+0), Value.true));
+        Q(Set(R, Value('lastIndex'), 𝔽(+0), Value.true));
         // 2. Return null.
         return Value.null;
       }
@@ -141,7 +141,7 @@ export function RegExpBuiltinExec(R, S) {
   // 16. If global is true or sticky is true, then
   if (global || sticky) {
     // a. Perform ? Set(R, "lastIndex", 𝔽(e), true).
-    Q(Set(R, Value('lastIndex'), F(e), Value.true));
+    Q(Set(R, Value('lastIndex'), 𝔽(e), Value.true));
   }
   // 17. Let n be the number of elements in r's captures List.
   const n = r.captures.length - 1;
@@ -152,9 +152,9 @@ export function RegExpBuiltinExec(R, S) {
   // 20. Let A be ! ArrayCreate(n + 1).
   const A = X(ArrayCreate(n + 1));
   // 21. Assert: The mathematical value of A's "length" property is n + 1.
-  Assert(X(Get(A, Value('length'))).numberValue() === n + 1);
+  Assert(ℝ(X(Get(A, Value('length')))) === n + 1);
   // 22. Perform ! CreateDataPropertyOrThrow(A, "index", 𝔽(lastIndex)).
-  X(CreateDataPropertyOrThrow(A, Value('index'), F(lastIndex)));
+  X(CreateDataPropertyOrThrow(A, Value('index'), 𝔽(lastIndex)));
   // 23. Perform ! CreateDataPropertyOrThrow(A, "input", S).
   X(CreateDataPropertyOrThrow(A, Value('input'), S));
   // 24. Let match be the Match Record { [[StartIndex]]: lastIndex, [[EndIndex]]: e }.
@@ -216,7 +216,7 @@ export function RegExpBuiltinExec(R, S) {
       indices.push(capture);
     }
     // e. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(i)), capturedValue).
-    X(CreateDataPropertyOrThrow(A, X(ToString(F(i))), capturedValue));
+    X(CreateDataPropertyOrThrow(A, X(ToString(𝔽(i))), capturedValue));
     // f. If the ith capture of R was defined with a GroupName, then
     if (R.parsedPattern.capturingGroups[i - 1].GroupSpecifier) {
       // i. Let s be the StringValue of the corresponding RegExpIdentifierName.
@@ -372,7 +372,7 @@ function RegExpProto_match([string = Value.undefined], { thisValue }) {
     // a. If flags contains "u", let fullUnicode be true. Otherwise, let fullUnicode be false.
     const fullUnicode = flags.stringValue().includes('u') ? Value.true : Value.false;
     // b. Perform ? Set(rx, "lastIndex", +0𝔽, true).
-    Q(Set(rx, Value('lastIndex'), F(+0), Value.true));
+    Q(Set(rx, Value('lastIndex'), 𝔽(+0), Value.true));
     // c. Let A be ! ArrayCreate(0).
     const A = X(ArrayCreate(0));
     // d. Let n be 0.
@@ -393,15 +393,15 @@ function RegExpProto_match([string = Value.undefined], { thisValue }) {
         // 1. Let matchStr be ? ToString(? Get(result, "0")).
         const matchStr = Q(ToString(Q(Get(result, Value('0')))));
         // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), matchStr).
-        X(CreateDataPropertyOrThrow(A, X(ToString(F(n))), matchStr));
+        X(CreateDataPropertyOrThrow(A, X(ToString(𝔽(n))), matchStr));
         // 3. If matchStr is the empty String, then
         if (matchStr.stringValue() === '') {
           // a. Let thisIndex be ℝ(? ToLength(? Get(rx, "lastIndex"))).
-          const thisIndex = Q(ToLength(Q(Get(rx, Value('lastIndex'))))).numberValue();
+          const thisIndex = ℝ(Q(ToLength(Q(Get(rx, Value('lastIndex'))))));
           // b. Let nextIndex be AdvanceStringIndex(S, thisIndex, fullUnicode).
           const nextIndex = AdvanceStringIndex(S, thisIndex, fullUnicode);
           // c. Perform ? Set(rx, "lastIndex", 𝔽(nextIndex), true).
-          Q(Set(rx, Value('lastIndex'), F(nextIndex), Value.true));
+          Q(Set(rx, Value('lastIndex'), 𝔽(nextIndex), Value.true));
         }
         // 4. Set n to n + 1.
         n += 1;
@@ -476,7 +476,7 @@ function RegExpProto_replace([string = Value.undefined, replaceValue = Value.und
     // a. If flags contains "u", let fullUnicode be true. Otherwise, let fullUnicode be false.
     fullUnicode = flags.stringValue().includes('u') ? Value.true : Value.false;
     // b. Perform ? Set(rx, "lastIndex", +0𝔽, true).
-    Q(Set(rx, Value('lastIndex'), F(+0), Value.true));
+    Q(Set(rx, Value('lastIndex'), 𝔽(+0), Value.true));
   }
   // 10. Let results be a new empty List.
   const results = [];
@@ -501,11 +501,11 @@ function RegExpProto_replace([string = Value.undefined, replaceValue = Value.und
         // 2. If matchStr is the empty String, then
         if (matchStr.stringValue() === '') {
           // a. Let thisIndex be ℝ(? ToLength(? Get(rx, "lastIndex"))).
-          const thisIndex = Q(ToLength(Q(Get(rx, Value('lastIndex'))))).numberValue();
+          const thisIndex = ℝ(Q(ToLength(Q(Get(rx, Value('lastIndex'))))));
           // b. Let nextIndex be AdvanceStringIndex(S, thisIndex, fullUnicode).
           const nextIndex = AdvanceStringIndex(S, thisIndex, fullUnicode);
           // c. Perform ? Set(rx, "lastIndex", 𝔽(nextIndex), true).
-          Q(Set(rx, Value('lastIndex'), F(nextIndex), Value.true));
+          Q(Set(rx, Value('lastIndex'), 𝔽(nextIndex), Value.true));
         }
       }
     }
@@ -535,7 +535,7 @@ function RegExpProto_replace([string = Value.undefined, replaceValue = Value.und
     // i. Repeat, while n ≤ nCaptures,
     while (n <= nCaptures) {
       // i. Let capN be ? Get(result, ! ToString(𝔽(n))).
-      let capN = Q(Get(result, X(ToString(F(n)))));
+      let capN = Q(Get(result, X(ToString(𝔽(n)))));
       // ii. If capN is not undefined, then
       if (capN !== Value.undefined) {
         // 1. Set capN to ? ToString(capN).
@@ -555,7 +555,7 @@ function RegExpProto_replace([string = Value.undefined, replaceValue = Value.und
     // k. If functionalReplace is true, then
     if (functionalReplace === Value.true) {
       // i. Let replacerArgs be the list-concatenation of « matched », captures, and « 𝔽(position), S ».
-      const replacerArgs = [matched, ...captures, F(position), S];
+      const replacerArgs = [matched, ...captures, 𝔽(position), S];
       // ii. If namedCaptures is not undefined, then
       if (namedCaptures !== Value.undefined) {
         // 1. Append namedCaptures to replacerArgs.
@@ -602,8 +602,8 @@ function RegExpProto_search([string = Value.undefined], { thisValue }) {
   const S = Q(ToString(string));
 
   const previousLastIndex = Q(Get(rx, Value('lastIndex')));
-  if (SameValue(previousLastIndex, F(+0)) === Value.false) {
-    Q(Set(rx, Value('lastIndex'), F(+0), Value.true));
+  if (SameValue(previousLastIndex, 𝔽(+0)) === Value.false) {
+    Q(Set(rx, Value('lastIndex'), 𝔽(+0), Value.true));
   }
 
   const result = Q(RegExpExec(rx, S));
@@ -613,7 +613,7 @@ function RegExpProto_search([string = Value.undefined], { thisValue }) {
   }
 
   if (result === Value.null) {
-    return F(-1);
+    return 𝔽(-1);
   }
 
   return Q(Get(result, Value('index')));
@@ -659,7 +659,7 @@ function RegExpProto_split([string = Value.undefined, limit = Value.undefined], 
   if (limit === Value.undefined) {
     lim = (2 ** 32) - 1;
   } else {
-    lim = Q(ToUint32(limit)).numberValue();
+    lim = ℝ(Q(ToUint32(limit)));
   }
 
   const size = S.stringValue().length;
@@ -680,19 +680,19 @@ function RegExpProto_split([string = Value.undefined, limit = Value.undefined], 
 
   let q = p;
   while (q < size) {
-    Q(Set(splitter, Value('lastIndex'), F(q), Value.true));
+    Q(Set(splitter, Value('lastIndex'), 𝔽(q), Value.true));
     const z = Q(RegExpExec(splitter, S));
     if (z === Value.null) {
       q = AdvanceStringIndex(S, q, unicodeMatching);
     } else {
       const lastIndex = Q(Get(splitter, Value('lastIndex')));
-      let e = Q(ToLength(lastIndex)).numberValue();
+      let e = ℝ(Q(ToLength(lastIndex)));
       e = Math.min(e, size);
       if (e === p) {
         q = AdvanceStringIndex(S, q, unicodeMatching);
       } else {
         const T = Value(S.stringValue().substring(p, q));
-        X(CreateDataProperty(A, X(ToString(F(lengthA))), T));
+        X(CreateDataProperty(A, X(ToString(𝔽(lengthA))), T));
         lengthA += 1;
         if (lengthA === lim) {
           return A;
@@ -702,8 +702,8 @@ function RegExpProto_split([string = Value.undefined, limit = Value.undefined], 
         numberOfCaptures = Math.max(numberOfCaptures - 1, 0);
         let i = 1;
         while (i <= numberOfCaptures) {
-          const nextCapture = Q(Get(z, X(ToString(F(i)))));
-          X(CreateDataProperty(A, X(ToString(F(lengthA))), nextCapture));
+          const nextCapture = Q(Get(z, X(ToString(𝔽(i)))));
+          X(CreateDataProperty(A, X(ToString(𝔽(lengthA))), nextCapture));
           i += 1;
           lengthA += 1;
           if (lengthA === lim) {
@@ -716,7 +716,7 @@ function RegExpProto_split([string = Value.undefined, limit = Value.undefined], 
   }
 
   const T = Value(S.stringValue().substring(p, size));
-  X(CreateDataProperty(A, X(ToString(F(lengthA))), T));
+  X(CreateDataProperty(A, X(ToString(𝔽(lengthA))), T));
   return A;
 }
 

--- a/src/intrinsics/RegExpStringIteratorPrototype.mts
+++ b/src/intrinsics/RegExpStringIteratorPrototype.mts
@@ -10,7 +10,7 @@ import {
   Get,
   Set,
   Yield,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { RegExpExec, AdvanceStringIndex } from './RegExpPrototype.mjs';
@@ -48,11 +48,11 @@ export function CreateRegExpStringIterator(R, S, global, fullUnicode) {
       // v. If matchStr is the empty String, then
       if (matchStr.stringValue() === '') {
         // i. Let thisIndex be ℝ(? ToLength(? Get(R, "lastIndex"))).
-        const thisIndex = Q(ToLength(Q(Get(R, Value('lastIndex'))))).numberValue();
+        const thisIndex = ℝ(Q(ToLength(Q(Get(R, Value('lastIndex'))))));
         // ii. Let nextIndex be ! AdvanceStringIndex(S, thisIndex, fullUnicode).
         const nextIndex = X(AdvanceStringIndex(S, thisIndex, fullUnicode));
         // iii. Perform ? Set(R, "lastIndex", 𝔽(nextIndex), true).
-        Q(Set(R, Value('lastIndex'), F(nextIndex), Value.true));
+        Q(Set(R, Value('lastIndex'), 𝔽(nextIndex), Value.true));
       }
       // vi. Perform ? Yield(match).
       Q(yield* Yield(match));

--- a/src/intrinsics/SetPrototype.mts
+++ b/src/intrinsics/SetPrototype.mts
@@ -2,10 +2,10 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
   Call,
-  F,
+  𝔽,
   IsCallable,
   RequireInternalSlot,
-  SameValueZero,
+  SameValueZero, ℝ,
 } from '../abstract-ops/all.mjs';
 import {
   NumberValue,
@@ -33,8 +33,8 @@ function SetProto_add([value = Value.undefined], { thisValue }) {
     }
   }
   // 5. If value is -0𝔽, set value to +0𝔽.
-  if (value instanceof NumberValue && Object.is(value.numberValue(), -0)) {
-    value = F(+0);
+  if (value instanceof NumberValue && Object.is(ℝ(value), -0)) {
+    value = 𝔽(+0);
   }
   // 6. Append value as the last element of entries.
   entries.push(value);
@@ -151,7 +151,7 @@ function SetProto_sizeGetter(args, { thisValue }) {
     }
   }
   // 6. Return 𝔽(count).
-  return F(count);
+  return 𝔽(count);
 }
 
 /** https://tc39.es/ecma262/#sec-set.prototype.values */

--- a/src/intrinsics/String.mts
+++ b/src/intrinsics/String.mts
@@ -16,7 +16,7 @@ import {
   ToObject,
   ToString,
   ToUint16,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import { UTF16EncodeCodePoint } from '../static-semantics/all.mjs';
 import { Q, X } from '../completion.mjs';
@@ -50,7 +50,7 @@ function String_fromCharCode(codeUnits) {
     elements.push(nextCU);
     nextIndex += 1;
   }
-  const result = elements.reduce((previous, current) => previous + String.fromCharCode(current.numberValue()), '');
+  const result = elements.reduce((previous, current) => previous + String.fromCharCode(ℝ(current)), '');
   return Value(result);
 }
 
@@ -67,11 +67,11 @@ function String_fromCodePoint(codePoints) {
       return surroundingAgent.Throw('RangeError', 'StringCodePointInvalid', next);
     }
     // c. If ℝ(nextCP) < 0 or ℝ(nextCP) > 0x10FFFF, throw a RangeError exception.
-    if (nextCP.numberValue() < 0 || nextCP.numberValue() > 0x10FFFF) {
+    if (ℝ(nextCP) < 0 || ℝ(nextCP) > 0x10FFFF) {
       return surroundingAgent.Throw('RangeError', 'StringCodePointInvalid', nextCP);
     }
     // d. Set result to the string-concatenation of result and UTF16EncodeCodePoint(ℝ(nextCP)).
-    result += UTF16EncodeCodePoint(nextCP.numberValue());
+    result += UTF16EncodeCodePoint(ℝ(nextCP));
   }
   // 3. Assert: If codePoints is empty, then result is the empty String.
   Assert(!(codePoints.length === 0) || result.length === 0);
@@ -92,7 +92,7 @@ function String_raw([template = Value.undefined, ...substitutions]) {
   const stringElements = [];
   let nextIndex = 0;
   while (true) {
-    const nextKey = X(ToString(F(nextIndex)));
+    const nextKey = X(ToString(𝔽(nextIndex)));
     const nextSeg = Q(ToString(Q(Get(raw, nextKey))));
     stringElements.push(nextSeg.stringValue());
     if (nextIndex + 1 === literalSegments) {

--- a/src/intrinsics/StringPrototype.mts
+++ b/src/intrinsics/StringPrototype.mts
@@ -25,7 +25,7 @@ import {
   ToUint32,
   StringCreate,
   Yield,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import {
   GetSubstitution,
@@ -73,9 +73,9 @@ function StringProto_charCodeAt([pos = Value.undefined], { thisValue }) {
   const position = Q(ToIntegerOrInfinity(pos));
   const size = S.stringValue().length;
   if (position < 0 || position >= size) {
-    return F(NaN);
+    return 𝔽(NaN);
   }
-  return F(S.stringValue().charCodeAt(position));
+  return 𝔽(S.stringValue().charCodeAt(position));
 }
 
 /** https://tc39.es/ecma262/#sec-string.prototype.codepointat */
@@ -88,7 +88,7 @@ function StringProto_codePointAt([pos = Value.undefined], { thisValue }) {
     return Value.undefined;
   }
   const cp = X(CodePointAt(S.stringValue(), position));
-  return F(cp.CodePoint);
+  return 𝔽(cp.CodePoint);
 }
 
 /** https://tc39.es/ecma262/#sec-string.prototype.concat */
@@ -222,12 +222,12 @@ function StringProto_lastIndexOf([searchString = Value.undefined, position = Val
         }
       }
       if (match) {
-        return F(k);
+        return 𝔽(k);
       }
     }
     k -= 1;
   }
-  return F(-1);
+  return 𝔽(-1);
 }
 
 /** https://tc39.es/ecma262/#sec-string.prototype.localecompare */
@@ -236,11 +236,11 @@ function StringProto_localeCompare([that = Value.undefined], { thisValue }) {
   const S = Q(ToString(O)).stringValue();
   const That = Q(ToString(that)).stringValue();
   if (S === That) {
-    return F(+0);
+    return 𝔽(+0);
   } else if (S < That) {
-    return F(-1);
+    return 𝔽(-1);
   } else {
-    return F(1);
+    return 𝔽(1);
   }
 }
 
@@ -367,7 +367,7 @@ function StringProto_replace([searchValue = Value.undefined, replaceValue = Valu
   }
   let replStr;
   if (functionalReplace === Value.true) {
-    const replValue = Q(Call(replaceValue, Value.undefined, [matched, F(pos), string]));
+    const replValue = Q(Call(replaceValue, Value.undefined, [matched, 𝔽(pos), string]));
     replStr = Q(ToString(replValue));
   } else {
     const captures = [];
@@ -423,13 +423,13 @@ function StringProto_replaceAll([searchValue = Value.undefined, replaceValue = V
   // 9. Let matchPositions be a new empty List.
   const matchPositions = [];
   // 10. Let position be ! StringIndexOf(string, searchString, 0).
-  let position = X(StringIndexOf(string, searchString, 0)).numberValue();
+  let position = ℝ(X(StringIndexOf(string, searchString, 0)));
   // 11. Repeat, while position is not -1
   while (position !== -1) {
     // a. Append position to the end of matchPositions.
     matchPositions.push(position);
     // b. Let position be ! StringIndexOf(string, searchString, position + advanceBy).
-    position = X(StringIndexOf(string, searchString, position + advanceBy)).numberValue();
+    position = ℝ(X(StringIndexOf(string, searchString, position + advanceBy)));
   }
   // 12. Let endOfLastMatch be 0.
   let endOfLastMatch = 0;
@@ -441,7 +441,7 @@ function StringProto_replaceAll([searchValue = Value.undefined, replaceValue = V
     // a. If functionalReplace is true, then
     if (functionalReplace === Value.true) {
       // i. Let replacement be ? ToString(? Call(replaceValue, undefined, « searchString, 𝔽(position), string »).
-      replacement = Q(ToString(Q(Call(replaceValue, Value.undefined, [searchString, F(position), string]))));
+      replacement = Q(ToString(Q(Call(replaceValue, Value.undefined, [searchString, 𝔽(position), string]))));
     } else { // b. Else,
       // i. Assert: Type(replaceValue) is String.
       Assert(replaceValue instanceof JSStringValue);
@@ -524,14 +524,14 @@ function StringProto_split([separator = Value.undefined, limit = Value.undefined
   let lengthA = 0;
   let lim;
   if (limit === Value.undefined) {
-    lim = F((2 ** 32) - 1);
+    lim = 𝔽((2 ** 32) - 1);
   } else {
     lim = Q(ToUint32(limit));
   }
   const s = S.stringValue().length;
   let p = 0;
   const R = Q(ToString(separator));
-  if (lim.numberValue() === 0) {
+  if (ℝ(lim) === 0) {
     return A;
   }
   if (separator === Value.undefined) {
@@ -554,9 +554,9 @@ function StringProto_split([separator = Value.undefined, limit = Value.undefined
         q += 1;
       } else {
         const T = Value(S.stringValue().substring(p, q));
-        X(CreateDataPropertyOrThrow(A, X(ToString(F(lengthA))), T));
+        X(CreateDataPropertyOrThrow(A, X(ToString(𝔽(lengthA))), T));
         lengthA += 1;
-        if (lengthA === lim.numberValue()) {
+        if (lengthA === ℝ(lim)) {
           return A;
         }
         p = e;
@@ -565,7 +565,7 @@ function StringProto_split([separator = Value.undefined, limit = Value.undefined
     }
   }
   const T = Value(S.stringValue().substring(p, s));
-  X(CreateDataPropertyOrThrow(A, X(ToString(F(lengthA))), T));
+  X(CreateDataPropertyOrThrow(A, X(ToString(𝔽(lengthA))), T));
   return A;
 }
 

--- a/src/intrinsics/TypedArray.mts
+++ b/src/intrinsics/TypedArray.mts
@@ -15,7 +15,7 @@ import {
   ToObject,
   ToString,
   TypedArrayCreate,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import { bootstrapConstructor } from './bootstrap.mjs';
 
@@ -51,14 +51,14 @@ function TypedArray_from([source = Value.undefined, mapfn = Value.undefined, thi
   if (usingIterator !== Value.undefined) {
     const values = Q(IterableToList(source, usingIterator));
     const len = values.length;
-    const targetObj = Q(TypedArrayCreate(C, [F(len)]));
+    const targetObj = Q(TypedArrayCreate(C, [𝔽(len)]));
     let k = 0;
     while (k < len) {
-      const Pk = X(ToString(F(k)));
+      const Pk = X(ToString(𝔽(k)));
       const kValue = values.shift();
       let mappedValue;
       if (mapping) {
-        mappedValue = Q(Call(mapfn, thisArg, [kValue, F(k)]));
+        mappedValue = Q(Call(mapfn, thisArg, [kValue, 𝔽(k)]));
       } else {
         mappedValue = kValue;
       }
@@ -74,20 +74,20 @@ function TypedArray_from([source = Value.undefined, mapfn = Value.undefined, thi
   // 9. Let len be ? LengthOfArrayLike(arrayLike).
   const len = Q(LengthOfArrayLike(arrayLike));
   // 10. Let targetObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-  const targetObj = Q(TypedArrayCreate(C, [F(len)]));
+  const targetObj = Q(TypedArrayCreate(C, [𝔽(len)]));
   // 11. Let k be 0.
   let k = 0;
   // 12. Repeat, while k < len
   while (k < len) {
     // a. Let Pk be ! ToString(𝔽(k)).
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     // b. Let kValue be ? Get(arrayLike, Pk).
     const kValue = Q(Get(arrayLike, Pk));
     let mappedValue;
     // c. If mapping is true, then
     if (mapping) {
       // i. Let mappedValue be ? Call(mapfn, thisArg, « kValue, 𝔽(k) »).
-      mappedValue = Q(Call(mapfn, thisArg, [kValue, F(k)]));
+      mappedValue = Q(Call(mapfn, thisArg, [kValue, 𝔽(k)]));
     } else {
       // d. Else, let mappedValue be kValue.
       mappedValue = kValue;
@@ -113,7 +113,7 @@ function TypedArray_of(items, { thisValue }) {
     return surroundingAgent.Throw('TypeError', 'NotAConstructor', C);
   }
   // 5. Let newObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-  const newObj = Q(TypedArrayCreate(C, [F(len)]));
+  const newObj = Q(TypedArrayCreate(C, [𝔽(len)]));
   // 6. Let k be 0.
   let k = 0;
   // 7. Repeat, while k < len
@@ -121,7 +121,7 @@ function TypedArray_of(items, { thisValue }) {
     // a. Let kValue be items[k].
     const kValue = items[k];
     // b. Let Pk be ! ToString(𝔽(k)).
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     // c. Perform ? Set(newObj, Pk, kValue, true).
     Q(Set(newObj, Pk, kValue, Value.true));
     // d. Set k to k + 1.

--- a/src/intrinsics/TypedArrayConstructors.mts
+++ b/src/intrinsics/TypedArrayConstructors.mts
@@ -23,7 +23,7 @@ import {
   ToIndex,
   ToString,
   typedArrayInfoByName,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { bootstrapConstructor } from './bootstrap.mjs';
@@ -176,7 +176,7 @@ export function bootstrapTypedArrayConstructors(realmRec) {
           // e. Repeat, while k < len
           while (k < len) {
             // i. Let Pk be ! ToString(𝔽(k)).
-            const Pk = X(ToString(F(k)));
+            const Pk = X(ToString(𝔽(k)));
             // ii. Let kValue be the first element of values and remove that element from values.
             const kValue = values.shift();
             // iii. Perform ? Set(O, Pk, kValue, true).
@@ -201,7 +201,7 @@ export function bootstrapTypedArrayConstructors(realmRec) {
         // 12. Repeat, while k < len.
         while (k < len) {
           // a. Let Pk be ! ToString(𝔽(k)).
-          const Pk = X(ToString(F(k)));
+          const Pk = X(ToString(𝔽(k)));
           // b. Let kValue be ? Get(arrayLike, Pk).
           const kValue = Q(Get(arrayLike, Pk));
           // c. Perform ? Set(O, Pk, kValue, true).
@@ -279,7 +279,7 @@ export function bootstrapTypedArrayConstructors(realmRec) {
     }
 
     const taConstructor = bootstrapConstructor(realmRec, TypedArrayConstructor, TypedArray, 3, realmRec.Intrinsics[`%${TypedArray}.prototype%`], [
-      ['BYTES_PER_ELEMENT', F(info.ElementSize), undefined, {
+      ['BYTES_PER_ELEMENT', 𝔽(info.ElementSize), undefined, {
         Writable: Value.false,
         Configurable: Value.false,
       }],

--- a/src/intrinsics/TypedArrayPrototype.mts
+++ b/src/intrinsics/TypedArrayPrototype.mts
@@ -25,7 +25,7 @@ import {
   RequireInternalSlot,
   typedArrayInfoByName,
   typedArrayInfoByType,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { surroundingAgent } from '../engine.mjs';
@@ -62,12 +62,12 @@ function TypedArrayProto_byteLength(args, { thisValue }) {
   const buffer = O.ViewedArrayBuffer;
   // 5. If IsDetachedBuffer(buffer) is true, return +0𝔽.
   if (IsDetachedBuffer(buffer) === Value.true) {
-    return F(+0);
+    return 𝔽(+0);
   }
   // 6. Let size be O.[[ByteLength]].
   const size = O.ByteLength;
   // 7. Return size.
-  return F(size);
+  return 𝔽(size);
 }
 
 /** https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset */
@@ -82,12 +82,12 @@ function TypedArrayProto_byteOffset(args, { thisValue }) {
   const buffer = O.ViewedArrayBuffer;
   // 5. If IsDetachedBuffer(buffer) is true, return +0𝔽.
   if (IsDetachedBuffer(buffer) === Value.true) {
-    return F(+0);
+    return 𝔽(+0);
   }
   // 6. Let offset be O.[[ByteOffset]].
   const offset = O.ByteOffset;
   // 7. Return offset.
-  return F(offset);
+  return 𝔽(offset);
 }
 
 /** https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin */
@@ -239,7 +239,7 @@ function TypedArrayProto_fill([value = Value.undefined, start = Value.undefined,
   // 11. Repeat, while k < final
   while (k < final) {
     // a. Let Pk be ! ToString(𝔽(k)).
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     // b. Perform ! Set(O, Pk, value, true).
     X(Set(O, Pk, value, Value.true));
     // c. Set k to k + 1.
@@ -270,11 +270,11 @@ function TypedArrayProto_filter([callbackfn = Value.undefined, thisArg = Value.u
   // 8. Repeat, while k < len
   while (k < len) {
     // a. Let Pk be ! ToString(𝔽(k)).
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     // b. Let kValue be ? Get(O, Pk).
     const kValue = Q(Get(O, Pk));
     // c. Let selected be ! ToBoolean(? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »)).
-    const selected = ToBoolean(Q(Call(callbackfn, thisArg, [kValue, F(k), O])));
+    const selected = ToBoolean(Q(Call(callbackfn, thisArg, [kValue, 𝔽(k), O])));
     // d. If selected is true, then
     if (selected === Value.true) {
       // i. Append kValue to the end of kept.
@@ -286,13 +286,13 @@ function TypedArrayProto_filter([callbackfn = Value.undefined, thisArg = Value.u
     k += 1;
   }
   // 9. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(captured) »).
-  const A = Q(TypedArraySpeciesCreate(O, [F(captured)]));
+  const A = Q(TypedArraySpeciesCreate(O, [𝔽(captured)]));
   // 10. Let n be 0.
   let n = 0;
   // 11. For each element e of kept, do
   for (const e of kept) {
     // a. Perform ! Set(A, ! ToString(𝔽(n)), e, true).
-    X(Set(A, X(ToString(F(n))), e, Value.true));
+    X(Set(A, X(ToString(𝔽(n))), e, Value.true));
     // b. Set n to n + 1.
     n += 1;
   }
@@ -322,12 +322,12 @@ function TypedArrayProto_length(args, { thisValue }) {
   const buffer = O.ViewedArrayBuffer;
   // 5. If IsDetachedBuffer(buffer) is true, return +0𝔽.
   if (IsDetachedBuffer(buffer) === Value.true) {
-    return F(+0);
+    return 𝔽(+0);
   }
   // 6. Let length be O.[[ArrayLength]].
   const length = O.ArrayLength;
   // 8. Return 𝔽(length).
-  return F(length);
+  return 𝔽(length);
 }
 
 /** https://tc39.es/ecma262/#sec-%typedarray%.prototype.map */
@@ -343,17 +343,17 @@ function TypedArrayProto_map([callbackfn = Value.undefined, thisArg = Value.unde
     return surroundingAgent.Throw('TypeError', 'NotAFunction', callbackfn);
   }
   // 5. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(len) »).
-  const A = Q(TypedArraySpeciesCreate(O, [F(len)]));
+  const A = Q(TypedArraySpeciesCreate(O, [𝔽(len)]));
   // 6. Let k be 0.
   let k = 0;
   // 7. Repeat, while k < len
   while (k < len) {
     // a. Let Pk be ! ToString(𝔽(k)).
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     // b. Let kValue be ? Get(O, Pk).
     const kValue = Q(Get(O, Pk));
     // c. Let mappedValue be ? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »).
-    const mappedValue = Q(Call(callbackfn, thisArg, [kValue, F(k), O]));
+    const mappedValue = Q(Call(callbackfn, thisArg, [kValue, 𝔽(k), O]));
     // d. Perform ? Set(A, Pk, mappedValue, true).
     Q(Set(A, Pk, mappedValue, Value.true));
     // e. Set k to k + 1.
@@ -487,11 +487,11 @@ function SetTypedArrayFromArrayLike(target, targetOffset, source) {
   // 9. Repeat, while k < srcLength,
   while (k < srcLength) {
     // a. Let Pk be ! ToString(𝔽(k)).
-    const Pk = X(ToString(F(k)));
+    const Pk = X(ToString(𝔽(k)));
     // b. Let value be ? Get(src, Pk).
     const value = Q(Get(src, Pk));
     // c. Let targetIndex be 𝔽(targetOffset + k).
-    const targetIndex = F(targetOffset + k);
+    const targetIndex = 𝔽(targetOffset + k);
     // d. Perform ? IntegerIndexedElementSet(target, targetIndex, value).
     Q(IntegerIndexedElementSet(target, targetIndex, value));
     // e. Set k to k + 1.
@@ -560,7 +560,7 @@ function TypedArrayProto_slice([start = Value.undefined, end = Value.undefined],
   // 8. Let count be max(final - k, 0).
   const count = Math.max(final - k, 0);
   // 9. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(count) »).
-  const A = Q(TypedArraySpeciesCreate(O, [F(count)]));
+  const A = Q(TypedArraySpeciesCreate(O, [𝔽(count)]));
   // 10. If count > 0, then
   if (count > 0) {
     // a. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
@@ -582,11 +582,11 @@ function TypedArrayProto_slice([start = Value.undefined, end = Value.undefined],
       // ii. Repeat, while k < final
       while (k < final) {
         // 1. Let Pk be ! ToString(𝔽(k)).
-        const Pk = X(ToString(F(k)));
+        const Pk = X(ToString(𝔽(k)));
         // 2. Let kValue be ! Get(O, Pk).
         const kValue = X(Get(O, Pk));
         // 3. Perform ! Set(A, ! ToString(𝔽(n)), kValue, true).
-        X(Set(A, X(ToString(F(n))), kValue, Value.true));
+        X(Set(A, X(ToString(𝔽(n))), kValue, Value.true));
         // 4. Set k to k + 1.
         k += 1;
         // 5. Set n to n + 1.
@@ -651,43 +651,43 @@ function TypedArraySortCompare(x, y, comparefn) {
     const v = Q(ToNumber(Q(Call(comparefn, Value.undefined, [x, y]))));
     // b. If v is NaN, return +0𝔽.
     if (v.isNaN()) {
-      return F(+0);
+      return 𝔽(+0);
     }
     // c. Return v.
     return v;
   }
   // 3. If x and y are both NaN, return +0𝔽.
   if (x.isNaN() && y.isNaN()) {
-    return F(+0);
+    return 𝔽(+0);
   }
   // 4. If x is NaN, return 1𝔽.
   if (x.isNaN()) {
-    return F(1);
+    return 𝔽(1);
   }
   // 5. If y is NaN, return -1𝔽.
   if (y.isNaN()) {
-    return F(-1);
+    return 𝔽(-1);
   }
-  x = x.numberValue ? x.numberValue() : x.bigintValue();
-  y = y.numberValue ? y.numberValue() : y.bigintValue();
+  x = x.numberValue ? ℝ(x) : ℝ(x);
+  y = y.numberValue ? ℝ(y) : ℝ(y);
   // 6. If x < y, return -1𝔽.
   if (x < y) {
-    return F(-1);
+    return 𝔽(-1);
   }
   // 7. If x > y, return 1𝔽.
   if (x > y) {
-    return F(1);
+    return 𝔽(1);
   }
   // 8. If x is -0𝔽 and y is +0𝔽, return -1𝔽.
   if (Object.is(x, -0) && Object.is(y, +0)) {
-    return F(-1);
+    return 𝔽(-1);
   }
   // 9. If x is +0𝔽 and y is -0𝔽, return 1𝔽.
   if (Object.is(x, +0) && Object.is(y, -0)) {
-    return F(1);
+    return 𝔽(1);
   }
   // 10. Return +0𝔽.
-  return F(+0);
+  return 𝔽(+0);
 }
 
 /** https://tc39.es/ecma262/#sec-%typedarray%.prototype.subarray */
@@ -736,7 +736,7 @@ function TypedArrayProto_subarray([begin = Value.undefined, end = Value.undefine
   // 14. Let beginByteOffset be srcByteOffset + beginIndex × elementSize.
   const beginByteOffset = srcByteOffset + beginIndex * elementSize;
   // 15. Let argumentsList be « buffer, 𝔽(beginByteOffset), 𝔽(newLength) ».
-  const argumentsList = [buffer, F(beginByteOffset), F(newLength)];
+  const argumentsList = [buffer, 𝔽(beginByteOffset), 𝔽(newLength)];
   // 16. Return ? TypedArraySpeciesCreate(O, argumentsList).
   return Q(TypedArraySpeciesCreate(O, argumentsList));
 }
@@ -795,7 +795,7 @@ function TypedArrayProto_at([index = Value.undefined], { thisValue }) {
     return Value.undefined;
   }
   // 8. Return ? Get(O, ! ToString(𝔽(k))).
-  return Q(Get(O, X(ToString(F(k)))));
+  return Q(Get(O, X(ToString(𝔽(k)))));
 }
 
 export function bootstrapTypedArrayPrototype(realmRec) {

--- a/src/intrinsics/TypedArrayPrototypes.mts
+++ b/src/intrinsics/TypedArrayPrototypes.mts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { typedArrayInfoByName, F } from '../abstract-ops/all.mjs';
+import { typedArrayInfoByName, 𝔽 } from '../abstract-ops/all.mjs';
 import { Value } from '../value.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
 
@@ -7,7 +7,7 @@ import { bootstrapPrototype } from './bootstrap.mjs';
 export function bootstrapTypedArrayPrototypes(realmRec) {
   Object.entries(typedArrayInfoByName).forEach(([TypedArray, info]) => {
     const proto = bootstrapPrototype(realmRec, [
-      ['BYTES_PER_ELEMENT', F(info.ElementSize), undefined, {
+      ['BYTES_PER_ELEMENT', 𝔽(info.ElementSize), undefined, {
         Writable: Value.false,
         Configurable: Value.false,
       }],

--- a/src/intrinsics/parseFloat.mts
+++ b/src/intrinsics/parseFloat.mts
@@ -2,7 +2,7 @@
 import {
   CreateBuiltinFunction,
   ToString,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import { Q, X } from '../completion.mjs';
 import { Value } from '../value.mjs';
@@ -29,7 +29,7 @@ function ParseFloat([string = Value.undefined]) {
   }
   const multiplier = trimmedString.startsWith('-') ? -1 : 1;
   if (numberString.startsWith('Infinity')) {
-    return F(Infinity * multiplier);
+    return 𝔽(Infinity * multiplier);
   }
   let index = 0;
   done: { // eslint-disable-line no-labels
@@ -37,7 +37,7 @@ function ParseFloat([string = Value.undefined]) {
     while (numberString[index] === '0') {
       index += 1;
       if (index === numberString.length) {
-        return F(+0 * multiplier);
+        return 𝔽(+0 * multiplier);
       }
     }
     // Eat integer part
@@ -70,7 +70,7 @@ function ParseFloat([string = Value.undefined]) {
       }
     }
   }
-  return F(parseFloat(numberString.slice(0, index)) * multiplier);
+  return 𝔽(parseFloat(numberString.slice(0, index)) * multiplier);
 }
 
 export function bootstrapParseFloat(realmRec) {

--- a/src/intrinsics/parseInt.mts
+++ b/src/intrinsics/parseInt.mts
@@ -4,7 +4,7 @@ import {
   CreateBuiltinFunction,
   ToInt32,
   ToString,
-  F,
+  𝔽, ℝ,
 } from '../abstract-ops/all.mjs';
 import { TrimString } from '../runtime-semantics/all.mjs';
 import { Q, X } from '../completion.mjs';
@@ -63,11 +63,11 @@ function ParseInt([string = Value.undefined, radix = Value.undefined]) {
     S = S.slice(1);
   }
 
-  let R = Q(ToInt32(radix)).numberValue();
+  let R = ℝ(Q(ToInt32(radix)));
   let stripPrefix = true;
   if (R !== 0) {
     if (R < 2 || R > 36) {
-      return F(NaN);
+      return 𝔽(NaN);
     }
     if (R !== 16) {
       stripPrefix = false;
@@ -83,17 +83,17 @@ function ParseInt([string = Value.undefined, radix = Value.undefined]) {
   }
   const Z = S.slice(0, searchNotRadixDigit(S, R));
   if (Z === '') {
-    return F(NaN);
+    return 𝔽(NaN);
   }
   const mathInt = stringToRadixNumber(Z, R);
   if (mathInt === 0) {
     if (sign === -1) {
-      return F(-0);
+      return 𝔽(-0);
     }
-    return F(+0);
+    return 𝔽(+0);
   }
   const number = mathInt;
-  return F(sign * number);
+  return 𝔽(sign * number);
 }
 
 export function bootstrapParseInt(realmRec) {

--- a/src/runtime-semantics/ArgumentListEvaluation.mts
+++ b/src/runtime-semantics/ArgumentListEvaluation.mts
@@ -13,7 +13,7 @@ import {
   GetValue,
   IteratorStep,
   IteratorValue,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import { TemplateStrings } from '../static-semantics/all.mjs';
 
@@ -48,7 +48,7 @@ function GetTemplateObject(templateLiteral) {
   // 11. Repeat, while index < count
   while (index < count) {
     // a. Let prop be ! ToString(𝔽(index)).
-    const prop = X(ToString(F(index)));
+    const prop = X(ToString(𝔽(index)));
     // b. Let cookedValue be the String value cookedStrings[index].
     const cookedValue = cookedStrings[index];
     // c. Call template.[[DefineOwnProperty]](prop, PropertyDescriptor { [[Value]]: cookedValue, [[Writable]]: false, [[Enumerable]]: true, [[Configurable]]: false }).

--- a/src/runtime-semantics/ArrayLiteral.mts
+++ b/src/runtime-semantics/ArrayLiteral.mts
@@ -9,7 +9,7 @@ import {
   IteratorValue,
   ToString,
   CreateDataPropertyOrThrow,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import { Evaluate } from '../evaluator.mjs';
 import { ReturnIfAbrupt, Q, X } from '../completion.mjs';
@@ -31,7 +31,7 @@ function* ArrayAccumulation(ElementList, array, nextIndex) {
     switch (element.type) {
       case 'Elision':
         postIndex += 1;
-        Q(Set(array, Value('length'), F(postIndex), Value.true));
+        Q(Set(array, Value('length'), 𝔽(postIndex), Value.true));
         break;
       case 'SpreadElement':
         postIndex = Q(yield* ArrayAccumulation_SpreadElement(element, array, postIndex));
@@ -63,7 +63,7 @@ function* ArrayAccumulation_SpreadElement({ AssignmentExpression }, array, nextI
     // c. Let nextValue be ? IteratorValue(next).
     const nextValue = Q(IteratorValue(next));
     // d. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(nextIndex)), nextValue).
-    X(CreateDataPropertyOrThrow(array, X(ToString(F(nextIndex))), nextValue));
+    X(CreateDataPropertyOrThrow(array, X(ToString(𝔽(nextIndex))), nextValue));
     // e. Set nextIndex to nextIndex + 1.
     nextIndex += 1;
   }
@@ -76,7 +76,7 @@ function* ArrayAccumulation_AssignmentExpression(AssignmentExpression, array, ne
   // 3. Let initValue be ? GetValue(initResult).
   const initValue = Q(GetValue(initResult));
   // 4. Let created be ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(nextIndex)), initValue).
-  const _created = X(CreateDataPropertyOrThrow(array, X(ToString(F(nextIndex))), initValue));
+  const _created = X(CreateDataPropertyOrThrow(array, X(ToString(𝔽(nextIndex))), initValue));
   // 5. Return nextIndex + 1.
   return nextIndex + 1;
 }

--- a/src/runtime-semantics/DestructuringAssignmentEvaluation.mts
+++ b/src/runtime-semantics/DestructuringAssignmentEvaluation.mts
@@ -16,7 +16,7 @@ import {
   ResolveBinding,
   RequireObjectCoercible,
   ToString,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import {
   IsAnonymousFunctionDefinition,
@@ -315,7 +315,7 @@ function* IteratorDestructuringAssignmentEvaluation(node, iteratorRecord) {
           // iii. ReturnIfAbrupt(nextValue).
           ReturnIfAbrupt(nextValue);
           // iv. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), nextValue).
-          X(CreateDataPropertyOrThrow(A, X(ToString(F(n))), nextValue));
+          X(CreateDataPropertyOrThrow(A, X(ToString(𝔽(n))), nextValue));
           // v. Set n to n + 1.
           n += 1;
         }

--- a/src/runtime-semantics/IteratorBindingInitialization.mts
+++ b/src/runtime-semantics/IteratorBindingInitialization.mts
@@ -11,7 +11,7 @@ import {
   ArrayCreate,
   CreateDataPropertyOrThrow,
   ToString,
-  F,
+  𝔽,
 } from '../abstract-ops/all.mjs';
 import {
   AbruptCompletion,
@@ -166,7 +166,7 @@ function* IteratorBindingInitialization_BindingRestElement({ BindingIdentifier, 
       // e. ReturnIfAbrupt(nextValue).
       ReturnIfAbrupt(nextValue);
       // f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), nextValue).
-      X(CreateDataPropertyOrThrow(A, X(ToString(F(n))), nextValue));
+      X(CreateDataPropertyOrThrow(A, X(ToString(𝔽(n))), nextValue));
       // g. Set n to n + 1.
       n += 1;
     }
@@ -207,7 +207,7 @@ function* IteratorBindingInitialization_BindingRestElement({ BindingIdentifier, 
       // e. ReturnIfAbrupt(nextValue).
       ReturnIfAbrupt(nextValue);
       // f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), nextValue).
-      X(CreateDataPropertyOrThrow(A, X(ToString(F(n))), nextValue));
+      X(CreateDataPropertyOrThrow(A, X(ToString(𝔽(n))), nextValue));
       // g. Set n to n + 1.
       n += 1;
     }

--- a/src/runtime-semantics/MV.mts
+++ b/src/runtime-semantics/MV.mts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { F } from '../abstract-ops/all.mjs';
+import { 𝔽 } from '../abstract-ops/all.mjs';
 
 /** https://tc39.es/ecma262/#sec-runtime-semantics-mv-s */
 //   StringNumericLiteral :::
@@ -7,5 +7,5 @@ import { F } from '../abstract-ops/all.mjs';
 //     StrWhiteSpace
 //     StrWhiteSpace_opt StrNumericLiteral StrWhiteSpace_opt
 export function MV_StringNumericLiteral(StringNumericLiteral) {
-  return F(Number(StringNumericLiteral));
+  return 𝔽(Number(StringNumericLiteral));
 }

--- a/src/runtime-semantics/NumberToBigInt.mts
+++ b/src/runtime-semantics/NumberToBigInt.mts
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import { surroundingAgent } from '../engine.mjs';
-import { Assert, IsIntegralNumber, Z } from '../abstract-ops/all.mjs';
+import {
+  Assert, IsIntegralNumber, ℤ, ℝ,
+} from '../abstract-ops/all.mjs';
 import { Value, NumberValue } from '../value.mjs';
 
 /** https://tc39.es/ecma262/#sec-numbertobigint */
@@ -12,5 +14,5 @@ export function NumberToBigInt(number) {
     return surroundingAgent.Throw('RangeError', 'CannotConvertDecimalToBigInt', number);
   }
   // 3. Return the BigInt value that represents the mathematical value of number.
-  return Z(BigInt(number.numberValue()));
+  return ℤ(BigInt(ℝ(number)));
 }

--- a/src/runtime-semantics/StringIndexOf.mts
+++ b/src/runtime-semantics/StringIndexOf.mts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { JSStringValue } from '../value.mjs';
-import { Assert, F, isNonNegativeInteger } from '../abstract-ops/all.mjs';
+import { Assert, 𝔽, isNonNegativeInteger } from '../abstract-ops/all.mjs';
 
 // https://tc39.es/proposal-string-replaceall/#sec-stringindexof
 export function StringIndexOf(string, searchValue, fromIndex) {
@@ -16,7 +16,7 @@ export function StringIndexOf(string, searchValue, fromIndex) {
   const len = stringStr.length;
   // 5. If searchValue is the empty string, and fromIndex <= len, return 𝔽(fromIndex).
   if (searchStr === '' && fromIndex <= len) {
-    return F(fromIndex);
+    return 𝔽(fromIndex);
   }
   // 6. Let searchLen be the length of searchValue.
   const searchLen = searchStr.length;
@@ -40,5 +40,5 @@ export function StringIndexOf(string, searchValue, fromIndex) {
     k += 1;
   }
   // 8. Return 𝔽(pos).
-  return F(pos);
+  return 𝔽(pos);
 }

--- a/src/runtime-semantics/StringPad.mts
+++ b/src/runtime-semantics/StringPad.mts
@@ -1,13 +1,15 @@
 // @ts-nocheck
 import { Value } from '../value.mjs';
-import { Assert, ToString, ToLength } from '../abstract-ops/all.mjs';
+import {
+  Assert, ToString, ToLength, ℝ,
+} from '../abstract-ops/all.mjs';
 import { Q } from '../completion.mjs';
 
 /** https://tc39.es/ecma262/#sec-stringpad */
 export function StringPad(O, maxLength, fillString, placement) {
   Assert(placement === 'start' || placement === 'end');
   const S = Q(ToString(O));
-  const intMaxLength = Q(ToLength(maxLength)).numberValue();
+  const intMaxLength = ℝ(Q(ToLength(maxLength)));
   const stringLength = S.stringValue().length;
   if (intMaxLength <= stringLength) {
     return S;

--- a/src/value.mts
+++ b/src/value.mts
@@ -15,8 +15,8 @@ import {
   OrdinarySetPrototypeOf,
   ToInt32,
   ToUint32,
-  Z,
-  F,
+  ℤ,
+  𝔽, ℝ,
 } from './abstract-ops/all.mjs';
 import { EnvironmentRecord } from './environment.mjs';
 import { Completion, X } from './completion.mjs';
@@ -170,9 +170,9 @@ export class NumberValue extends PrimitiveValue {
   /** https://tc39.es/ecma262/#sec-numeric-types-number-unaryMinus */
   static unaryMinus(x: NumberValue) {
     if (x.isNaN()) {
-      return F(NaN);
+      return 𝔽(NaN);
     }
-    return F(-x.numberValue());
+    return 𝔽(-ℝ(x));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-bitwiseNOT */
@@ -180,38 +180,38 @@ export class NumberValue extends PrimitiveValue {
     // 1. Let oldValue be ! ToInt32(x).
     const oldValue = X(ToInt32(x));
     // 2. Return the result of applying bitwise complement to oldValue. The result is a signed 32-bit integer.
-    return F(~oldValue.numberValue());
+    return 𝔽(~ℝ(oldValue));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-exponentiate */
   static exponentiate(base: NumberValue, exponent: NumberValue) {
-    return F(base.numberValue() ** exponent.numberValue());
+    return 𝔽(ℝ(base) ** ℝ(exponent));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-multiply */
   static multiply(x: NumberValue, y: NumberValue) {
-    return F(x.numberValue() * y.numberValue());
+    return 𝔽(ℝ(x) * ℝ(y));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-divide */
   static divide(x: NumberValue, y: NumberValue) {
-    return F(x.numberValue() / y.numberValue());
+    return 𝔽(ℝ(x) / ℝ(y));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-remainder */
   static remainder(n: NumberValue, d: NumberValue) {
-    return F(n.numberValue() % d.numberValue());
+    return 𝔽(ℝ(n) % ℝ(d));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-add */
   static add(x: NumberValue, y: NumberValue) {
-    return F(x.numberValue() + y.numberValue());
+    return 𝔽(ℝ(x) + ℝ(y));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-subtract */
   static subtract(x: NumberValue, y: NumberValue) {
     // The result of - operator is x + (-y).
-    return NumberValue.add(x, F(-y.numberValue()));
+    return NumberValue.add(x, 𝔽(-ℝ(y)));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-leftShift */
@@ -221,9 +221,9 @@ export class NumberValue extends PrimitiveValue {
     // 2. Let rnum be ! ToUint32(y).
     const rnum = X(ToUint32(y));
     // 3. Let shiftCount be the result of masking out all but the least significant 5 bits of rnum, that is, compute rnum & 0x1F.
-    const shiftCount = rnum.numberValue() & 0x1F; // eslint-disable-line no-bitwise
+    const shiftCount = ℝ(rnum) & 0x1F; // eslint-disable-line no-bitwise
     // 4. Return the result of left shifting lnum by shiftCount bits. The result is a signed 32-bit integer.
-    return F(lnum.numberValue() << shiftCount); // eslint-disable-line no-bitwise
+    return 𝔽(ℝ(lnum) << shiftCount); // eslint-disable-line no-bitwise
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-signedRightShift */
@@ -233,10 +233,10 @@ export class NumberValue extends PrimitiveValue {
     // 2. Let rnum be ! ToUint32(y).
     const rnum = X(ToUint32(y));
     // 3. Let shiftCount be the result of masking out all but the least significant 5 bits of rnum, that is, compute rnum & 0x1F.
-    const shiftCount = rnum.numberValue() & 0x1F; // eslint-disable-line no-bitwise
+    const shiftCount = ℝ(rnum) & 0x1F; // eslint-disable-line no-bitwise
     // 4. Return the result of performing a sign-extending right shift of lnum by shiftCount bits.
     //    The most significant bit is propagated. The result is a signed 32-bit integer.
-    return F(lnum.numberValue() >> shiftCount); // eslint-disable-line no-bitwise
+    return 𝔽(ℝ(lnum) >> shiftCount); // eslint-disable-line no-bitwise
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-unsignedRightShift */
@@ -246,10 +246,10 @@ export class NumberValue extends PrimitiveValue {
     // 2. Let rnum be ! ToUint32(y).
     const rnum = X(ToUint32(y));
     // 3. Let shiftCount be the result of masking out all but the least significant 5 bits of rnum, that is, compute rnum & 0x1F.
-    const shiftCount = rnum.numberValue() & 0x1F; // eslint-disable-line no-bitwise
+    const shiftCount = ℝ(rnum) & 0x1F; // eslint-disable-line no-bitwise
     // 4. Return the result of performing a zero-filling right shift of lnum by shiftCount bits.
     //    Vacated bits are filled with zero. The result is an unsigned 32-bit integer.
-    return F(lnum.numberValue() >>> shiftCount); // eslint-disable-line no-bitwise
+    return 𝔽(ℝ(lnum) >>> shiftCount); // eslint-disable-line no-bitwise
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-lessThan */
@@ -263,22 +263,22 @@ export class NumberValue extends PrimitiveValue {
     // If nx and ny are the same Number value, return false.
     // If nx is +0 and ny is -0, return false.
     // If nx is -0 and ny is +0, return false.
-    if (x.numberValue() === y.numberValue()) {
+    if (ℝ(x) === ℝ(y)) {
       return Value.false;
     }
-    if (x.numberValue() === +Infinity) {
+    if (ℝ(x) === +Infinity) {
       return Value.false;
     }
-    if (y.numberValue() === +Infinity) {
+    if (ℝ(y) === +Infinity) {
       return Value.true;
     }
-    if (y.numberValue() === -Infinity) {
+    if (ℝ(y) === -Infinity) {
       return Value.false;
     }
-    if (x.numberValue() === -Infinity) {
+    if (ℝ(x) === -Infinity) {
       return Value.true;
     }
-    return x.numberValue() < y.numberValue() ? Value.true : Value.false;
+    return ℝ(x) < ℝ(y) ? Value.true : Value.false;
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-number-equal */
@@ -289,8 +289,8 @@ export class NumberValue extends PrimitiveValue {
     if (y.isNaN()) {
       return Value.false;
     }
-    const xVal = x.numberValue();
-    const yVal = y.numberValue();
+    const xVal = ℝ(x);
+    const yVal = ℝ(y);
     if (xVal === yVal) {
       return Value.true;
     }
@@ -308,8 +308,8 @@ export class NumberValue extends PrimitiveValue {
     if (x.isNaN() && y.isNaN()) {
       return Value.true;
     }
-    const xVal = x.numberValue();
-    const yVal = y.numberValue();
+    const xVal = ℝ(x);
+    const yVal = ℝ(y);
     if (Object.is(xVal, 0) && Object.is(yVal, -0)) {
       return Value.false;
     }
@@ -327,8 +327,8 @@ export class NumberValue extends PrimitiveValue {
     if (x.isNaN() && y.isNaN()) {
       return Value.true;
     }
-    const xVal = x.numberValue();
-    const yVal = y.numberValue();
+    const xVal = ℝ(x);
+    const yVal = ℝ(y);
     if (Object.is(xVal, 0) && Object.is(yVal, -0)) {
       return Value.true;
     }
@@ -364,12 +364,12 @@ export class NumberValue extends PrimitiveValue {
     if (x.isNaN()) {
       return Value('NaN');
     }
-    const xVal = x.numberValue();
+    const xVal = ℝ(x);
     if (xVal === 0) {
       return Value('0');
     }
     if (xVal < 0) {
-      const str = X(NumberValue.toString(F(-xVal))).stringValue();
+      const str = X(NumberValue.toString(𝔽(-xVal))).stringValue();
       return Value(`-${str}`);
     }
     if (x.isInfinity()) {
@@ -391,11 +391,11 @@ function NumberBitwiseOp(op: '&' | '|' | '^', x: NumberValue, y: NumberValue) {
   // 3. Return the result of applying the bitwise operator op to lnum and rnum. The result is a signed 32-bit integer.
   switch (op) {
     case '&':
-      return F(lnum.numberValue() & rnum.numberValue());
+      return 𝔽(ℝ(lnum) & ℝ(rnum));
     case '|':
-      return F(lnum.numberValue() | rnum.numberValue());
+      return 𝔽(ℝ(lnum) | ℝ(rnum));
     case '^':
-      return F(lnum.numberValue() ^ rnum.numberValue());
+      return 𝔽(ℝ(lnum) ^ ℝ(rnum));
     default:
       throw new OutOfRange('NumberBitwiseOp', op);
   }
@@ -423,86 +423,86 @@ export class BigIntValue extends PrimitiveValue {
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-unaryMinus */
   static unaryMinus(x: BigIntValue) {
-    if (x.bigintValue() === 0n) {
-      return Z(0n);
+    if (ℝ(x) === 0n) {
+      return ℤ(0n);
     }
-    return Z(-x.bigintValue());
+    return ℤ(-ℝ(x));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-bitwiseNOT */
   static bitwiseNOT(x: BigIntValue) {
-    return Z(-x.bigintValue() - 1n);
+    return ℤ(-ℝ(x) - 1n);
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-exponentiate */
   static exponentiate(base: BigIntValue, exponent: BigIntValue) {
     // 1. If exponent < 0n, throw a RangeError exception.
-    if (exponent.bigintValue() < 0n) {
+    if (ℝ(exponent) < 0n) {
       return surroundingAgent.Throw('RangeError', 'BigIntNegativeExponent');
     }
     // 2. If base is 0n and exponent is 0n, return 1n.
-    if (base.bigintValue() === 0n && exponent.bigintValue() === 0n) {
-      return Z(1n);
+    if (ℝ(base) === 0n && ℝ(exponent) === 0n) {
+      return ℤ(1n);
     }
     // 3. Return the BigInt value that represents the mathematical value of base raised to the power exponent.
-    return Z(base.bigintValue() ** exponent.bigintValue());
+    return ℤ(ℝ(base) ** ℝ(exponent));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-multiply */
   static multiply(x: BigIntValue, y: BigIntValue) {
-    return Z(x.bigintValue() * y.bigintValue());
+    return ℤ(ℝ(x) * ℝ(y));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-divide */
   static divide(x: BigIntValue, y: BigIntValue) {
     // 1. If y is 0n, throw a RangeError exception.
-    if (y.bigintValue() === 0n) {
+    if (ℝ(y) === 0n) {
       return surroundingAgent.Throw('RangeError', 'BigIntDivideByZero');
     }
     // 2. Let quotient be the mathematical value of x divided by y.
-    const quotient = x.bigintValue() / y.bigintValue();
+    const quotient = ℝ(x) / ℝ(y);
     // 3. Return the BigInt value that represents quotient rounded towards 0 to the next integral value.
-    return Z(quotient);
+    return ℤ(quotient);
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-remainder */
   static remainder(n: BigIntValue, d: BigIntValue) {
     // 1. If d is 0n, throw a RangeError exception.
-    if (d.bigintValue() === 0n) {
+    if (ℝ(d) === 0n) {
       return surroundingAgent.Throw('RangeError', 'BigIntDivideByZero');
     }
     // 2. If n is 0n, return 0n.
-    if (n.bigintValue() === 0n) {
-      return Z(0n);
+    if (ℝ(n) === 0n) {
+      return ℤ(0n);
     }
     // 3. Let r be the BigInt defined by the mathematical relation r = n - (d × q)
     //   where q is a BigInt that is negative only if n/d is negative and positive
     //   only if n/d is positive, and whose magnitude is as large as possible without
     //   exceeding the magnitude of the true mathematical quotient of n and d.
-    const r = Z(n.bigintValue() % d.bigintValue());
+    const r = ℤ(ℝ(n) % ℝ(d));
     // 4. Return r.
     return r;
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-add */
   static add(x: BigIntValue, y: BigIntValue) {
-    return Z(x.bigintValue() + y.bigintValue());
+    return ℤ(ℝ(x) + ℝ(y));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-subtract */
   static subtract(x: BigIntValue, y: BigIntValue) {
-    return Z(x.bigintValue() - y.bigintValue());
+    return ℤ(ℝ(x) - ℝ(y));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-leftShift */
   static leftShift(x: BigIntValue, y: BigIntValue) {
-    return Z(x.bigintValue() << y.bigintValue()); // eslint-disable-line no-bitwise
+    return ℤ(ℝ(x) << ℝ(y)); // eslint-disable-line no-bitwise
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-signedRightShift */
   static signedRightShift(x: BigIntValue, y: BigIntValue) {
     // 1. Return BigInt::leftShift(x, -y).
-    return BigIntValue.leftShift(x, Z(-y.bigintValue()));
+    return BigIntValue.leftShift(x, ℤ(-ℝ(y)));
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-unsignedRightShift */
@@ -512,13 +512,13 @@ export class BigIntValue extends PrimitiveValue {
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-lessThan */
   static lessThan(x: BigIntValue, y: BigIntValue) {
-    return x.bigintValue() < y.bigintValue() ? Value.true : Value.false;
+    return ℝ(x) < ℝ(y) ? Value.true : Value.false;
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-equal */
   static equal(x: BigIntValue, y: BigIntValue) {
     // Return true if x and y have the same mathematical integer value and false otherwise.
-    return x.bigintValue() === y.bigintValue() ? Value.true : Value.false;
+    return ℝ(x) === ℝ(y) ? Value.true : Value.false;
   }
 
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-sameValue */
@@ -554,12 +554,12 @@ export class BigIntValue extends PrimitiveValue {
   /** https://tc39.es/ecma262/#sec-numeric-types-bigint-tostring */
   static override toString(x: BigIntValue): StringValue {
     // 1. If x is less than zero, return the string-concatenation of the String "-" and ! BigInt::toString(-x).
-    if (x.bigintValue() < 0n) {
-      const str = X(BigIntValue.toString(Z(-x.bigintValue()))).stringValue();
+    if (ℝ(x) < 0n) {
+      const str = X(BigIntValue.toString(ℤ(-ℝ(x)))).stringValue();
       return Value(`-${str}`);
     }
     // 2. Return the String value consisting of the code units of the digits of the decimal representation of x.
-    return Value(`${x.bigintValue()}`);
+    return Value(`${ℝ(x)}`);
   }
 
   static readonly unit = new BigIntValue(1n);
@@ -672,11 +672,11 @@ function BigIntBitwiseOp(op: '&' | '|' | '^', x: BigIntValue, y: BigIntValue) {
  */
   switch (op) {
     case '&':
-      return Z(x.bigintValue() & y.bigintValue());
+      return ℤ(ℝ(x) & ℝ(y));
     case '|':
-      return Z(x.bigintValue() | y.bigintValue());
+      return ℤ(ℝ(x) | ℝ(y));
     case '^':
-      return Z(x.bigintValue() ^ y.bigintValue());
+      return ℤ(ℝ(x) ^ ℝ(y));
     default:
       throw new OutOfRange('BigIntBitwiseOp', op);
   }

--- a/test/eslint-plugin-engine262/bigint-value.js
+++ b/test/eslint-plugin-engine262/bigint-value.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      ImportSpecifier(node) {
+        if (node.imported.name === 'Z') {
+          context.report({
+            node,
+            message: 'Use ℤ, not Z, to get a BigIntValue',
+            fix(fixer) {
+              return fixer.replaceText(node.imported, 'ℤ');
+            },
+          });
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'Z') {
+          context.report({
+            node: node.callee,
+            message: 'Use ℤ, not Z, to get a BigIntValue',
+            fix(fixer) {
+              return fixer.replaceText(node.callee, 'ℤ');
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/test/eslint-plugin-engine262/index.js
+++ b/test/eslint-plugin-engine262/index.js
@@ -5,5 +5,8 @@ module.exports = {
     'no-use-in-def': require('./no-use-in-def'),
     'valid-feature': require('./valid-feature'),
     'valid-throw': require('./valid-throw'),
+    'number-value': require('./number-value'),
+    'bigint-value': require('./bigint-value'),
+    'mathematical-value': require('./mathematical-value'),
   },
 };

--- a/test/eslint-plugin-engine262/mathematical-value.js
+++ b/test/eslint-plugin-engine262/mathematical-value.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const path = require('node:path');
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    fixable: 'code',
+    hasSuggestions: true,
+  },
+  create(context) {
+    const pathToAbstractOps = `${path.resolve(context.cwd, 'src/abstract-ops').replaceAll('\\', '/')}/`;
+    const pathToSpecTypesModule = path.resolve(pathToAbstractOps, 'spec-types.mjs').replaceAll('\\', '/');
+    const pathToAllModule = path.resolve(pathToAbstractOps, 'all.mjs').replaceAll('\\', '/');
+    /** @type {import('estree').ImportSpecifier | undefined} */
+    let importSpecifierForR;
+    /** @type {import('estree').ImportSpecifier | undefined} */
+    let importSpecifierForℝ;
+    /** @type {import('estree').ImportDeclaration | undefined} */
+    let importForAllModule;
+    /** @type {import('estree').ImportDeclaration | undefined} */
+    let importForSpecTypesModule;
+    /** @type {import('estree').ImportDeclaration | undefined} */
+    let lastImport;
+    /** @type {import('estree').Node | undefined} */
+    let needsImportForℝ;
+    return {
+      Program() {
+        importSpecifierForR = undefined;
+        importSpecifierForℝ = undefined;
+        importForAllModule = undefined;
+        importForSpecTypesModule = undefined;
+        lastImport = undefined;
+        needsImportForℝ = undefined;
+      },
+      'Program:exit': function Program_exit() {
+        if (needsImportForℝ && !importSpecifierForℝ) {
+          if (importSpecifierForR) {
+            context.report({
+              node: needsImportForℝ,
+              message: 'Import ℝ, not R, to convert mathematical values',
+              fix(fixer) {
+                return fixer.replaceText(importSpecifierForR.imported, 'ℝ');
+              },
+            });
+          } else if (importForSpecTypesModule) {
+            context.report({
+              node: needsImportForℝ,
+              message: 'Import ℝ to convert mathematical values',
+              * fix(fixer) {
+                const last = importForSpecTypesModule.specifiers.at(-1);
+                yield fixer.insertTextAfter(last, ', ℝ');
+              },
+            });
+          } else if (importForAllModule) {
+            context.report({
+              node: needsImportForℝ,
+              message: 'Import ℝ to convert mathematical values',
+              * fix(fixer) {
+                const last = importForAllModule.specifiers.at(-1);
+                yield fixer.insertTextAfter(last, ', ℝ');
+              },
+            });
+          } else {
+            const filename = path.resolve(context.filename).replaceAll('\\', '/');
+            let relativePath;
+            if (filename.startsWith(pathToAbstractOps)) {
+              relativePath = path.relative(path.dirname(filename), pathToSpecTypesModule).replaceAll('\\', '/');
+            } else {
+              relativePath = path.relative(path.dirname(filename), pathToAllModule).replaceAll('\\', '/');
+            }
+            if (!path.isAbsolute(relativePath)
+              && !relativePath.startsWith('../')
+              && !relativePath.startsWith('./')) {
+              relativePath = `./${relativePath}`;
+            }
+            if (lastImport) {
+              context.report({
+                node: needsImportForℝ,
+                message: 'Import ℝ to convert mathematical values',
+                * fix(fixer) {
+                  yield fixer.insertTextAfter(lastImport, `\nimport { ℝ } from ${JSON.stringify(relativePath)};`);
+                },
+              });
+            } else {
+              context.report({
+                node: needsImportForℝ,
+                message: 'Import ℝ to convert mathematical values',
+                * fix(fixer) {
+                  yield fixer.insertTextAfterRange([0, 0], `import { ℝ } from ${JSON.stringify(relativePath)};\n`);
+                },
+              });
+            }
+          }
+        }
+      },
+      ImportDeclaration(node) {
+        lastImport = node;
+        const importPath = path.resolve(path.dirname(context.filename), node.source.value).replaceAll('\\', '/');
+        if (importPath === pathToAllModule) {
+          importForAllModule = node;
+        } else if (importPath === pathToSpecTypesModule) {
+          importForSpecTypesModule = node;
+        }
+      },
+      ImportSpecifier(node) {
+        if (node.imported.name === 'R') {
+          importSpecifierForR = node;
+        } else if (node.imported.name === 'ℝ') {
+          importSpecifierForℝ = node;
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'R') {
+          /** @type {import('eslint').Rule.ReportFixer} */
+          const fix = function* fix(fixer) {
+            yield fixer.replaceText(node.callee, 'ℝ');
+          };
+
+          context.report({
+            node: node.callee,
+            message: 'Use ℝ, not R, to get a mathematical value',
+            fix: importSpecifierForℝ ? fix : undefined,
+          });
+
+          needsImportForℝ ??= node.callee;
+        }
+
+        if (node.callee.type === 'MemberExpression'
+          && node.callee.computed === false
+          && node.callee.property.type === 'Identifier') {
+          if (node.callee.property.name === 'numberValue') {
+            /** @type {import('eslint').Rule.ReportFixer} */
+            const fix = function* fix(fixer) {
+              //    foo.numberValue()
+              // -> foo
+              yield fixer.removeRange([node.callee.object.range[1], node.range[1]]);
+
+              //    foo
+              // -> ℝ(foo)
+              yield fixer.insertTextBefore(node, 'ℝ(');
+              yield fixer.insertTextAfter(node, ')');
+            };
+
+            context.report({
+              node: node.callee,
+              message: 'Use ℝ, not .numberValue(), to get a mathematical value',
+              fix: importSpecifierForℝ ? fix : undefined,
+            });
+
+            needsImportForℝ ??= node.callee;
+          }
+
+          if (node.callee.property.name === 'bigintValue') {
+            /** @type {import('eslint').Rule.ReportFixer} */
+            const fix = function* fix(fixer) {
+              //    foo.bigintValue()
+              // -> foo
+              yield fixer.removeRange([node.callee.object.range[1], node.range[1]]);
+
+              //    foo
+              // -> ℝ(foo)
+              yield fixer.insertTextBefore(node, 'ℝ(');
+              yield fixer.insertTextAfter(node, ')');
+            };
+
+            context.report({
+              node: node.callee,
+              message: 'Use ℝ, not .bigintValue(), to get a mathematical value',
+              fix: importSpecifierForℝ ? fix : undefined,
+            });
+
+            needsImportForℝ ??= node.callee;
+          }
+        }
+      },
+    };
+  },
+};

--- a/test/eslint-plugin-engine262/number-value.js
+++ b/test/eslint-plugin-engine262/number-value.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      ImportSpecifier(node) {
+        if (node.imported.name === 'F') {
+          context.report({
+            node,
+            message: 'Use 𝔽, not F, to get a NumberValue',
+            fix(fixer) {
+              return fixer.replaceText(node.imported, '𝔽');
+            },
+          });
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'F') {
+          context.report({
+            node: node.callee,
+            message: 'Use 𝔽, not F, to get a NumberValue',
+            fix(fixer) {
+              return fixer.replaceText(node.callee, '𝔽');
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/test/supplemental.js
+++ b/test/supplemental.js
@@ -33,7 +33,7 @@ const { total, pass, fail } = require('./base');
     setSurroundingAgent(agent);
     const realm = new ManagedRealm();
     const result = realm.evaluateScript('debugger;');
-    assert.strictEqual(result.Value.numberValue(), 42);
+    assert.strictEqual(result.Value.numberValue(), 42); // eslint-disable-line @engine262/mathematical-value
   },
   () => {
     const agent = new Agent();


### PR DESCRIPTION
For consistency with the spec, this adds `𝔽` and `Z` as aliases for `F` and `Z`, respectively, and adds both an `R` and `ℝ` shorthand to read the "mathematical value" of a `Number` or `BigInt`.

This also adds lint rules to point out when you should use `𝔽`, `Z`, and `ℝ` instead of their ASCII counterparts, as well as automatic fixes to replace `F`, `Z`, and `R` for you so that you don't have to hunt for the Unicode characters when developing and can just use `npm run lint:fix` to swap them to the Unicode characters.