### PR TITLE
Refactor completions into a discriminated union

### DIFF
--- a/src/abstract-ops/notational-conventions.mts
+++ b/src/abstract-ops/notational-conventions.mts
@@ -13,7 +13,7 @@ export function Assert(invariant: boolean, source?: string): asserts invariant {
 }
 
 /** https://tc39.es/ecma262/#sec-requireinternalslot */
-export function RequireInternalSlot(O: Value, internalSlot: string): ThrowCompletion<ObjectValue> | undefined {
+export function RequireInternalSlot(O: Value, internalSlot: string): ThrowCompletion | undefined {
   if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', O);
   }

--- a/test/eslint-plugin-engine262/no-use-in-def.js
+++ b/test/eslint-plugin-engine262/no-use-in-def.js
@@ -19,6 +19,9 @@ function isUsedInDef(reference) {
   const location = reference.identifier.range[1];
 
   while (node) {
+    if (node.type === 'TSTypeParameter') {
+      return false;
+    }
     if (node.type === 'VariableDeclarator') {
       if (isInRange(node.init, location)) {
         return true;


### PR DESCRIPTION
This refactors `Completion` and subtypes into a discriminated union. In addition, rather than patching in `instanceof` support via `[Symbol.hasInstance]`, this just creates a distinct subclass for each completion type and uses `new.target` in the constructor of `Completion` to create the appropriate subtype. 

For all `Completion` subclasses, the constructors are marked `private` to indicate that they shouldn't be created, but still allows `instanceof` to work correctly in TypeScript.

Also, completion operations such as `ReturnIfAbrupt`/`Q`, `X`, `UpdateIfEmpty`, and `EnsureCompletion` are given better types to handle more cases.