### PR TITLE
refactor: add types to RegExp parser

### DIFF
--- a/src/parse.mts
+++ b/src/parse.mts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { Parser } from './parser/Parser.mjs';
-import { RegExpParser } from './parser/RegExpParser.mjs';
+import { RegExpParser, type RegExpParserContext } from './parser/RegExpParser.mjs';
 import { surroundingAgent } from './engine.mjs';
 import { SourceTextModuleRecord } from './modules.mjs';
 import { Value } from './value.mjs';
@@ -187,7 +187,7 @@ export function ParseJSONModule(sourceText, realm, hostDefined) {
 
 /** https://tc39.es/ecma262/#sec-parsepattern */
 export function ParsePattern(patternText, u) {
-  const parse = (flags) => {
+  const parse = (flags: RegExpParserContext) => {
     const p = new RegExpParser(patternText);
     return p.scope(flags, () => p.parsePattern());
   };

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -15,7 +15,7 @@ import {
 } from './tokens.mjs';
 import { isLineTerminator, type TokenData } from './Lexer.mjs';
 import { FunctionParser, FunctionKind } from './FunctionParser.mjs';
-import { RegExpParser } from './RegExpParser.mjs';
+import { RegExpParser, type RegExpParserContext } from './RegExpParser.mjs';
 import type { ParseNode } from './ParseNode.mjs';
 
 export abstract class ExpressionParser extends FunctionParser {
@@ -1150,12 +1150,12 @@ export abstract class ExpressionParser extends FunctionParser {
   parseRegularExpressionLiteral(): ParseNode.RegularExpressionLiteral {
     const node = this.startNode<ParseNode.RegularExpressionLiteral>();
     this.scanRegularExpressionBody();
-    node.RegularExpressionBody = this.scannedValue as string; // NOTE: unsound cast
+    const body = node.RegularExpressionBody = this.scannedValue as string; // NOTE: unsound cast
     this.scanRegularExpressionFlags();
     node.RegularExpressionFlags = this.scannedValue as string; // NOTE: unsound cast
     try {
-      const parse = (flags: { U: boolean; N: boolean; }) => {
-        const p = new RegExpParser(node.RegularExpressionBody);
+      const parse = (flags: RegExpParserContext) => {
+        const p = new RegExpParser(body);
         return p.scope(flags, () => p.parsePattern());
       };
       if (node.RegularExpressionFlags.includes('u')) {

--- a/src/parser/ExpressionParser.mts
+++ b/src/parser/ExpressionParser.mts
@@ -1150,7 +1150,8 @@ export abstract class ExpressionParser extends FunctionParser {
   parseRegularExpressionLiteral(): ParseNode.RegularExpressionLiteral {
     const node = this.startNode<ParseNode.RegularExpressionLiteral>();
     this.scanRegularExpressionBody();
-    const body = node.RegularExpressionBody = this.scannedValue as string; // NOTE: unsound cast
+    const body = this.scannedValue as string; // NOTE: unsound cast
+    node.RegularExpressionBody = body;
     this.scanRegularExpressionFlags();
     node.RegularExpressionFlags = this.scannedValue as string; // NOTE: unsound cast
     try {

--- a/src/parser/ParseNode.mts
+++ b/src/parser/ParseNode.mts
@@ -2188,6 +2188,153 @@ export namespace ParseNode {
     T;
 }
 
+/** https://tc39.es/ecma262/multipage/text-processing.html#sec-patterns */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace ParseNode.RegExp {
+  // NON-SPEC
+  export type Mutable<T> = {
+    -readonly [K in keyof T]: T[K];
+  }
+  export interface Pattern {
+    readonly type: 'Pattern';
+    readonly Disjunction: Disjunction;
+    readonly groupSpecifiers: ReadonlyMap<string, number>;
+    readonly capturingGroups: readonly Atom_Group[];
+  }
+  export interface Disjunction {
+    readonly type: 'Disjunction';
+    readonly Alternative: Alternative;
+    readonly Disjunction: Disjunction | undefined;
+  }
+  export interface Alternative {
+    readonly type: 'Alternative';
+    readonly Term: Term | undefined;
+    readonly Alternative: Alternative | undefined;
+  }
+  export type Term = Assertion | Term_Atom;
+  export interface Term_Atom {
+    readonly type: 'Term';
+    readonly Atom: Atom;
+    readonly Quantifier: Quantifier | undefined;
+    readonly capturingParenthesesBefore: number;
+  }
+  export interface Assertion {
+    readonly type: 'Assertion';
+    readonly subtype: '^' | '$' | 'b' | 'B' | '?=' | '?!' | '?<=' | '?<!';
+    readonly Disjunction?: Disjunction | undefined;
+  }
+  export interface Quantifier {
+    readonly type: 'Quantifier';
+    readonly QuantifierPrefix: '*' | '+' | '?' | QuantifierCount | undefined;
+    readonly greedy: boolean;
+  }
+  export interface QuantifierCount {
+    readonly DecimalDigits_a: number;
+    readonly DecimalDigits_b: number | undefined;
+  }
+  export type Atom = Atom_Dot | AtomEscape | Atom_Group | Atom_Rest;
+  export interface Atom_Dot {
+    readonly type: 'Atom';
+    readonly subtype: '.';
+    readonly enclosedCapturingParentheses: number;
+  }
+  export interface Atom_Group {
+    readonly type: 'Atom';
+    readonly capturingParenthesesBefore: number;
+    readonly enclosedCapturingParentheses: number;
+    readonly capturing: boolean;
+    readonly GroupSpecifier: string | undefined;
+    readonly Disjunction: Disjunction | undefined;
+  }
+  export interface Atom_Rest {
+    readonly type: 'Atom';
+    readonly CharacterClass?: CharacterClass | undefined;
+    readonly PatternCharacter?: string | undefined;
+  }
+  export interface AtomEscape {
+    readonly type: 'AtomEscape';
+    readonly position?: number | undefined;
+    readonly GroupName?: string | undefined;
+    readonly CharacterClassEscape?: CharacterClassEscape | undefined;
+    readonly DecimalEscape?: DecimalEscape | undefined;
+    readonly CharacterEscape?: CharacterEscape | undefined;
+  }
+  export interface CharacterEscape {
+    readonly type: 'CharacterEscape';
+    readonly subtype?: string | undefined;
+    readonly ControlEscape?: string | undefined;
+    readonly IdentityEscape?: string | undefined;
+    readonly ControlLetter?: string | undefined;
+    readonly HexEscapeSequence?: HexEscapeSequence | undefined;
+    readonly RegExpUnicodeEscapeSequence?: RegExpUnicodeEscapeSequence | undefined;
+  }
+  export interface DecimalEscape {
+    readonly type: 'DecimalEscape';
+    readonly position: number;
+    readonly value: number;
+  }
+  export interface CharacterClassEscape {
+    readonly type: 'CharacterClassEscape';
+    readonly value: string;
+    readonly UnicodePropertyValueExpression?: UnicodePropertyValueExpression | undefined;
+  }
+  export interface UnicodePropertyValueExpression {
+    readonly type: 'UnicodePropertyValueExpression';
+    readonly LoneUnicodePropertyNameOrValue?: string | undefined;
+    readonly UnicodePropertyName?: string | undefined;
+    readonly UnicodePropertyValue?: string | undefined;
+  }
+  export interface CharacterClass {
+    readonly type: 'CharacterClass';
+    readonly invert: boolean;
+    readonly ClassRanges: readonly ClassRange[];
+  }
+  export type ClassRange = ClassAtom | [ClassAtom, ClassAtom];
+  export type ClassAtom = ClassAtom_SourceCharacter | ClassEscape | CharacterClassEscape;
+  export interface ClassAtom_SourceCharacter {
+    readonly type: 'ClassAtom';
+    readonly SourceCharacter?: string | undefined;
+    readonly value?: '-' | undefined;
+  }
+  export interface ClassEscape {
+    readonly type: 'ClassEscape';
+    readonly value?: 'b' | '-' | undefined;
+    readonly CharacterEscape?: CharacterEscape | undefined;
+  }
+  export interface RegExpUnicodeEscapeSequence {
+    readonly type: 'RegExpUnicodeEscapeSequence';
+    readonly CodePoint?: number;
+    readonly HexLeadSurrogate?: number | undefined;
+    readonly HexTrailSurrogate?: number | undefined;
+    readonly Hex4Digits?: number | undefined;
+  }
+  export interface HexEscapeSequence {
+    readonly type: 'HexEscapeSequence';
+    readonly HexDigit_a: string;
+    readonly HexDigit_b: string;
+  }
+  export type RegExpParseNode =
+    | Pattern
+    | Disjunction
+    | Alternative
+    | Term_Atom
+    | Assertion
+    | Quantifier
+    | Atom_Dot
+    | AtomEscape
+    | Atom_Group
+    | Atom_Rest
+    | CharacterClass
+    | ClassAtom_SourceCharacter
+    | ClassEscape
+    | RegExpUnicodeEscapeSequence
+    | HexEscapeSequence
+    | CharacterEscape
+    | DecimalEscape
+    | CharacterClassEscape
+    | UnicodePropertyValueExpression;
+}
+
 export type ParseNode =
   | ParseNode.PrivateIdentifier
   | ParseNode.IdentifierName

--- a/src/runtime-semantics/RegExp.mts
+++ b/src/runtime-semantics/RegExp.mts
@@ -7,6 +7,7 @@ import { CharacterValue, StringToCodePoints } from '../static-semantics/all.mjs'
 import { X } from '../completion.mjs';
 import { isLineTerminator, isWhitespace, isDecimalDigit } from '../parser/Lexer.mjs';
 import { OutOfRange } from '../helpers.mjs';
+import type { ParseNode } from '../parser/ParseNode.mjs';
 import {
   UnicodeMatchProperty,
   UnicodeMatchPropertyValue,
@@ -15,7 +16,6 @@ import {
   NonbinaryUnicodeProperties,
   getUnicodePropertyValueSet,
 } from './all.mjs';
-import type { ParseNode } from '../parser/ParseNode.mjs';
 
 /** https://tc39.es/ecma262/#sec-pattern */
 class State {

--- a/src/runtime-semantics/RegExp.mts
+++ b/src/runtime-semantics/RegExp.mts
@@ -15,6 +15,7 @@ import {
   NonbinaryUnicodeProperties,
   getUnicodePropertyValueSet,
 } from './all.mjs';
+import type { ParseNode } from '../parser/ParseNode.mjs';
 
 /** https://tc39.es/ecma262/#sec-pattern */
 class State {
@@ -186,7 +187,7 @@ export function Evaluate_Pattern(Pattern, flags) {
     };
   }
 
-  function Evaluate(node, ...args) {
+  function Evaluate(node: ParseNode.RegExp.RegExpParseNode, ...args) {
     switch (node.type) {
       case 'Disjunction':
         return Evaluate_Disjunction(node, ...args);


### PR DESCRIPTION
It's similar to the current `ParseNode`. I added an extra namespace `ParseNode.RegExp` because it does not share basic structure with normal AST.

cc @rbuckton maybe you'd like to review this?