### PR TITLE
Refactor completions into a discriminated union (alt)

### DIFF
--- a/bin/test262_realm.js
+++ b/bin/test262_realm.js
@@ -11,7 +11,7 @@ const {
   ToString,
   Type,
   Throw,
-  AbruptCompletion,
+  isAbruptCompletion,
   ManagedRealm,
   inspect,
   gc,
@@ -83,7 +83,7 @@ const createRealm = ({ printCompatMode = false } = {}) => {
           for (let i = 0; i < args.length; i += 1) {
             const arg = args[i];
             const s = ToString(arg);
-            if (s instanceof AbruptCompletion) {
+            if (isAbruptCompletion(s)) {
               return s;
             }
             process.stdout.write(s.stringValue());

--- a/inspector/context.js
+++ b/inspector/context.js
@@ -142,13 +142,13 @@ class InspectorContext {
     let p = object;
     while (p !== engine262.Value.null) {
       const keys = p.OwnPropertyKeys();
-      if (keys instanceof engine262.AbruptCompletion) {
+      if (engine262.isAbruptCompletion(keys)) {
         return keys;
       }
 
       for (const key of keys) {
         const desc = p.GetOwnProperty(key);
-        if (desc instanceof engine262.AbruptCompletion) {
+        if (engine262.isAbruptCompletion(desc)) {
           return desc;
         }
         if (options.accessorPropertiesOnly && desc.Value) {
@@ -175,7 +175,7 @@ class InspectorContext {
         break;
       }
       p = p.GetPrototypeOf();
-      if (p instanceof engine262.AbruptCompletion) {
+      if (engine262.isAbruptCompletion(p)) {
         return p;
       }
     }
@@ -201,14 +201,14 @@ class InspectorContext {
     const wrap = (v) => this.toRemoteObject(v, options);
 
     const keys = object.OwnPropertyKeys();
-    if (keys instanceof engine262.AbruptCompletion) {
+    if (engine262.isAbruptCompletion(keys)) {
       return keys;
     }
 
     const properties = [];
     for (const key of keys) {
       const desc = object.GetOwnProperty(key);
-      if (desc instanceof engine262.AbruptCompletion) {
+      if (engine262.isAbruptCompletion(desc)) {
         return desc;
       }
       const descriptor = {
@@ -302,7 +302,7 @@ class InspectorContext {
   }
 
   createEvaluationResult(completion, options) {
-    if (completion instanceof engine262.AbruptCompletion) {
+    if (engine262.isAbruptCompletion(completion)) {
       return {
         exceptionDetails: {
           text: 'uh oh',

--- a/inspector/methods.js
+++ b/inspector/methods.js
@@ -67,7 +67,7 @@ module.exports = {
       const object = context.getObject(options.objectId);
 
       const properties = context.getProperties(object, options);
-      if (properties instanceof engine262.AbruptCompletion) {
+      if (engine262.isAbruptCompletion(properties)) {
         return context.createEvaluationResult(properties, options);
       }
 

--- a/scripts/transform.js
+++ b/scripts/transform.js
@@ -30,17 +30,17 @@ function getEnclosingConditionalExpression(path) {
 }
 
 module.exports = ({ types: t, template }) => {
-  function createImportCompletion(file) {
+  function createImportCompletionRecord(file) {
     const r = fileToImport(file, COMPLETION_PATH);
     return template.ast(`
-      import { Completion } from "${r}";
+      import { CompletionRecord } from "${r}";
     `);
   }
 
-  function createImportAbruptCompletion(file) {
+  function createImportIsAbruptCompletion(file) {
     const r = fileToImport(file, COMPLETION_PATH);
     return template.ast(`
-      import { AbruptCompletion } from "${r}";
+      import { isAbruptCompletion } from "${r}";
     `);
   }
 
@@ -93,56 +93,56 @@ module.exports = ({ types: t, template }) => {
       template: template(`
       let ID = ARGUMENT;
       /* c8 ignore if */
-      if (ID instanceof AbruptCompletion) {
+      if (isAbruptCompletion(ID)) {
         return ID;
       }
       /* c8 ignore if */
-      if (ID instanceof Completion) {
+      if (ID instanceof CompletionRecord) {
         ID = ID.Value;
       }
       `, { preserveComments: true }),
-      imports: ['AbruptCompletion', 'Completion'],
+      imports: ['isAbruptCompletion', 'CompletionRecord'],
     },
     X: {
       template: template(`
       let ID = ARGUMENT;
-      Assert(!(ID instanceof AbruptCompletion), SOURCE + ' returned an abrupt completion');
+      Assert(!isAbruptCompletion(ID), SOURCE + ' returned an abrupt completion');
       /* c8 ignore if */
-      if (ID instanceof Completion) {
+      if (ID instanceof CompletionRecord) {
         ID = ID.Value;
       }
       `, { preserveComments: true }),
-      imports: ['Assert', 'Completion', 'AbruptCompletion'],
+      imports: ['Assert', 'CompletionRecord', 'isAbruptCompletion'],
     },
     IfAbruptCloseIterator: {
       template: template(`
       /* c8 ignore if */
-      if (%%value%% instanceof AbruptCompletion) {
+      if (isAbruptCompletion(%%value%%)) {
         return IteratorClose(%%iteratorRecord%%, %%value%%);
       }
       /* c8 ignore if */
-      if (%%value%% instanceof Completion) {
+      if (%%value%% instanceof CompletionRecord) {
         %%value%% = %%value%%.Value;
       }
       `, { preserveComments: true }),
-      imports: ['IteratorClose', 'AbruptCompletion', 'Completion'],
+      imports: ['IteratorClose', 'isAbruptCompletion', 'CompletionRecord'],
     },
     IfAbruptRejectPromise: {
       template: template(`
       /* c8 ignore if */
-      if (ID instanceof AbruptCompletion) {
+      if (isAbruptCompletion(ID)) {
         const hygenicTemp2 = Call(CAPABILITY.Reject, Value.undefined, [ID.Value]);
-        if (hygenicTemp2 instanceof AbruptCompletion) {
+        if (isAbruptCompletion(hygenicTemp2)) {
           return hygenicTemp2;
         }
         return CAPABILITY.Promise;
       }
       /* c8 ignore if */
-      if (ID instanceof Completion) {
+      if (ID instanceof CompletionRecord) {
         ID = ID.Value;
       }
       `, { preserveComments: true }),
-      imports: ['Call', 'Value', 'AbruptCompletion', 'Completion'],
+      imports: ['Call', 'Value', 'isAbruptCompletion', 'CompletionRecord'],
     },
   };
   MACROS.ReturnIfAbrupt = MACROS.Q;
@@ -155,11 +155,11 @@ module.exports = ({ types: t, template }) => {
           state.needed = {};
         },
         exit(path, state) {
-          if (state.needed.Completion && !state.file.opts.filename.endsWith('completion.mjs')) {
-            path.node.body.unshift(createImportCompletion(state.file));
+          if (state.needed.CompletionRecord && !state.file.opts.filename.endsWith('completion.mjs')) {
+            path.node.body.unshift(createImportCompletionRecord(state.file));
           }
-          if (state.needed.AbruptCompletion && !state.file.opts.filename.endsWith('completion.mjs')) {
-            path.node.body.unshift(createImportAbruptCompletion(state.file));
+          if (state.needed.isAbruptCompletion && !state.file.opts.filename.endsWith('completion.mjs')) {
+            path.node.body.unshift(createImportIsAbruptCompletion(state.file));
           }
           if (state.needed.Assert) {
             path.node.body.unshift(createImportAssert(state.file));
@@ -224,11 +224,11 @@ module.exports = ({ types: t, template }) => {
             binding.path.parent.kind = 'let';
             statementPath.insertBefore(template(`
               /* c8 ignore if */
-              if (ID instanceof AbruptCompletion) {
+              if (isAbruptCompletion(ID)) {
                 return ID;
               }
               /* c8 ignore if */
-              if (ID instanceof Completion) {
+              if (ID instanceof CompletionRecord) {
                 ID = ID.Value;
               }
             `, { preserveComments: true })({ ID: argument }));

--- a/src/abstract-ops/async-generator-objects.mts
+++ b/src/abstract-ops/async-generator-objects.mts
@@ -6,8 +6,9 @@ import {
   Completion,
   EnsureCompletion,
   NormalCompletion,
-  AbruptCompletion,
   ThrowCompletion,
+  isAbruptCompletion,
+  CompletionRecord,
 } from '../completion.mjs';
 import { Evaluate } from '../evaluator.mjs';
 import { Value } from '../value.mjs';
@@ -180,7 +181,7 @@ export function AsyncGeneratorResume(generator, completion) {
   // 7. Resume the suspended evaluation of genContext using completion as the result of the operation that suspended it. Let result be the completion record returned by the resumed computation.
   const result = resume(genContext, completion);
   // 8. Assert: result is never an abrupt completion.
-  Assert(!(result instanceof AbruptCompletion));
+  Assert(!isAbruptCompletion(result));
   // 9. Assert: When we return here, genContext has already been removed from the execution context stack and callerContext is the currently running execution context.
   Assert(surroundingAgent.runningExecutionContext === callerContext);
 }
@@ -199,8 +200,8 @@ function* AsyncGeneratorUnwrapYieldResumption(resumptionValue) {
   }
   // 4. Assert: awaited.[[Type]] is normal.
   Assert(awaited.Type === 'normal');
-  // 5. Return Completion { [[Type]]: return, [[Value]]: awaited.[[Value]], [[Target]]: empty }.
-  return new Completion({ Type: 'return', Value: awaited.Value, Target: undefined });
+  // 5. Return Completion Record { [[Type]]: return, [[Value]]: awaited.[[Value]], [[Target]]: empty }.
+  return new CompletionRecord({ Type: 'return', Value: awaited.Value, Target: undefined });
 }
 
 /** https://tc39.es/ecma262/#sec-asyncgeneratoryield */

--- a/src/abstract-ops/function-operations.mts
+++ b/src/abstract-ops/function-operations.mts
@@ -14,10 +14,9 @@ import {
 import {
   EnsureCompletion,
   NormalCompletion,
-  AbruptCompletion,
   ReturnIfAbrupt,
   Completion,
-  Q, X,
+  Q, X, isAbruptCompletion,
 } from '../completion.mjs';
 import { ExpectedArgumentCount } from '../static-semantics/all.mjs';
 import { EvaluateBody } from '../runtime-semantics/all.mjs';
@@ -249,7 +248,7 @@ function FunctionConstructSlot(argumentsList, newTarget) {
     // b. Let initializeResult be InitializeInstanceElements(thisArgument, F).
     const initializeResult = InitializeInstanceElements(thisArgument, F);
     // c. If initializeResult is an abrupt completion, then
-    if (initializeResult instanceof AbruptCompletion) {
+    if (isAbruptCompletion(initializeResult)) {
       // i. Remove calleeContext from the execution context stack and restore callerContext as the running execution context.
       surroundingAgent.executionContextStack.pop(calleeContext);
       // ii. Return Completion(initializeResult).

--- a/src/abstract-ops/global-object.mts
+++ b/src/abstract-ops/global-object.mts
@@ -13,10 +13,9 @@ import {
 } from '../static-semantics/all.mjs';
 import {
   Completion,
-  AbruptCompletion,
   NormalCompletion,
   EnsureCompletion,
-  Q, X,
+  Q, X, isAbruptCompletion,
 } from '../completion.mjs';
 import { wrappedParse } from '../parse.mjs';
 import {
@@ -350,7 +349,7 @@ function EvalDeclarationInstantiation(body, varEnv, lexEnv, privateEnv, strict) 
         // 1. Let status be ! varEnv.CreateMutableBinding(fn, true).
         const status = X(varEnv.CreateMutableBinding(fn, Value.true));
         // 2. Assert: status is not an abrupt completion because of validation preceding step 12.
-        Assert(!(status instanceof AbruptCompletion));
+        Assert(!isAbruptCompletion(status));
         // 3. Perform ! varEnv.InitializeBinding(fn, fo).
         X(varEnv.InitializeBinding(fn, fo));
       } else { // iii. Else,
@@ -373,7 +372,7 @@ function EvalDeclarationInstantiation(body, varEnv, lexEnv, privateEnv, strict) 
         // 1. Let status be ! varEnv.CreateMutableBinding(vn, true).
         const status = X(varEnv.CreateMutableBinding(vn, Value.true));
         // 2. Assert: status is not an abrupt completion because of validation preceding step 12.
-        Assert(!(status instanceof AbruptCompletion));
+        Assert(!isAbruptCompletion(status));
         // 3. Perform ! varEnv.InitializeBinding(vn, undefined).
         X(varEnv.InitializeBinding(vn, Value.undefined));
       }

--- a/src/abstract-ops/import-calls.mts
+++ b/src/abstract-ops/import-calls.mts
@@ -5,12 +5,12 @@
 import {
   Call, GetModuleNamespace, PerformPromiseThen, Value,
 } from '../api.mjs';
-import { AbruptCompletion, X } from '../completion.mjs';
+import { isAbruptCompletion, X } from '../completion.mjs';
 
 /** https://tc39.es/ecma262/#sec-ContinueDynamicImport */
 export function ContinueDynamicImport(promiseCapability, moduleCompletion) {
   // 1. If moduleCompletion is an abrupt completion, then
-  if (moduleCompletion instanceof AbruptCompletion) {
+  if (isAbruptCompletion(moduleCompletion)) {
     // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « moduleCompletion.[[Value]] »).
     X(Call(promiseCapability.Reject, undefined, [moduleCompletion.Value]));
     // b. Return unused.
@@ -36,7 +36,7 @@ export function ContinueDynamicImport(promiseCapability, moduleCompletion) {
     // a. Let link be Completion(module.Link()).
     const link = module.Link();
     // b. If link is an abrupt completion, then
-    if (link instanceof AbruptCompletion) {
+    if (isAbruptCompletion(link)) {
       // i. Perform ! Call(promiseCapability.[[Reject]], undefined, « link.[[Value]] »).
       X(Call(promiseCapability.Reject, Value.undefined, [link.Value]));
       // ii. Return unused.

--- a/src/abstract-ops/iterator-operations.mts
+++ b/src/abstract-ops/iterator-operations.mts
@@ -13,6 +13,7 @@ import {
   Q, X,
   Await,
   NormalCompletion,
+  CompletionRecord,
 } from '../completion.mjs';
 import {
   Assert,
@@ -109,7 +110,7 @@ export function IteratorClose(iteratorRecord, completion) {
   // 2. Assert: completion is a Completion Record.
   // TODO: completion should be a Completion Record so this should not be necessary
   completion = EnsureCompletion(completion);
-  Assert(completion instanceof Completion);
+  Assert(completion instanceof CompletionRecord);
   // 3. Let iterator be iteratorRecord.[[Iterator]].
   const iterator = iteratorRecord.Iterator;
   // 4. Let innerResult be GetMethod(iterator, "return").
@@ -146,7 +147,7 @@ export function* AsyncIteratorClose(iteratorRecord, completion) {
   // 1. Assert: Type(iteratorRecord.[[Iterator]]) is Object.
   Assert(iteratorRecord.Iterator instanceof ObjectValue);
   // 2. Assert: completion is a Completion Record.
-  Assert(completion instanceof Completion);
+  Assert(completion instanceof CompletionRecord);
   // 3. Let iterator be iteratorRecord.[[Iterator]].
   const iterator = iteratorRecord.Iterator;
   // 4. Let innerResult be GetMethod(iterator, "return").

--- a/src/abstract-ops/module-records.mts
+++ b/src/abstract-ops/module-records.mts
@@ -7,7 +7,7 @@ import {
 } from '../modules.mjs';
 import { Value } from '../value.mjs';
 import {
-  Q, X, NormalCompletion, ThrowCompletion,
+  Q, X, NormalCompletion, ThrowCompletion, isNormalCompletion,
 } from '../completion.mjs';
 import {
   Assert,
@@ -95,7 +95,7 @@ export function ContinueModuleLoading(state, result) {
     return;
   }
   // 2. If moduleCompletion is a normal completion, then
-  if (result instanceof NormalCompletion) {
+  if (isNormalCompletion(result)) {
     // a. Perform InnerModuleLoading(state, moduleCompletion.[[Value]]).
     InnerModuleLoading(state, result.Value);
   // 3. Else,
@@ -300,7 +300,7 @@ function AsyncModuleExecutionFulfilled(module) {
         X(ExecuteAsyncModule(m));
       } else {
         const result = m.ExecuteModule();
-        if (result instanceof NormalCompletion) {
+        if (isNormalCompletion(result)) {
           X(AsyncModuleExecutionFulfilled(m));
         } else {
           X(AsyncModuleExecutionRejected(m, result.Value));

--- a/src/abstract-ops/notational-conventions.mts
+++ b/src/abstract-ops/notational-conventions.mts
@@ -13,7 +13,7 @@ export function Assert(invariant: boolean, source?: string): asserts invariant {
 }
 
 /** https://tc39.es/ecma262/#sec-requireinternalslot */
-export function RequireInternalSlot(O: Value, internalSlot: string): ThrowCompletion<ObjectValue> | undefined {
+export function RequireInternalSlot(O: Value, internalSlot: string): ThrowCompletion | undefined {
   if (!(O instanceof ObjectValue)) {
     return surroundingAgent.Throw('TypeError', 'NotAnObject', O);
   }

--- a/src/abstract-ops/promise-operations.mts
+++ b/src/abstract-ops/promise-operations.mts
@@ -11,6 +11,7 @@ import {
   Completion,
   EnsureCompletion,
   isAbruptCompletion,
+  isNormalCompletion,
   NormalCompletion,
   Q,
   ThrowCompletion,

--- a/src/abstract-ops/promise-operations.mts
+++ b/src/abstract-ops/promise-operations.mts
@@ -8,9 +8,9 @@ import {
 } from '../engine.mjs';
 import { ObjectValue, Value, UndefinedValue } from '../value.mjs';
 import {
-  AbruptCompletion,
   Completion,
   EnsureCompletion,
+  isAbruptCompletion,
   NormalCompletion,
   Q,
   ThrowCompletion,
@@ -116,7 +116,7 @@ function NewPromiseResolveThenableJob(promiseToResolve, thenable, then) {
     // b. Let thenCallResult be HostCallJobCallback(then, thenable, « resolvingFunctions.[[Resolve]], resolvingFunctions.[[Reject]] »).
     const thenCallResult = HostCallJobCallback(then, thenable, [resolvingFunctions.Resolve, resolvingFunctions.Reject]);
     // c. If thenCallResult is an abrupt completion, then
-    if (thenCallResult instanceof AbruptCompletion) {
+    if (isAbruptCompletion(thenCallResult)) {
       // i .Let status be Call(resolvingFunctions.[[Reject]], undefined, « thenCallResult.[[Value]] »).
       const status = Call(resolvingFunctions.Reject, Value.undefined, [thenCallResult.Value]);
       // ii. Return Completion(status).
@@ -129,7 +129,7 @@ function NewPromiseResolveThenableJob(promiseToResolve, thenable, then) {
   const getThenRealmResult = EnsureCompletion(GetFunctionRealm(then.Callback));
   // 3. If getThenRealmResult is a normal completion, then let thenRealm be getThenRealmResult.[[Value]].
   let thenRealm;
-  if (getThenRealmResult instanceof NormalCompletion) {
+  if (isNormalCompletion(getThenRealmResult)) {
     thenRealm = getThenRealmResult.Value;
   } else {
     // 4. Else, let _thenRealm_ be the current Realm Record.
@@ -171,7 +171,7 @@ function PromiseResolveFunctions([resolution = Value.undefined]) {
   // 9. Let then be Get(resolution, "then").
   const then = Get(resolution, Value('then'));
   // 10. If then is an abrupt completion, then
-  if (then instanceof AbruptCompletion) {
+  if (isAbruptCompletion(then)) {
     // a. Return RejectPromise(promise, then.[[Value]]).
     return RejectPromise(promise, then.Value);
   }
@@ -331,13 +331,13 @@ function NewPromiseReactionJob(reaction, argument) {
     // g. If promiseCapability is undefined, then
     if (promiseCapability === Value.undefined) {
       // i. Assert: handlerResult is not an abrupt completion.
-      Assert(!(handlerResult instanceof AbruptCompletion));
+      Assert(!isAbruptCompletion(handlerResult));
       // ii. Return NormalCompletion(empty).
       return NormalCompletion(undefined);
     }
     let status;
     // h. If handlerResult is an abrupt completion, then
-    if (handlerResult instanceof AbruptCompletion) {
+    if (isAbruptCompletion(handlerResult)) {
       // i. Let status be Call(promiseCapability.[[Reject]], undefined, « handlerResult.[[Value]] »).
       status = Call(promiseCapability.Reject, Value.undefined, [handlerResult.Value]);
     } else {
@@ -354,7 +354,7 @@ function NewPromiseReactionJob(reaction, argument) {
     // a. Let getHandlerRealmResult be GetFunctionRealm(reaction.[[Handler]].[[Callback]]).
     const getHandlerRealmResult = EnsureCompletion(GetFunctionRealm(reaction.Handler.Callback));
     // b. If getHandlerRealmResult is a normal completion, then set handlerRealm to getHandlerRealmResult.[[Value]].
-    if (getHandlerRealmResult instanceof NormalCompletion) {
+    if (isNormalCompletion(getHandlerRealmResult)) {
       handlerRealm = getHandlerRealmResult.Value;
     } else {
       // c. Else, set _handlerRealm_ to the current Realm Record.

--- a/src/api.mts
+++ b/src/api.mts
@@ -9,8 +9,8 @@ import {
 import {
   X,
   ThrowCompletion,
-  AbruptCompletion,
   EnsureCompletion,
+  isAbruptCompletion,
 } from './completion.mjs';
 import {
   Realm,
@@ -237,7 +237,7 @@ export class ManagedRealm extends Realm {
       });
     });
 
-    if (!(res instanceof AbruptCompletion)) {
+    if (!isAbruptCompletion(res)) {
       runJobQueue();
     }
 
@@ -278,7 +278,7 @@ export class ManagedRealm extends Realm {
 class ManagedSourceTextModuleRecord extends SourceTextModuleRecord {
   Evaluate() {
     const r = super.Evaluate();
-    if (!(r instanceof AbruptCompletion)) {
+    if (!isAbruptCompletion(r)) {
       runJobQueue();
     }
     return r;

--- a/src/completion.mts
+++ b/src/completion.mts
@@ -56,9 +56,9 @@ type CompletionInit<T> =
 
 /** https://tc39.es/ecma262/#sec-completion-record-specification-type */
 export class CompletionRecord<C extends CompletionInit<any>> {
-  readonly Type: C["Type"];
-  readonly Value: C["Value"];
-  readonly Target: C["Target"];
+  readonly Type: C['Type'];
+  readonly Value: C['Value'];
+  readonly Target: C['Target'];
 
   constructor(init: C) {
     this.Type = init.Type;

--- a/src/completion.mts
+++ b/src/completion.mts
@@ -131,6 +131,9 @@ export function Completion<T extends Completion<unknown>>(completionRecord: T): 
   return completionRecord;
 }
 
+/** @deprecated Use `value instanceof CompletionRecord` instead of `value instanceof Completion` */
+Object.defineProperty(Completion, Symbol.hasInstance, { configurable: true, value: (value: unknown) => value instanceof CompletionRecord });
+
 /**
  * https://tc39.es/ecma262/#sec-completion-record-specification-type
  *

--- a/src/intrinsics/AsyncGeneratorFunctionPrototypePrototype.mts
+++ b/src/intrinsics/AsyncGeneratorFunctionPrototypePrototype.mts
@@ -2,10 +2,10 @@
 import { surroundingAgent } from '../engine.mjs';
 import {
   X,
-  Completion,
   NormalCompletion,
   ThrowCompletion,
   IfAbruptRejectPromise,
+  CompletionRecord,
 } from '../completion.mjs';
 import { Value } from '../value.mjs';
 import {
@@ -67,8 +67,8 @@ function AsyncGeneratorPrototype_return([value = Value.undefined], { thisValue }
   const result = AsyncGeneratorValidate(generator, undefined);
   // 4. IfAbruptRejectPromise(result, promiseCapability).
   IfAbruptRejectPromise(result, promiseCapability);
-  // 5. Let completion be Completion { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
-  const completion = new Completion({ Type: 'return', Value: value, Target: undefined });
+  // 5. Let completion be Completion Record { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
+  const completion = new CompletionRecord({ Type: 'return', Value: value, Target: undefined });
   // 6. Perform ! AsyncGeneratorEnqueue(generator, completion, promiseCapability).
   X(AsyncGeneratorEnqueue(generator, completion, promiseCapability));
   // 7. Let state be generator.[[AsyncGeneratorState]].

--- a/src/intrinsics/Date.mts
+++ b/src/intrinsics/Date.mts
@@ -15,7 +15,7 @@ import {
 } from '../abstract-ops/all.mjs';
 import { Value, JSStringValue, ObjectValue } from '../value.mjs';
 import {
-  AbruptCompletion,
+  isAbruptCompletion,
   Q, X,
 } from '../completion.mjs';
 import { bootstrapConstructor } from './bootstrap.mjs';
@@ -127,7 +127,7 @@ function Date_now() {
 /** https://tc39.es/ecma262/#sec-date.parse */
 function Date_parse([string = Value.undefined]) {
   const str = ToString(string);
-  if (str instanceof AbruptCompletion) {
+  if (isAbruptCompletion(str)) {
     return str;
   }
   return parseDate(str);

--- a/src/intrinsics/GeneratorFunctionPrototypePrototype.mts
+++ b/src/intrinsics/GeneratorFunctionPrototypePrototype.mts
@@ -4,9 +4,9 @@ import {
   GeneratorResumeAbrupt,
 } from '../abstract-ops/all.mjs';
 import {
-  Completion,
   ThrowCompletion,
   Q,
+  CompletionRecord,
 } from '../completion.mjs';
 import { Value } from '../value.mjs';
 import { bootstrapPrototype } from './bootstrap.mjs';
@@ -23,8 +23,8 @@ function GeneratorProto_next([value = Value.undefined], { thisValue }) {
 function GeneratorProto_return([value = Value.undefined], { thisValue }) {
   // 1. Let g be the this value.
   const g = thisValue;
-  // 2. Let C be Completion { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
-  const C = new Completion({ Type: 'return', Value: value, Target: undefined });
+  // 2. Let C be Completion Record { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
+  const C = new CompletionRecord({ Type: 'return', Value: value, Target: undefined });
   // 3. Return ? GeneratorResumeAbrupt(g, C, empty).
   return Q(GeneratorResumeAbrupt(g, C, undefined));
 }

--- a/src/intrinsics/Promise.mts
+++ b/src/intrinsics/Promise.mts
@@ -31,12 +31,12 @@ import {
   PromiseResolve,
 } from '../abstract-ops/all.mjs';
 import {
-  AbruptCompletion, Completion,
+  Completion,
   ThrowCompletion,
   IfAbruptRejectPromise,
   ReturnIfAbrupt,
   EnsureCompletion,
-  Q, X,
+  Q, X, isAbruptCompletion,
 } from '../completion.mjs';
 import { bootstrapConstructor } from './bootstrap.mjs';
 
@@ -73,7 +73,7 @@ function PromiseConstructor([executor = Value.undefined], { NewTarget }) {
     resolvingFunctions.Resolve, resolvingFunctions.Reject,
   ]);
   // 10. If completion is an abrupt completion, then
-  if (completion instanceof AbruptCompletion) {
+  if (isAbruptCompletion(completion)) {
     // a. Perform ? Call(resolvingFunctions.[[Reject]], undefined, « completion.[[Value]] »).
     Q(Call(resolvingFunctions.Reject, Value.undefined, [completion.Value]));
   }
@@ -135,7 +135,7 @@ function PerformPromiseAll(iteratorRecord, constructor, resultCapability, promis
     // a. Let next be IteratorStep(iteratorRecord).
     const next = IteratorStep(iteratorRecord);
     // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (next instanceof AbruptCompletion) {
+    if (isAbruptCompletion(next)) {
       iteratorRecord.Done = Value.true;
     }
     // c. ReturnIfAbrupt(next).
@@ -159,7 +159,7 @@ function PerformPromiseAll(iteratorRecord, constructor, resultCapability, promis
     // e. Let nextValue be IteratorValue(next).
     const nextValue = IteratorValue(next);
     // f. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (nextValue instanceof AbruptCompletion) {
+    if (isAbruptCompletion(nextValue)) {
       iteratorRecord.Done = Value.true;
     }
     // g. ReturnIfAbrupt(nextValue).
@@ -212,7 +212,7 @@ function Promise_all([iterable = Value.undefined], { thisValue }) {
   // 7. Let result be PerformPromiseAll(iteratorRecord, C, promiseCapability, promiseResolve).
   let result = EnsureCompletion(PerformPromiseAll(iteratorRecord, C, promiseCapability, promiseResolve));
   // 8. If result is an abrupt completion, then
-  if (result instanceof AbruptCompletion) {
+  if (isAbruptCompletion(result)) {
     // a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
     if (iteratorRecord.Done === Value.false) {
       result = IteratorClose(iteratorRecord, result);
@@ -289,7 +289,7 @@ function PerformPromiseAllSettled(iteratorRecord, constructor, resultCapability,
     // a. Let next be IteratorStep(iteratorRecord).
     const next = IteratorStep(iteratorRecord);
     // b. Let next be IteratorStep(iteratorRecord).
-    if (next instanceof AbruptCompletion) {
+    if (isAbruptCompletion(next)) {
       iteratorRecord.Done = Value.true;
     }
     // c. ReturnIfAbrupt(next).
@@ -313,7 +313,7 @@ function PerformPromiseAllSettled(iteratorRecord, constructor, resultCapability,
     // e. Let nextValue be IteratorValue(next).
     const nextValue = IteratorValue(next);
     // f. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (nextValue instanceof AbruptCompletion) {
+    if (isAbruptCompletion(nextValue)) {
       iteratorRecord.Done = Value.true;
     }
     // g. ReturnIfAbrupt(nextValue).
@@ -394,7 +394,7 @@ function Promise_allSettled([iterable = Value.undefined], { thisValue }) {
   // 7. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability, promiseResolve).
   let result = EnsureCompletion(PerformPromiseAllSettled(iteratorRecord, C, promiseCapability, promiseResolve));
   // 8. If result is an abrupt completion, then
-  if (result instanceof AbruptCompletion) {
+  if (isAbruptCompletion(result)) {
     // a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
     if (iteratorRecord.Done === Value.false) {
       result = IteratorClose(iteratorRecord, result);
@@ -467,7 +467,7 @@ function PerformPromiseAny(iteratorRecord, constructor, resultCapability, promis
     // a. Let next be IteratorStep(iteratorRecord).
     const next = IteratorStep(iteratorRecord);
     // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (next instanceof AbruptCompletion) {
+    if (isAbruptCompletion(next)) {
       iteratorRecord.Done = Value.true;
     }
     // c. ReturnIfAbrupt(next).
@@ -498,7 +498,7 @@ function PerformPromiseAny(iteratorRecord, constructor, resultCapability, promis
     // e. Let nextValue be IteratorValue(next).
     const nextValue = IteratorValue(next);
     // f. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (nextValue instanceof AbruptCompletion) {
+    if (isAbruptCompletion(nextValue)) {
       iteratorRecord.Done = Value.true;
     }
     // g. ReturnIfAbrupt(nextValue).
@@ -549,7 +549,7 @@ function Promise_any([iterable = Value.undefined], { thisValue }) {
   // 7. Let result be PerformPromiseAny(iteratorRecord, C, promiseCapability).
   let result = EnsureCompletion(PerformPromiseAny(iteratorRecord, C, promiseCapability, promiseResolve));
   // 8. If result is an abrupt completion, then
-  if (result instanceof AbruptCompletion) {
+  if (isAbruptCompletion(result)) {
     // a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
     if (iteratorRecord.Done === Value.false) {
       result = IteratorClose(iteratorRecord, result);
@@ -573,7 +573,7 @@ function PerformPromiseRace(iteratorRecord, constructor, resultCapability, promi
     // a. Let next be IteratorStep(iteratorRecord).
     const next = IteratorStep(iteratorRecord);
     // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (next instanceof AbruptCompletion) {
+    if (isAbruptCompletion(next)) {
       iteratorRecord.Done = Value.true;
     }
     // c. ReturnIfAbrupt(next).
@@ -588,7 +588,7 @@ function PerformPromiseRace(iteratorRecord, constructor, resultCapability, promi
     // e. Let nextValue be IteratorValue(next).
     const nextValue = IteratorValue(next);
     // f. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (nextValue instanceof AbruptCompletion) {
+    if (isAbruptCompletion(nextValue)) {
       iteratorRecord.Done = Value.true;
     }
     // g. ReturnIfAbrupt(nextValue).
@@ -617,7 +617,7 @@ function Promise_race([iterable = Value.undefined], { thisValue }) {
   // 7. Let result be PerformPromiseRace(iteratorRecord, C, promiseCapability, promiseResolve).
   let result = EnsureCompletion(PerformPromiseRace(iteratorRecord, C, promiseCapability, promiseResolve));
   // 8. If result is an abrupt completion, then
-  if (result instanceof AbruptCompletion) {
+  if (isAbruptCompletion(result)) {
     // a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
     if (iteratorRecord.Done === Value.false) {
       result = IteratorClose(iteratorRecord, result);

--- a/src/modules.mts
+++ b/src/modules.mts
@@ -27,9 +27,8 @@ import { InstantiateFunctionObject } from './runtime-semantics/all.mjs';
 import {
   Completion,
   NormalCompletion,
-  AbruptCompletion,
   EnsureCompletion,
-  Q, X,
+  Q, X, isAbruptCompletion,
 } from './completion.mjs';
 import { ValueSet, unwind } from './helpers.mjs';
 import { Evaluate } from './evaluator.mjs';
@@ -130,7 +129,7 @@ export class CyclicModuleRecord extends AbstractModuleRecord {
     // 3. Let result be Completion(InnerModuleLinking(module, stack, 0)).
     const result = InnerModuleLinking(module, stack, 0);
     // 5. If result is an abrupt completion, then
-    if (result instanceof AbruptCompletion) {
+    if (isAbruptCompletion(result)) {
       // a. For each Cyclic Module Record m of stack, do
       for (const m of stack) {
         // i. Assert: m.[[Status]] is linking.
@@ -176,7 +175,7 @@ export class CyclicModuleRecord extends AbstractModuleRecord {
     // 5. Let result be InnerModuleEvaluation(module, stack, 0).
     const result = InnerModuleEvaluation(module, stack, 0);
     // 6. If result is an abrupt completion, then
-    if (result instanceof AbruptCompletion) {
+    if (isAbruptCompletion(result)) {
       // a. For each Cyclic Module Record m in stack, do
       for (const m of stack) {
         // i. Assert: m.[[Status]] is evaluating.

--- a/src/runtime-semantics/BreakStatement.mts
+++ b/src/runtime-semantics/BreakStatement.mts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { Completion } from '../completion.mjs';
+import { CompletionRecord } from '../completion.mjs';
 import { StringValue } from '../static-semantics/all.mjs';
 
 /** https://tc39.es/ecma262/#sec-break-statement-runtime-semantics-evaluation */
@@ -8,11 +8,11 @@ import { StringValue } from '../static-semantics/all.mjs';
 //     `break` LabelIdentifier `;`
 export function Evaluate_BreakStatement({ LabelIdentifier }) {
   if (!LabelIdentifier) {
-    // 1. Return Completion { [[Type]]: break, [[Value]]: empty, [[Target]]: empty }.
-    return new Completion({ Type: 'break', Value: undefined, Target: undefined });
+    // 1. Return Completion Record { [[Type]]: break, [[Value]]: empty, [[Target]]: empty }.
+    return new CompletionRecord({ Type: 'break', Value: undefined, Target: undefined });
   }
   // 1. Let label be the StringValue of LabelIdentifier.
   const label = StringValue(LabelIdentifier);
-  // 2. Return Completion { [[Type]]: break, [[Value]]: empty, [[Target]]: label }.
-  return new Completion({ Type: 'break', Value: undefined, Target: label });
+  // 2. Return Completion Record { [[Type]]: break, [[Value]]: empty, [[Target]]: label }.
+  return new CompletionRecord({ Type: 'break', Value: undefined, Target: label });
 }

--- a/src/runtime-semantics/ClassDefinitionEvaluation.mts
+++ b/src/runtime-semantics/ClassDefinitionEvaluation.mts
@@ -34,7 +34,7 @@ import {
 } from '../environment.mjs';
 import {
   Q, X,
-  AbruptCompletion,
+  isAbruptCompletion,
   Completion,
   EnsureCompletion,
 } from '../completion.mjs';
@@ -228,7 +228,7 @@ export function* ClassDefinitionEvaluation(ClassTail, classBinding, className) {
       field = yield* ClassElementEvaluation(e, F, Value.false);
     }
     // c. If field is an abrupt completion, then
-    if (field instanceof AbruptCompletion) {
+    if (isAbruptCompletion(field)) {
       // i. Set the running execution context's LexicalEnvironment to env.
       surroundingAgent.runningExecutionContext.LexicalEnvironment = env;
       // ii. Set the running execution context's PrivateEnvironment to outerPrivateEnvironment.
@@ -321,7 +321,7 @@ export function* ClassDefinitionEvaluation(ClassTail, classBinding, className) {
       result = Completion(Call(elementRecord.BodyFunction, F));
     }
     // c. If result is an abrupt completion, then
-    if (result instanceof AbruptCompletion) {
+    if (isAbruptCompletion(result)) {
       // i. Set the running execution context's PrivateEnvironment to outerPrivateEnvironment.
       surroundingAgent.runningExecutionContext.PrivateEnvironment = outerPrivateEnvironment;
       // ii. Return result.

--- a/src/runtime-semantics/ContinueStatement.mts
+++ b/src/runtime-semantics/ContinueStatement.mts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { Completion } from '../completion.mjs';
+import { CompletionRecord } from '../completion.mjs';
 import { StringValue } from '../static-semantics/all.mjs';
 
 /** https://tc39.es/ecma262/#sec-continue-statement-runtime-semantics-evaluation */
@@ -8,11 +8,11 @@ import { StringValue } from '../static-semantics/all.mjs';
 //     `continue` LabelIdentifier `;`
 export function Evaluate_ContinueStatement({ LabelIdentifier }) {
   if (!LabelIdentifier) {
-    // 1. Return Completion { [[Type]]: continue, [[Value]]: empty, [[Target]]: empty }.
-    return new Completion({ Type: 'continue', Value: undefined, Target: undefined });
+    // 1. Return Completion Record { [[Type]]: continue, [[Value]]: empty, [[Target]]: empty }.
+    return new CompletionRecord({ Type: 'continue', Value: undefined, Target: undefined });
   }
   // 1. Let label be the StringValue of LabelIdentifier.
   const label = StringValue(LabelIdentifier);
-  // 2. Return Completion { [[Type]]: continue, [[Value]]: empty, [[Target]]: label }.
-  return new Completion({ Type: 'continue', Value: undefined, Target: label });
+  // 2. Return Completion Record { [[Type]]: continue, [[Value]]: empty, [[Target]]: label }.
+  return new CompletionRecord({ Type: 'continue', Value: undefined, Target: label });
 }

--- a/src/runtime-semantics/DestructuringAssignmentEvaluation.mts
+++ b/src/runtime-semantics/DestructuringAssignmentEvaluation.mts
@@ -27,10 +27,10 @@ import { Evaluate } from '../evaluator.mjs';
 import {
   Q, X,
   Completion,
-  AbruptCompletion,
   NormalCompletion,
   ReturnIfAbrupt,
   EnsureCompletion,
+  isAbruptCompletion,
 } from '../completion.mjs';
 import { OutOfRange } from '../helpers.mjs';
 import {
@@ -166,7 +166,7 @@ function* DestructuringAssignmentEvaluation_ArrayAssignmentPattern({ AssignmentE
   // 2. Let status be IteratorDestructuringAssignmentEvaluation of AssignmentElementList with argument iteratorRecord.
   let status = EnsureCompletion(yield* IteratorDestructuringAssignmentEvaluation(AssignmentElementList, iteratorRecord));
   // 3. If status is an abrupt completion, then
-  if (status instanceof AbruptCompletion) {
+  if (isAbruptCompletion(status)) {
     // a. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iteratorRecord, status).
     if (iteratorRecord.Done === Value.false) {
       return Q(IteratorClose(iteratorRecord, status));
@@ -202,7 +202,7 @@ function* IteratorDestructuringAssignmentEvaluation(node, iteratorRecord) {
         // a. Let next be IteratorStep(iteratorRecord).
         const next = IteratorStep(iteratorRecord);
         // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-        if (next instanceof AbruptCompletion) {
+        if (isAbruptCompletion(next)) {
           iteratorRecord.Done = Value.true;
         }
         // c. ReturnIfAbrupt(next)
@@ -229,7 +229,7 @@ function* IteratorDestructuringAssignmentEvaluation(node, iteratorRecord) {
         // a. Let next be IteratorStep(iteratorRecord).
         const next = IteratorStep(iteratorRecord);
         // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-        if (next instanceof AbruptCompletion) {
+        if (isAbruptCompletion(next)) {
           iteratorRecord.Done = Value.true;
         }
         // c. ReturnIfAbrupt(next);
@@ -241,7 +241,7 @@ function* IteratorDestructuringAssignmentEvaluation(node, iteratorRecord) {
           // i. Let value be IteratorValue(next).
           value = IteratorValue(next);
           // ii. If value is an abrupt completion, set iteratorRecord.[[Done]] to true.
-          if (value instanceof AbruptCompletion) {
+          if (isAbruptCompletion(value)) {
             iteratorRecord.Done = Value.true;
           }
           // iii. ReturnIfAbrupt(value).
@@ -297,7 +297,7 @@ function* IteratorDestructuringAssignmentEvaluation(node, iteratorRecord) {
         // a. Let next be IteratorStep(iteratorRecord).
         const next = IteratorStep(iteratorRecord);
         // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-        if (next instanceof AbruptCompletion) {
+        if (isAbruptCompletion(next)) {
           iteratorRecord.Done = Value.true;
         }
         // c. ReturnIfAbrupt(next);
@@ -309,7 +309,7 @@ function* IteratorDestructuringAssignmentEvaluation(node, iteratorRecord) {
           // i. Let nextValue be IteratorValue(next).
           const nextValue = IteratorValue(next);
           // ii. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
-          if (nextValue instanceof AbruptCompletion) {
+          if (isAbruptCompletion(nextValue)) {
             iteratorRecord.Done = Value.true;
           }
           // iii. ReturnIfAbrupt(nextValue).

--- a/src/runtime-semantics/EvaluateBody.mts
+++ b/src/runtime-semantics/EvaluateBody.mts
@@ -12,8 +12,8 @@ import {
   GetValue,
 } from '../abstract-ops/all.mjs';
 import {
-  Completion,
-  AbruptCompletion,
+  CompletionRecord,
+  isAbruptCompletion,
   Q, X,
 } from '../completion.mjs';
 import { Evaluate } from '../evaluator.mjs';
@@ -44,8 +44,8 @@ export function* Evaluate_ExpressionBody({ AssignmentExpression }) {
   const exprRef = yield* Evaluate(AssignmentExpression);
   // 2. Let exprValue be ? GetValue(exprRef).
   const exprValue = Q(GetValue(exprRef));
-  // 3. Return Completion { [[Type]]: return, [[Value]]: exprValue, [[Target]]: empty }.
-  return new Completion({ Type: 'return', Value: exprValue, Target: undefined });
+  // 3. Return Completion Record { [[Type]]: return, [[Value]]: exprValue, [[Target]]: empty }.
+  return new CompletionRecord({ Type: 'return', Value: exprValue, Target: undefined });
 }
 
 /** https://tc39.es/ecma262/#sec-arrow-function-definitions-runtime-semantics-evaluatebody */
@@ -65,15 +65,15 @@ function* EvaluateBody_AsyncConciseBody({ ExpressionBody }, functionObject, argu
   // 2. Let declResult be FunctionDeclarationInstantiation(functionObject, argumentsList).
   const declResult = yield* FunctionDeclarationInstantiation(functionObject, argumentsList);
   // 3. If declResult is not an abrupt completion, then
-  if (!(declResult instanceof AbruptCompletion)) {
+  if (!isAbruptCompletion(declResult)) {
     // a. Perform ! AsyncFunctionStart(promiseCapability, ExpressionBody).
     X(AsyncFunctionStart(promiseCapability, ExpressionBody));
   } else { // 4. Else
     // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « declResult.[[Value]] »).
     X(Call(promiseCapability.Reject, Value.undefined, [declResult.Value]));
   }
-  // 5. Return Completion { [[Type]]: return, [[Value]]: promiseCapability.[[Promise]], [[Target]]: empty }.
-  return new Completion({ Type: 'return', Value: promiseCapability.Promise, Target: undefined });
+  // 5. Return Completion Record { [[Type]]: return, [[Value]]: promiseCapability.[[Promise]], [[Target]]: empty }.
+  return new CompletionRecord({ Type: 'return', Value: promiseCapability.Promise, Target: undefined });
 }
 
 /** https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluatebody */
@@ -87,8 +87,8 @@ export function* EvaluateBody_GeneratorBody(GeneratorBody, functionObject, argum
   G.GeneratorBrand = undefined;
   // 4. Perform GeneratorStart(G, FunctionBody).
   GeneratorStart(G, GeneratorBody);
-  // 5. Return Completion { [[Type]]: return, [[Value]]: G, [[Target]]: empty }.
-  return new Completion({ Type: 'return', Value: G, Target: undefined });
+  // 5. Return Completion Record { [[Type]]: return, [[Value]]: G, [[Target]]: empty }.
+  return new CompletionRecord({ Type: 'return', Value: G, Target: undefined });
 }
 
 /** https://tc39.es/ecma262/#sec-asyncgenerator-definitions-evaluatebody */
@@ -107,8 +107,8 @@ export function* EvaluateBody_AsyncGeneratorBody(FunctionBody, functionObject, a
   generator.GeneratorBrand = undefined;
   // 4. Perform ! AsyncGeneratorStart(generator, FunctionBody).
   X(AsyncGeneratorStart(generator, FunctionBody));
-  // 5. Return Completion { [[Type]]: return, [[Value]]: generator, [[Target]]: empty }.
-  return new Completion({ Type: 'return', Value: generator, Target: undefined });
+  // 5. Return Completion Record { [[Type]]: return, [[Value]]: generator, [[Target]]: empty }.
+  return new CompletionRecord({ Type: 'return', Value: generator, Target: undefined });
 }
 
 /** https://tc39.es/ecma262/#sec-async-function-definitions-EvaluateBody */
@@ -119,15 +119,15 @@ export function* EvaluateBody_AsyncFunctionBody(FunctionBody, functionObject, ar
   // 2. Let declResult be FunctionDeclarationInstantiation(functionObject, argumentsList).
   const declResult = yield* FunctionDeclarationInstantiation(functionObject, argumentsList);
   // 3. If declResult is not an abrupt completion, then
-  if (!(declResult instanceof AbruptCompletion)) {
+  if (!isAbruptCompletion(declResult)) {
     // a. Perform ! AsyncFunctionStart(promiseCapability, FunctionBody).
     X(AsyncFunctionStart(promiseCapability, FunctionBody));
   } else { // 4. Else,
     // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « declResult.[[Value]] »).
     X(Call(promiseCapability.Reject, Value.undefined, [declResult.Value]));
   }
-  // 5. Return Completion { [[Type]]: return, [[Value]]: promiseCapability.[[Promise]], [[Target]]: empty }.
-  return new Completion({ Type: 'return', Value: promiseCapability.Promise, Target: undefined });
+  // 5. Return Completion Record { [[Type]]: return, [[Value]]: promiseCapability.[[Promise]], [[Target]]: empty }.
+  return new CompletionRecord({ Type: 'return', Value: promiseCapability.Promise, Target: undefined });
 }
 
 // Initializer :
@@ -148,8 +148,8 @@ export function* EvaluateBody_AssignmentExpression(AssignmentExpression, functio
     // b. Let value be ? GetValue(rhs).
     value = Q(GetValue(rhs));
   }
-  // 5. Return Completion { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
-  return new Completion({ Type: 'return', Value: value, Target: undefined });
+  // 5. Return Completion Record { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
+  return new CompletionRecord({ Type: 'return', Value: value, Target: undefined });
 }
 
 /** https://tc39.es/ecma262/#sec-runtime-semantics-evaluateclassstaticblockbody */

--- a/src/runtime-semantics/EvaluateCall.mts
+++ b/src/runtime-semantics/EvaluateCall.mts
@@ -11,7 +11,7 @@ import {
   PrepareForTailCall,
   Call,
 } from '../abstract-ops/all.mjs';
-import { Q, Completion, AbruptCompletion } from '../completion.mjs';
+import { Q, isAbruptCompletion, CompletionRecord } from '../completion.mjs';
 import { EnvironmentRecord } from '../environment.mjs';
 import { ArgumentListEvaluation } from './all.mjs';
 
@@ -55,8 +55,8 @@ export function* EvaluateCall(func, ref, args, tailPosition) {
   // 8. Assert: If tailPosition is true, the above call will not return here but instead
   //    evaluation will continue as if the following return has already occurred.
   // 9. Assert: If result is not an abrupt completion, then Type(result) is an ECMAScript language type.
-  if (!(result instanceof AbruptCompletion)) {
-    Assert(result instanceof Value || result instanceof Completion);
+  if (!isAbruptCompletion(result)) {
+    Assert(result instanceof Value || result instanceof CompletionRecord);
   }
   // 10. Return result.
   return result;

--- a/src/runtime-semantics/IteratorBindingInitialization.mts
+++ b/src/runtime-semantics/IteratorBindingInitialization.mts
@@ -14,7 +14,7 @@ import {
   F,
 } from '../abstract-ops/all.mjs';
 import {
-  AbruptCompletion,
+  isAbruptCompletion,
   NormalCompletion,
   ReturnIfAbrupt,
   Q, X,
@@ -79,7 +79,7 @@ function* IteratorBindingInitialization_SingleNameBinding({ BindingIdentifier, I
     // a. Let next be IteratorStep(iteratorRecord).
     const next = IteratorStep(iteratorRecord);
     // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (next instanceof AbruptCompletion) {
+    if (isAbruptCompletion(next)) {
       iteratorRecord.Done = Value.true;
     }
     // c. ReturnIfAbrupt(next).
@@ -91,7 +91,7 @@ function* IteratorBindingInitialization_SingleNameBinding({ BindingIdentifier, I
       // i. Let v be IteratorValue(next).
       v = IteratorValue(next);
       // ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
-      if (v instanceof AbruptCompletion) {
+      if (isAbruptCompletion(v)) {
         iteratorRecord.Done = Value.true;
       }
       // iii. ReturnIfAbrupt(v).
@@ -138,7 +138,7 @@ function* IteratorBindingInitialization_BindingRestElement({ BindingIdentifier, 
         // i. Let next be IteratorStep(iteratorRecord).
         next = IteratorStep(iteratorRecord);
         // ii. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-        if (next instanceof AbruptCompletion) {
+        if (isAbruptCompletion(next)) {
           iteratorRecord.Done = Value.true;
         }
         // iii. ReturnIfAbrupt(next).
@@ -160,7 +160,7 @@ function* IteratorBindingInitialization_BindingRestElement({ BindingIdentifier, 
       // c. Let nextValue be IteratorValue(next).
       const nextValue = IteratorValue(next);
       // d. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
-      if (nextValue instanceof AbruptCompletion) {
+      if (isAbruptCompletion(nextValue)) {
         iteratorRecord.Done = Value.true;
       }
       // e. ReturnIfAbrupt(nextValue).
@@ -183,7 +183,7 @@ function* IteratorBindingInitialization_BindingRestElement({ BindingIdentifier, 
         // i. Let next be IteratorStep(iteratorRecord).
         next = IteratorStep(iteratorRecord);
         // ii. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-        if (next instanceof AbruptCompletion) {
+        if (isAbruptCompletion(next)) {
           iteratorRecord.Done = Value.true;
         }
         // iii. ReturnIfAbrupt(next).
@@ -201,7 +201,7 @@ function* IteratorBindingInitialization_BindingRestElement({ BindingIdentifier, 
       // c. Let nextValue be IteratorValue(next).
       const nextValue = IteratorValue(next);
       // d. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
-      if (nextValue instanceof AbruptCompletion) {
+      if (isAbruptCompletion(nextValue)) {
         iteratorRecord.Done = Value.true;
       }
       // e. ReturnIfAbrupt(nextValue).
@@ -221,7 +221,7 @@ function* IteratorBindingInitialization_BindingPattern({ BindingPattern, Initial
     // a. Let next be IteratorStep(iteratorRecord).
     const next = IteratorStep(iteratorRecord);
     // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (next instanceof AbruptCompletion) {
+    if (isAbruptCompletion(next)) {
       iteratorRecord.Done = Value.true;
     }
     // c. ReturnIfAbrupt(next).
@@ -233,7 +233,7 @@ function* IteratorBindingInitialization_BindingPattern({ BindingPattern, Initial
       // i. Let v be IteratorValue(next).
       v = IteratorValue(next);
       // ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
-      if (v instanceof AbruptCompletion) {
+      if (isAbruptCompletion(v)) {
         iteratorRecord.Done = Value.true;
       }
       // iii. ReturnIfAbrupt(v).
@@ -262,7 +262,7 @@ function IteratorDestructuringAssignmentEvaluation(node, iteratorRecord) {
     // a. Let next be IteratorStep(iteratorRecord).
     const next = IteratorStep(iteratorRecord);
     // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-    if (next instanceof AbruptCompletion) {
+    if (isAbruptCompletion(next)) {
       iteratorRecord.Done = Value.true;
     }
     // c. ReturnIfAbrupt(next).

--- a/src/runtime-semantics/LabelledEvaluation.mts
+++ b/src/runtime-semantics/LabelledEvaluation.mts
@@ -30,12 +30,12 @@ import { CreateForInIterator } from '../intrinsics/ForInIteratorPrototype.mjs';
 import {
   Completion,
   NormalCompletion,
-  AbruptCompletion,
+  isAbruptCompletion,
   UpdateEmpty,
   EnsureCompletion,
   ReturnIfAbrupt,
   Await,
-  Q, X,
+  Q, X, CompletionRecord,
 } from '../completion.mjs';
 import { OutOfRange } from '../helpers.mjs';
 import {
@@ -292,7 +292,7 @@ function* LabelledEvaluation_BreakableStatement_ForStatement(ForStatement, label
       // 7. Let forDcl be the result of evaluating LexicalDeclaration.
       const forDcl = yield* Evaluate(LexicalDeclaration);
       // 8. If forDcl is an abrupt completion, then
-      if (forDcl instanceof AbruptCompletion) {
+      if (isAbruptCompletion(forDcl)) {
         // a. Set the running execution context's LexicalEnvironment to oldEnv.
         surroundingAgent.runningExecutionContext.LexicalEnvironment = oldEnv;
         // b. Return Completion(forDcl).
@@ -538,8 +538,8 @@ function* ForInOfHeadEvaluation(uninitializedBoundNames, expr, iterationKind) {
   if (iterationKind === 'enumerate') {
     // a. If exprValue is undefined or null, then
     if (exprValue === Value.undefined || exprValue === Value.null) {
-      // i. Return Completion { [[Type]]: break, [[Value]]: empty, [[Target]]: empty }.
-      return new Completion({ Type: 'break', Value: undefined, Target: undefined });
+      // i. Return Completion Record { [[Type]]: break, [[Value]]: empty, [[Target]]: empty }.
+      return new CompletionRecord({ Type: 'break', Value: undefined, Target: undefined });
     }
     // b. Let obj be ! ToObject(exprValue).
     const obj = X(ToObject(exprValue));
@@ -637,7 +637,7 @@ function* ForInOfBodyEvaluation(lhs, stmt, iteratorRecord, iterationKind, lhsKin
     // i. If destructuring is false, then
     if (destructuring === false) {
       // i. If lhsRef is an abrupt completion, then
-      if (lhsRef instanceof AbruptCompletion) {
+      if (isAbruptCompletion(lhsRef)) {
         // 1. Let status be lhsRef.
         status = lhsRef;
       } else if (lhsKind === 'lexicalBinding') { // ii. Else is lhsKind is lexicalBinding, then
@@ -666,7 +666,7 @@ function* ForInOfBodyEvaluation(lhs, stmt, iteratorRecord, iterationKind, lhsKin
       }
     }
     // k. If status is an abrupt completion, then
-    if (status instanceof AbruptCompletion) {
+    if (isAbruptCompletion(status)) {
       // i. Set the running execution context's LexicalEnvironment to oldEnv.
       surroundingAgent.runningExecutionContext.LexicalEnvironment = oldEnv;
       // ii. If iteratorKind is async, return ? AsyncIteratorClose(iteratorRecord, status).

--- a/src/runtime-semantics/ReturnStatement.mts
+++ b/src/runtime-semantics/ReturnStatement.mts
@@ -3,9 +3,8 @@ import { Value } from '../value.mjs';
 import { Evaluate } from '../evaluator.mjs';
 import { GetValue, GetGeneratorKind } from '../abstract-ops/all.mjs';
 import {
-  Completion,
   Await,
-  Q, X,
+  Q, X, CompletionRecord,
 } from '../completion.mjs';
 
 /** https://tc39.es/ecma262/#sec-return-statement-runtime-semantics-evaluation */
@@ -14,8 +13,8 @@ import {
 //    `return` Expression `;`
 export function* Evaluate_ReturnStatement({ Expression }) {
   if (!Expression) {
-    // 1. Return Completion { [[Type]]: return, [[Value]]: undefined, [[Target]]: empty }.
-    return new Completion({ Type: 'return', Value: Value.undefined, Target: undefined });
+    // 1. Return Completion Record { [[Type]]: return, [[Value]]: undefined, [[Target]]: empty }.
+    return new CompletionRecord({ Type: 'return', Value: Value.undefined, Target: undefined });
   }
   // 1. Let exprRef be the result of evaluating Expression.
   const exprRef = yield* Evaluate(Expression);
@@ -25,6 +24,6 @@ export function* Evaluate_ReturnStatement({ Expression }) {
   if (X(GetGeneratorKind()) === 'async') {
     exprValue = Q(yield* Await(exprValue));
   }
-  // 1. Return Completion { [[Type]]: return, [[Value]]: exprValue, [[Target]]: empty }.
-  return new Completion({ Type: 'return', Value: exprValue, Target: undefined });
+  // 1. Return Completion Record { [[Type]]: return, [[Value]]: exprValue, [[Target]]: empty }.
+  return new CompletionRecord({ Type: 'return', Value: exprValue, Target: undefined });
 }

--- a/src/runtime-semantics/SwitchStatement.mts
+++ b/src/runtime-semantics/SwitchStatement.mts
@@ -6,7 +6,7 @@ import { Assert, GetValue, StrictEqualityComparison } from '../abstract-ops/all.
 import { Value } from '../value.mjs';
 import {
   Completion,
-  AbruptCompletion,
+  isAbruptCompletion,
   NormalCompletion,
   EnsureCompletion,
   UpdateEmpty,
@@ -64,7 +64,7 @@ function* CaseBlockEvaluation({ CaseClauses_a, DefaultClause, CaseClauses_b }, i
             V = R.Value;
           }
           // iii. If R is an abrupt completion, return Completion(UpdateEmpty(R, V)).
-          if (R instanceof AbruptCompletion) {
+          if (isAbruptCompletion(R)) {
             return Completion(UpdateEmpty(R, V));
           }
         }
@@ -101,7 +101,7 @@ function* CaseBlockEvaluation({ CaseClauses_a, DefaultClause, CaseClauses_b }, i
             V = R.Value;
           }
           // iii. If R is an abrupt completion, return Completion(UpdateEmpty(R, V)).
-          if (R instanceof AbruptCompletion) {
+          if (isAbruptCompletion(R)) {
             return Completion(UpdateEmpty(R, V));
           }
         }
@@ -135,7 +135,7 @@ function* CaseBlockEvaluation({ CaseClauses_a, DefaultClause, CaseClauses_b }, i
               V = R.Value;
             }
             // iii. If R is an abrupt completion, return Completion(UpdateEmpty(R, V)).
-            if (R instanceof AbruptCompletion) {
+            if (isAbruptCompletion(R)) {
               return Completion(UpdateEmpty(R, V));
             }
           }
@@ -152,7 +152,7 @@ function* CaseBlockEvaluation({ CaseClauses_a, DefaultClause, CaseClauses_b }, i
         V = R.Value;
       }
       // 13. If R is an abrupt completion, return Completion(UpdateEmpty(R, V)).
-      if (R instanceof AbruptCompletion) {
+      if (isAbruptCompletion(R)) {
         return Completion(UpdateEmpty(R, V));
       }
       // 14. NOTE: The following is another complete iteration of the second CaseClauses.
@@ -165,7 +165,7 @@ function* CaseBlockEvaluation({ CaseClauses_a, DefaultClause, CaseClauses_b }, i
           V = innerR.Value;
         }
         // c. If R is an abrupt completion, return Completion(UpdateEmpty(R, V)).
-        if (innerR instanceof AbruptCompletion) {
+        if (isAbruptCompletion(innerR)) {
           return Completion(UpdateEmpty(innerR, V));
         }
       }

--- a/src/runtime-semantics/TryStatement.mts
+++ b/src/runtime-semantics/TryStatement.mts
@@ -4,7 +4,7 @@ import { Value } from '../value.mjs';
 import { Evaluate } from '../evaluator.mjs';
 import {
   Completion,
-  AbruptCompletion,
+  isAbruptCompletion,
   UpdateEmpty,
   EnsureCompletion,
   X,
@@ -105,7 +105,7 @@ function* CatchClauseEvaluation({ CatchParameter, Block }, thrownValue) {
   // 5. Let status be BindingInitialization of CatchParameter with arguments thrownValue and catchEnv.
   const status = yield* BindingInitialization(CatchParameter, thrownValue, catchEnv);
   // 6. If status is an abrupt completion, then
-  if (status instanceof AbruptCompletion) {
+  if (isAbruptCompletion(status)) {
     // a. Set the running execution context's LexicalEnvironment to oldEnv.
     surroundingAgent.runningExecutionContext.LexicalEnvironment = oldEnv;
     // b. Return Completion(status).

--- a/src/runtime-semantics/YieldExpression.mts
+++ b/src/runtime-semantics/YieldExpression.mts
@@ -21,7 +21,7 @@ import {
   Completion,
   NormalCompletion,
   EnsureCompletion,
-  Q, X,
+  Q, X, CompletionRecord,
 } from '../completion.mjs';
 import { Evaluate } from '../evaluator.mjs';
 
@@ -145,8 +145,8 @@ export function* Evaluate_YieldExpression({ hasStar, AssignmentExpression }) {
         if (done === Value.true) {
           // 1. Let value be ? IteratorValue(innerReturnResult).
           const innerValue = Q(IteratorValue(innerReturnResult));
-          // 2. Return Completion { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
-          return new Completion({ Type: 'return', Value: innerValue, Target: undefined });
+          // 2. Return Completion Record { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
+          return new CompletionRecord({ Type: 'return', Value: innerValue, Target: undefined });
         }
         // ix. If generatorKind is async, then set received to AsyncGeneratorYield(? IteratorValue(innerResult)).
         if (generatorKind === 'async') {

--- a/src/value.mts
+++ b/src/value.mts
@@ -19,7 +19,7 @@ import {
   F,
 } from './abstract-ops/all.mjs';
 import { EnvironmentRecord } from './environment.mjs';
-import { Completion, X } from './completion.mjs';
+import { CompletionRecord, X } from './completion.mjs';
 import { ValueMap, OutOfRange, callable } from './helpers.mjs';
 import type { PrivateElementRecord } from './runtime-semantics/MethodDefinitionEvaluation.mjs';
 
@@ -869,7 +869,7 @@ export function Type(val: Value) {
     return 'PrivateName';
   }
 
-  if (val instanceof Completion) {
+  if (val instanceof CompletionRecord) {
     return 'Completion';
   }
 

--- a/test/eslint-plugin-engine262/no-use-in-def.js
+++ b/test/eslint-plugin-engine262/no-use-in-def.js
@@ -19,6 +19,9 @@ function isUsedInDef(reference) {
   const location = reference.identifier.range[1];
 
   while (node) {
+    if (node.type === 'TSTypeParameter') {
+      return false;
+    }
     if (node.type === 'VariableDeclarator') {
       if (isInRange(node.init, location)) {
         return true;

--- a/test/json/json.js
+++ b/test/json/json.js
@@ -12,7 +12,7 @@ const {
   Agent,
   setSurroundingAgent,
   ManagedRealm,
-  AbruptCompletion,
+  isAbruptCompletion,
   inspect,
 } = require('../..');
 
@@ -38,7 +38,7 @@ JSON.parse(source);
 
   const testName = path.basename(filename);
 
-  if (!result || result instanceof AbruptCompletion) {
+  if (!result || isAbruptCompletion(result)) {
     if (testName.startsWith('n_')) {
       pass();
     } else if (testName.startsWith('i_')) {

--- a/test/stepped.js
+++ b/test/stepped.js
@@ -36,7 +36,7 @@ if (isMainThread) {
     Agent,
     setSurroundingAgent,
     ManagedRealm,
-    AbruptCompletion,
+    isAbruptCompletion,
     inspect,
   } = require('..');
 
@@ -56,7 +56,7 @@ if (isMainThread) {
 
   realm.scope(() => {
     const completion = realm.evaluateScript(workerData.source);
-    if (completion instanceof AbruptCompletion) {
+    if (isAbruptCompletion(completion)) {
       process.stdout.write(`${inspect(completion, realm)}\n`);
     }
   });

--- a/test/test262/test262.js
+++ b/test/test262/test262.js
@@ -242,7 +242,7 @@ if (!process.send) {
     JSStringValue,
     ObjectValue,
 
-    AbruptCompletion,
+    isAbruptCompletion,
     Throw,
   } = require('../..');
   const { createRealm, createAgent } = require('../../bin/test262_realm');
@@ -307,7 +307,7 @@ if (!process.send) {
         }
         const entry = includeCache[include];
         const completion = realm.evaluateScript(entry.source, { specifier: entry.specifier });
-        if (completion instanceof AbruptCompletion) {
+        if (isAbruptCompletion(completion)) {
           return { status: 'FAIL', error: inspect(completion) };
         }
       }
@@ -330,7 +330,7 @@ function $DONE(error) {
     __consolePrintHandle__('Test262:AsyncTestComplete');
   }
 }`);
-        if (completion instanceof AbruptCompletion) {
+        if (isAbruptCompletion(completion)) {
           return { status: 'FAIL', error: inspect(completion) };
         }
       }
@@ -352,24 +352,24 @@ function $DONE(error) {
       let completion;
       if (test.attrs.flags.module) {
         completion = realm.createSourceTextModule(specifier, test.contents);
-        if (!(completion instanceof AbruptCompletion)) {
+        if (!isAbruptCompletion(completion)) {
           const module = completion;
           resolverCache.set(specifier, module);
           completion = module.LoadRequestedModules();
-          if (!(completion instanceof AbruptCompletion)) {
+          if (!isAbruptCompletion(completion)) {
             if (completion.PromiseState === 'rejected') {
               completion = Throw(completion.PromiseResult);
             } else if (completion.PromiseState === 'pending') {
               throw new Error('Internal error: .LoadRequestedModules() returned a pending promise');
             }
           }
-          if (!(completion instanceof AbruptCompletion)) {
+          if (!isAbruptCompletion(completion)) {
             completion = module.Link();
           }
-          if (!(completion instanceof AbruptCompletion)) {
+          if (!isAbruptCompletion(completion)) {
             completion = module.Evaluate();
           }
-          if (!(completion instanceof AbruptCompletion)) {
+          if (!isAbruptCompletion(completion)) {
             if (completion.PromiseState === 'rejected') {
               completion = Throw(completion.PromiseResult);
             }
@@ -379,7 +379,7 @@ function $DONE(error) {
         completion = realm.evaluateScript(test.contents, { specifier });
       }
 
-      if (completion instanceof AbruptCompletion) {
+      if (isAbruptCompletion(completion)) {
         if (test.attrs.negative && isError(test.attrs.negative.type, completion.Value)) {
           return { status: 'PASS' };
         } else {


### PR DESCRIPTION
This is an alternative to #222 that is far less complicated, though it does mean more changes to existing code for the following cases:

- `x instanceof AbruptCompletion` to `isAbruptCompletion(x)`
- `x instanceof NormalCompletion` to `isNormalCompletion(x)`
- `x instanceof Completion` to `x instanceof CompletionRecord`
- `new Completion({ ... })` to `new CompletionRecord({ ... })`

