### PR TITLE
Adds support for Stage 3 RegExp Modifiers

### DIFF
--- a/src/abstract-ops/regexp-objects.mts
+++ b/src/abstract-ops/regexp-objects.mts
@@ -4,7 +4,7 @@ import {
   Descriptor, Value, ObjectValue, BooleanValue, JSStringValue,
 } from '../value.mjs';
 import { Q, X } from '../completion.mjs';
-import { Evaluate_Pattern } from '../runtime-semantics/all.mjs';
+import { CompilePattern } from '../runtime-semantics/all.mjs';
 import { ParsePattern } from '../parse.mjs';
 import { isLineTerminator } from '../parser/Lexer.mjs';
 import {
@@ -78,7 +78,7 @@ export function RegExpInitialize(obj, pattern, flags) {
   // 14. Set obj.[[RegExpMatcher]] to the Abstract Closure that evaluates parseResult by
   //     applying the semantics provided in 21.2.2 using patternCharacters as the pattern's
   //     List of SourceCharacter values and F as the flag parameters.
-  const evaluatePattern = surroundingAgent.hostDefinedOptions.boost?.evaluatePattern || Evaluate_Pattern;
+  const evaluatePattern = surroundingAgent.hostDefinedOptions.boost?.evaluatePattern || CompilePattern;
   obj.RegExpMatcher = evaluatePattern(parseResult, F.stringValue());
   // 15. Perform ? Set(obj, "lastIndex", +0𝔽, true).
   Q(Set(obj, Value('lastIndex'), toNumberValue(+0), Value.true));

--- a/src/parser/Lexer.mts
+++ b/src/parser/Lexer.mts
@@ -25,8 +25,8 @@ export const isHexDigit = (c: string) => c && /[\da-f]/ui.test(c);
 const isOctalDigit = (c: string) => c && /[0-7]/u.test(c);
 const isBinaryDigit = (c: string) => (c === '0' || c === '1');
 export const isWhitespace = (c: string) => c && (/[\u0009\u000B\u000C\u0020\u00A0\uFEFF]/u.test(c) || isSpaceSeparatorRegex.test(c)); // eslint-disable-line no-control-regex
-export const isLineTerminator = (c: string) => c && /[\r\n\u2028\u2029]/u.test(c);
-const isRegularExpressionFlagPart = (c: string) => c && (isUnicodeIDContinue(c) || c === '$');
+export const isLineTerminator = (c: string) => !!c && /[\r\n\u2028\u2029]/u.test(c);
+export const isRegularExpressionFlagPart = (c: string) => c && (isUnicodeIDContinue(c) || c === '$');
 export const isIdentifierStart = (c: string) => SingleCharTokens[c] === Token.IDENTIFIER || isUnicodeIDStart(c);
 export const isIdentifierPart = (c: string) => SingleCharTokens[c] === Token.IDENTIFIER || c === '\u{200C}' || c === '\u{200D}' || isUnicodeIDContinue(c);
 export const isLeadingSurrogate = (cp: number) => cp >= 0xD800 && cp <= 0xDBFF;

--- a/src/parser/ParseNode.mts
+++ b/src/parser/ParseNode.mts
@@ -2218,11 +2218,19 @@ export namespace ParseNode.RegExp {
     readonly Quantifier: Quantifier | undefined;
     readonly capturingParenthesesBefore: number;
   }
-  export interface Assertion {
+  export interface SimpleAssertion {
     readonly type: 'Assertion';
-    readonly subtype: '^' | '$' | 'b' | 'B' | '?=' | '?!' | '?<=' | '?<!';
-    readonly Disjunction?: Disjunction | undefined;
+    readonly subtype: '^' | '$' | 'b' | 'B';
+    readonly Disjunction?: undefined;
   }
+  export interface ComplexAssertion {
+    readonly type: 'Assertion';
+    readonly subtype: '?=' | '?!' | '?<=' | '?<!';
+    readonly Disjunction: Disjunction;
+  }
+  export type Assertion =
+    | SimpleAssertion
+    | ComplexAssertion;
   export interface Quantifier {
     readonly type: 'Quantifier';
     readonly QuantifierPrefix: '*' | '+' | '?' | QuantifierCount;
@@ -2232,7 +2240,7 @@ export namespace ParseNode.RegExp {
     readonly DecimalDigits_a: number;
     readonly DecimalDigits_b: number | undefined;
   }
-  export type Atom = Atom_Dot | AtomEscape | Atom_Group | Atom_Rest;
+  export type Atom = Atom_Dot | AtomEscape | Atom_Group | Atom_CharacterClass | Atom_PatternCharacter;
   export interface Atom_Dot {
     readonly type: 'Atom';
     readonly subtype: '.';
@@ -2246,12 +2254,15 @@ export namespace ParseNode.RegExp {
     readonly RegularExpressionFlags_a: string | undefined;
     readonly RegularExpressionFlags_b: string | undefined;
     readonly GroupSpecifier: string | undefined;
-    readonly Disjunction: Disjunction | undefined;
+    readonly Disjunction: Disjunction;
   }
-  export interface Atom_Rest {
+  export interface Atom_CharacterClass {
     readonly type: 'Atom';
-    readonly CharacterClass?: CharacterClass | undefined;
-    readonly PatternCharacter?: string | undefined;
+    readonly CharacterClass: CharacterClass;
+  }
+  export interface Atom_PatternCharacter {
+    readonly type: 'Atom';
+    readonly PatternCharacter: string;
   }
   export interface AtomEscape {
     readonly type: 'AtomEscape';
@@ -2325,7 +2336,8 @@ export namespace ParseNode.RegExp {
     | Atom_Dot
     | AtomEscape
     | Atom_Group
-    | Atom_Rest
+    | Atom_CharacterClass
+    | Atom_PatternCharacter
     | CharacterClass
     | ClassAtom_SourceCharacter
     | ClassEscape

--- a/src/parser/ParseNode.mts
+++ b/src/parser/ParseNode.mts
@@ -2225,7 +2225,7 @@ export namespace ParseNode.RegExp {
   }
   export interface Quantifier {
     readonly type: 'Quantifier';
-    readonly QuantifierPrefix: '*' | '+' | '?' | QuantifierCount | undefined;
+    readonly QuantifierPrefix: '*' | '+' | '?' | QuantifierCount;
     readonly greedy: boolean;
   }
   export interface QuantifierCount {
@@ -2243,6 +2243,8 @@ export namespace ParseNode.RegExp {
     readonly capturingParenthesesBefore: number;
     readonly enclosedCapturingParentheses: number;
     readonly capturing: boolean;
+    readonly RegularExpressionFlags_a: string | undefined;
+    readonly RegularExpressionFlags_b: string | undefined;
     readonly GroupSpecifier: string | undefined;
     readonly Disjunction: Disjunction | undefined;
   }

--- a/src/parser/RegExpParser.mts
+++ b/src/parser/RegExpParser.mts
@@ -354,7 +354,7 @@ export class RegExpParser {
         RegularExpressionFlags_a: undefined,
         RegularExpressionFlags_b: undefined,
         GroupSpecifier: undefined,
-        Disjunction: undefined,
+        Disjunction: undefined!,
       };
       if (this.eat('?')) {
         node.RegularExpressionFlags_a = this.scanRegularExpressionModifiers();
@@ -463,7 +463,11 @@ export class RegExpParser {
   // IdentityEscape ::
   //   [+U] SyntaxCharacter
   //   [+U] `/`
-  //   [~U] SourceCharacter but not UnicodeIDContinue
+  //   [~U] SourceCharacterIdentityEscape
+  //
+  // SourceCharacterIdentityEscape ::
+  //   [~N] SourceCharacter but not `c`
+  //   [+N] SourceCharacter but not one of `c` or `k`
   private parseCharacterEscape(): ParseNode.RegExp.CharacterEscape {
     switch (this.peek()) {
       case 'f':
@@ -550,7 +554,7 @@ export class RegExpParser {
             this.raise('Invalid identity escape');
           }
         } else {
-          if (isIdentifierContinue(c)) {
+          if (this.plusN ? c === 'c' || c === 'k' : c === 'c') {
             this.raise('Invalid identity escape');
           }
         }

--- a/src/runtime-semantics/RegExp.mts
+++ b/src/runtime-semantics/RegExp.mts
@@ -1,11 +1,11 @@
-// @ts-nocheck
+// @ts-ignore
 import unicodeCaseFoldingCommon from '@unicode/unicode-15.0.0/Case_Folding/C/symbols.js';
+// @ts-ignore
 import unicodeCaseFoldingSimple from '@unicode/unicode-15.0.0/Case_Folding/S/symbols.js';
-import { JSStringValue, UndefinedValue, Value } from '../value.mjs';
+import { UndefinedValue, Value } from '../value.mjs';
 import { Assert, isNonNegativeInteger } from '../abstract-ops/all.mjs';
-import { CharacterValue, StringToCodePoints } from '../static-semantics/all.mjs';
-import { X } from '../completion.mjs';
-import { isLineTerminator, isWhitespace, isDecimalDigit } from '../parser/Lexer.mjs';
+import { CharacterValue } from '../static-semantics/all.mjs';
+import { isLineTerminator, isWhitespace } from '../parser/Lexer.mjs';
 import { OutOfRange } from '../helpers.mjs';
 import type { ParseNode } from '../parser/ParseNode.mjs';
 import {
@@ -18,17 +18,20 @@ import {
 } from './all.mjs';
 
 /** https://tc39.es/ecma262/#pattern-matchstate */
-class MatchState {
-  endIndex;
-  captures;
-  constructor(endIndex: number, captures: (Range | UndefinedValue)[]) {
-    this.endIndex = endIndex;
-    this.captures = captures;
+export class MatchState {
+  readonly Input;
+  readonly EndIndex;
+  readonly Captures;
+
+  constructor(input: number[], endIndex: number, captures: (CaptureRange | UndefinedValue)[]) {
+    this.Input = input;
+    this.EndIndex = endIndex;
+    this.Captures = captures;
   }
 }
 
 /** https://tc39.es/ecma262/#pattern-matchresult */
-type MatchResult = MatchState | 'failure';
+export type MatchResult = MatchState | 'failure';
 
 /** https://tc39.es/ecma262/#pattern-matchercontinuation */
 type MatcherContinuation = (m: MatchState) => MatchResult;
@@ -39,19 +42,24 @@ type Matcher = (x: MatchState, c: MatcherContinuation) => MatchResult;
 const FORWARD = +1;
 const BACKWARD = -1;
 
+export const FAILURE = 'failure';
+
 type Direction = 1 | -1;
 
-export { MatchState as RegExpState };
-
-/** https://tc39.es/proposal-regexp-modifiers/#sec-modifiers-records */
-export class ModifiersRecord {
-  readonly DotAll: boolean;
+/** https://tc39.es/ecma262/#sec-regexp-records */
+export class RegExpRecord {
   readonly IgnoreCase: boolean;
   readonly Multiline: boolean;
-  constructor(DotAll: boolean, IgnoreCase: boolean, Multiline: boolean) {
-    this.DotAll = DotAll;
+  readonly DotAll: boolean;
+  readonly Unicode: boolean;
+  readonly CapturingGroupsCount: number;
+
+  constructor(IgnoreCase: boolean, Multiline: boolean, DotAll: boolean, Unicode: boolean, CapturingGroupsCount: number) {
     this.IgnoreCase = IgnoreCase;
     this.Multiline = Multiline;
+    this.DotAll = DotAll;
+    this.Unicode = Unicode;
+    this.CapturingGroupsCount = CapturingGroupsCount;
   }
 }
 
@@ -61,101 +69,292 @@ function isContinuation(v: unknown): v is MatcherContinuation {
 
 abstract class CharSet {
   abstract has(c: number): boolean;
-  union(other: CharSet) {
-    const concrete = new Set<number>();
-    const fns = new Set<(ch: number) => boolean>();
-    const add = (cs: CharSet) => {
-      if (cs instanceof UnionCharSet) {
-        cs.fns.forEach((fn) => {
-          fns.add(fn);
-        });
-        cs.concrete.forEach((c) => {
-          concrete.add(c);
-        });
-      } else if (cs instanceof VirtualCharSet) {
-        fns.add(cs.fn);
-      } else {
-        Assert(cs instanceof ConcreteCharSet);
-        cs.concrete.forEach((c) => {
-          concrete.add(c);
-        });
-      }
-    };
-    add(this);
-    add(other);
-    return new UnionCharSet(concrete, fns);
-  }
-}
-
-class UnionCharSet extends CharSet {
-  concrete;
-  fns;
-  constructor(concrete: Set<number>, fns: Set<(ch: number) => boolean>) {
-    super();
-
-    this.concrete = concrete;
-    this.fns = fns;
-  }
-
-  has(c: number) {
-    if (this.concrete.has(c)) {
-      return true;
-    }
-    for (const fn of this.fns) {
-      if (fn(c)) {
+  abstract isConcrete(): this is ConcreteCharSet;
+  some(cb: (a: number) => boolean) {
+    for (let i = 0; i <= 0x10FFFF; i++) {
+      if (this.has(i) && cb(i)) {
         return true;
       }
     }
     return false;
   }
+  union(other: CharSet): CharSet {
+    if (other === CharSet.EmptyCharSet.instance) {
+      return this;
+    }
+    if (other === CharSet.AllCharactersCharSet.instance) {
+      return other;
+    }
+    const concrete = new Set<number>();
+    const virtuals = new Set<CharSet>();
+    const add = (cs: CharSet) => {
+      if (cs instanceof CharSet.UnionCharSet) {
+        cs.virtuals.forEach((v) => {
+          virtuals.add(v);
+        });
+        cs.concrete.forEach((c) => {
+          concrete.add(c);
+        });
+      } else if (cs instanceof CharSet.ConcreteCharSet) {
+        cs.concrete.forEach((c) => {
+          concrete.add(c);
+        });
+      } else {
+        virtuals.add(cs);
+      }
+    };
+    add(this);
+    add(other);
+    if (virtuals.size === 0) {
+      if (concrete.size === 0) {
+        return CharSet.EmptyCharSet.instance;
+      }
+      return new CharSet.ConcreteCharSet(concrete);
+    }
+    return new CharSet.UnionCharSet(concrete, virtuals);
+  }
+  except(other: CharSet): CharSet {
+    if (other === CharSet.EmptyCharSet.instance) {
+      return this;
+    }
+    if (other === CharSet.AllCharactersCharSet.instance) {
+      return CharSet.empty();
+    }
+    return new CharSet.ComplementCharSet(this, other);
+  }
+  static empty(): CharSet {
+    return CharSet.EmptyCharSet.instance;
+  }
+  static all(): CharSet {
+    return CharSet.AllCharactersCharSet.instance;
+  }
+  static from(items: Iterable<number>): CharSet {
+    const concrete = new Set(items);
+    if (concrete.size === 0) {
+      return CharSet.EmptyCharSet.instance;
+    }
+    return new CharSet.ConcreteCharSet(concrete);
+  }
+  static of(...items: number[]): CharSet {
+    if (items.length === 0) {
+      return CharSet.EmptyCharSet.instance;
+    }
+    return new CharSet.ConcreteCharSet(items);
+  }
+  static virtual(has: (c: number) => boolean, some?: (cb: (a: number) => boolean) => boolean): CharSet {
+    return new CharSet.VirtualCharSet(has, some);
+  }
+
+  private static EmptyCharSet = class EmptyCharSet extends CharSet {
+    static readonly instance = new EmptyCharSet();
+    override has(_c: number): boolean {
+      return false;
+    }
+    override some(_cb: (a: number) => boolean): boolean {
+      return false;
+    }
+    override union(other: CharSet): CharSet {
+      return other;
+    }
+    override except(_other: CharSet): CharSet {
+      return this;
+    }
+    override isConcrete() { return true; }
+    get size() { return 0; }
+    first(): never {
+      Assert(false);
+    }
+  };
+
+  private static AllCharactersCharSet = class AllCharactersCharSet extends CharSet {
+    static readonly instance = new AllCharactersCharSet();
+    override has(_c: number): boolean {
+      return true;
+    }
+    override union(_other: CharSet): CharSet {
+        return this;
+    }
+    override isConcrete() { return false; }
+  };
+
+  private static ConcreteCharSet = class ConcreteCharSet extends CharSet {
+    concrete;
+    constructor(items: Iterable<number>) {
+      super();
+      this.concrete = items instanceof Set ? items : new Set(items);
+    }
+    override has(c: number) {
+      return this.concrete.has(c);
+    }
+    override some(cb: (a: number) => boolean) {
+      for (const a of this.concrete) {
+        if (cb(a)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    override except(other: CharSet): CharSet {
+      if (other === CharSet.EmptyCharSet.instance) {
+        return this;
+      }
+      if (other === CharSet.AllCharactersCharSet.instance) {
+        return CharSet.EmptyCharSet.instance;
+      }
+      const concrete = new Set<number>();
+      for (const a of this.concrete) {
+        if (!other.has(a)) {
+          concrete.add(a);
+        }
+      }
+      if (concrete.size === 0) {
+        return CharSet.EmptyCharSet.instance;
+      }
+      return new ConcreteCharSet(concrete);
+    }
+    override isConcrete() { return true; }
+    get size() {
+      return this.concrete.size;
+    }
+    first() {
+      Assert(this.concrete.size >= 1);
+      return this.concrete.values().next().value;
+    }
+  };
+
+  private static UnionCharSet = class UnionCharSet extends CharSet {
+    concrete: ReadonlySet<number>;
+    virtuals: ReadonlySet<CharSet>;
+
+    constructor(concrete: Iterable<number>, virtuals: Iterable<CharSet>) {
+      super();
+      this.concrete = concrete instanceof Set ? concrete : new Set(concrete);
+      this.virtuals = virtuals instanceof Set ? virtuals : new Set(virtuals);
+    }
+
+    override has(c: number) {
+      if (this.concrete.has(c)) {
+        return true;
+      }
+      for (const v of this.virtuals) {
+        if (v.has(c)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    override some(cb: (a: number) => boolean) {
+      for (const a of this.concrete) {
+        if (cb(a)) {
+          return true;
+        }
+      }
+      for (const v of this.virtuals) {
+        if (v.some(cb)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    override isConcrete() { return false; }
+  };
+
+  private static VirtualCharSet = class VirtualCharSet extends CharSet {
+    private _hasfn;
+    private _somefn;
+    private _includedCache: Set<number> | undefined;
+    private _excludedCache: Set<number> | undefined;
+    private _nextCodePoint = 0;
+    constructor(has: (ch: number) => boolean, some?: (cb: (a: number) => boolean) => boolean) {
+      super();
+      this._hasfn = has;
+      this._somefn = some;
+    }
+    override has(c: number) {
+      if (this._includedCache?.has(c)) {
+        // We've already tested and found this value and it was included, so indicate it was present.
+        return true;
+      }
+      if (this._excludedCache?.has(c)) {
+        // We've already tested and found this value is excluded, so indicate it was not present.
+        return false;
+      }
+      if (c === this._nextCodePoint) {
+        // This is the next code point we haven't cached yet, so increment the counter before we cache the result below.
+        this._nextCodePoint++;
+      }
+      if (this._hasfn(c)) {
+        this._includedCache ??= new Set();
+        this._includedCache.add(c);
+        return true;
+      } else {
+        this._excludedCache ??= new Set();
+        this._excludedCache.add(c);
+        return false;
+      }
+    }
+    override some(cb: (a: number) => boolean) {
+      if (this._somefn) {
+        return this._somefn(cb);
+      }
+
+      if (this._nextCodePoint > 0x10FFFF) {
+        // We've enumerated every possible code point so we can just iterate over the cache.
+        if (this._includedCache) {
+          for (const a of this._includedCache) {
+            if (cb(a)) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+
+      return super.some(cb);
+    }
+    override isConcrete() { return false; }
+  };
+
+  private static ComplementCharSet = class ComplementCharSet extends CharSet {
+    first;
+    second;
+    constructor(first: CharSet, second: CharSet) {
+      super();
+      this.first = first;
+      this.second = second;
+    }
+    override has(ch: number) {
+      return this.first.has(ch) && !this.second.has(ch);
+    }
+    override some(cb: (a: number) => boolean) {
+      return this.first.some(a => !this.second.has(a) && cb(a));
+    }
+    override isConcrete() { return false; }
+  };
 }
 
-class ConcreteCharSet extends CharSet {
-  concrete;
-  constructor(items: Iterable<number>) {
-    super();
-    this.concrete = items instanceof Set ? items : new Set(items);
-  }
-
-  has(c: number) {
-    return this.concrete.has(c);
-  }
-
-  get size() {
-    return this.concrete.size;
-  }
-
-  first() {
-    Assert(this.concrete.size >= 1);
-    return this.concrete.values().next().value;
-  }
+interface ConcreteCharSet extends CharSet {
+  get size(): number;
+  first(): number;
+  isConcrete(): true;
 }
 
-class VirtualCharSet extends CharSet {
-  fn;
-  constructor(fn: (ch: number) => boolean) {
-    super();
-    this.fn = fn;
-  }
-
-  has(c: number) {
-    return this.fn(c);
-  }
-}
-
-class Range {
-  startIndex;
-  endIndex;
+/** https://tc39.es/ecma262/#pattern-capturerange */
+class CaptureRange {
+  StartIndex;
+  EndIndex;
   constructor(startIndex: number, endIndex: number) {
     Assert(startIndex <= endIndex);
-    this.startIndex = startIndex;
-    this.endIndex = endIndex;
+    this.StartIndex = startIndex;
+    this.EndIndex = endIndex;
   }
 }
 
 /** https://tc39.es/ecma262/#sec-pattern */
 //   Pattern :: Disjunction
-export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string) {
+export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, rer: RegExpRecord) {
   // The descriptions below use the following variables:
   //   * Input is a List consisting of all of the characters, in order, of the String being matched
   //     by the regular expression pattern. Each character is either a code unit or a code point,
@@ -170,66 +369,45 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
   //   * IgnoreCase is true if the RegExp object's [[OriginalFlags]] internal slot contains "i" and otherwise is false.
   //   * Multiline is true if the RegExp object's [[OriginalFlags]] internal slot contains "m" and otherwise is false.
   //   * Unicode is true if the RegExp object's [[OriginalFlags]] internal slot contains "u" and otherwise is false.
-  let Input: number[];
-  let InputLength: number;
-  const NcapturingParens = Pattern.capturingGroups.length;
-  const DotAll = flags.includes('s');
-  const IgnoreCase = flags.includes('i');
-  const Multiline = flags.includes('m');
-  const Unicode = flags.includes('u');
 
   {
-    // *1. Let modifiers be the Modifiers Record { [[DotAll]]: DotAll, [[IgnoreCase]]: IgnoreCase, [[Multiline]]: Multiline }.
-    const modifiers = new ModifiersRecord(DotAll, IgnoreCase, Multiline);
-    // 1. Evaluate Disjunction with +1 as its direction argument to obtain a Matcher m.
-    const m = CompileSubpattern(Pattern.Disjunction, FORWARD, modifiers);
-    // 2. Return a new abstract closure with parameters (str, index) that captures m and performs the following steps when called:
-    return (str: JSStringValue, index: number) => {
-      // a. Assert: Type(str) is String.
-      Assert(str instanceof JSStringValue);
+    // 1. Let m be CompileSubpattern of Disjunction with arguments rer and FORWARD.
+    const m = CompileSubpattern(Pattern.Disjunction, rer, FORWARD);
+    // 2. Return a new Abstract Closure with parameters (Input, index) that captures rer and m and performs the following steps when called:
+    return (Input: number[], index: number) => {
+      // a. Assert: Input is a List of characters.
       // b. Assert: index is a non-negative integer which is ≤ the length of str.
-      Assert(isNonNegativeInteger(index) && index <= str.stringValue().length);
-      // c. If Unicode is true, let Input be a List consisting of the sequence of code points of ! StringToCodePoints(str).
-      //    Otherwise, let Input be a List consisting of the sequence of code units that are the elements of str.
-      //    Input will be used throughout the algorithms in 21.2.2. Each element of Input is considered to be a character.
-      if (Unicode) {
-        Input = X(StringToCodePoints(str.stringValue()));
-      } else {
-        Input = str.stringValue().split('').map((c) => c.charCodeAt(0));
-      }
-      // d. Let InputLength be the number of characters contained in Input. This variable will be used throughout the algorithms in 21.2.2.
-      InputLength = Input.length;
-      // e. Let listIndex be the index into Input of the character that was obtained from element index of str.
-      const listIndex = index;
-      // f. Let c be a new Continuation with parameters (y) that captures nothing and performs the following steps when called:
+      Assert(isNonNegativeInteger(index) && index <= Input.length);
+      // c. Let c be a new MatcherContinuation with parameters (y) that captures nothing and performs the following steps when called:
       const c: MatcherContinuation = (y) => {
-        // i. Assert: y is a State.
+        // i. Assert: y is a MatchState.
         Assert(y instanceof MatchState);
         // ii. Return y.
         return y;
       };
-      // g. Let cap be a List of NcapturingParens undefined values, indexed 1 through NcapturingParens.
-      const cap = Array.from({ length: NcapturingParens + 1 }, () => Value.undefined);
-      // h. Let x be the State (listIndex, cap).
-      const x = new MatchState(listIndex, cap);
-      // i. Call m(x, c) and return its result.
+      // d. Let cap be a List of rer.[[CapturingGroupCount]] undefined values, indexed 1 through rer.[[CapturingGroupCount]].
+      const cap = Array.from({ length: rer.CapturingGroupsCount + 1 }, () => Value.undefined);
+      // e. Let x be the MatchState { [[Input]]: Input, [[EndIndex]]: index, [[Captures]]: cap }.
+      const x = new MatchState(Input, index, cap);
+      // f. Return m(x, c).
       return m(x, c);
     };
   }
 
   /** https://tc39.es/ecma262/#sec-compilesubpattern */
-  function CompileSubpattern(node: ParseNode.RegExp.Disjunction | ParseNode.RegExp.Alternative | ParseNode.RegExp.Term | ParseNode.RegExp.Assertion, direction: Direction, modifiers: ModifiersRecord): Matcher {
-    switch (node.type) {
+  function CompileSubpattern(node: ParseNode.RegExp.Disjunction | ParseNode.RegExp.Alternative | ParseNode.RegExp.Term | ParseNode.RegExp.Assertion, rer: RegExpRecord, direction: Direction): Matcher {
+    const type = node.type;
+    switch (type) {
       case 'Disjunction':
-        return CompileSubpattern_Disjunction(node, direction, modifiers);
+        return CompileSubpattern_Disjunction(node, rer, direction);
       case 'Alternative':
-        return CompileSubpattern_Alternative(node, direction, modifiers);
+        return CompileSubpattern_Alternative(node, rer, direction);
       case 'Term':
-        return CompileSubpattern_Term(node, direction, modifiers);
+        return CompileSubpattern_Term(node, rer, direction);
       case 'Assertion':
-        return CompileSubpattern_Assertion(node, direction, modifiers);
+        return CompileSubpattern_Assertion(node, rer, direction);
       default:
-        throw new OutOfRange('CompileSubpattern', subtype);
+        throw new OutOfRange('CompileSubpattern', type);
     }
   }
 
@@ -237,200 +415,75 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
   //   Disjunction ::
   //     Alternative
   //     Alternative `|` Disjunction
-  function CompileSubpattern_Disjunction({ Alternative, Disjunction }: ParseNode.RegExp.Disjunction, direction: Direction, modifiers: ModifiersRecord): Matcher {
+  function CompileSubpattern_Disjunction({ Alternative, Disjunction }: ParseNode.RegExp.Disjunction, rer: RegExpRecord, direction: Direction): Matcher {
     if (!Disjunction) {
       // 1. Evaluate Alternative with argument direction to obtain a Matcher m.
-      const m = CompileSubpattern(Alternative, direction, modifiers);
+      const m = CompileSubpattern(Alternative, rer, direction);
       // 2. Return m.
       return m;
     }
-    // 1. Evaluate Alternative with argument direction to obtain a Matcher m1.
-    const m1 = CompileSubpattern(Alternative, direction, modifiers);
-    // 2. Evaluate Disjunction with argument direction to obtain a Matcher m2.
-    const m2 = CompileSubpattern(Disjunction, direction, modifiers);
-    // 3. Return a new Matcher with parameters (x, c) that captures m1 and m2 and performs the following steps when called:
-    return (x, c) => {
-      // a. Assert: x is a State.
-      Assert(x instanceof MatchState);
-      // b. Assert: c is a Continuation.
-      Assert(isContinuation(c));
-      // c. Call m1(x, c) and let r be its result.
-      const r = m1(x, c);
-      // d. If r is not failure, return r.
-      if (r !== 'failure') {
-        return r;
-      }
-      // e. Call m2(x, c) and return its result.
-      return m2(x, c);
-    };
+    // 1. Let m1 be CompileSubpattern of Alternative with arguments rer and direction.
+    const m1 = CompileSubpattern(Alternative, rer, direction);
+    // 2. Let m2 be CompileSubpattern of Alternative with arguments rer and direction.
+    const m2 = CompileSubpattern(Disjunction, rer, direction);
+    // 3. Return MatchTwoAlternatives(m1, m2).
+    return MatchTwoAlternatives(m1, m2);
   }
 
   /** https://tc39.es/ecma262/#sec-alternative */
   //   Alternative ::
   //     [empty]
   //     Alternative Term
-  function CompileSubpattern_Alternative({ Alternative, Term }: ParseNode.RegExp.Alternative, direction: Direction, modifiers: ModifiersRecord): Matcher {
+  function CompileSubpattern_Alternative({ Alternative, Term }: ParseNode.RegExp.Alternative, rer: RegExpRecord, direction: Direction): Matcher {
     if (!Alternative && !Term) {
-      // 1. Return a new Matcher with parameters (x, c) that captures nothing and performs the following steps when called:
-      return (x, c) => {
-        // 1. Assert: x is a State.
-        Assert(x instanceof MatchState);
-        // 2. Assert: c is a Continuation.
-        Assert(isContinuation(c));
-        // 3. Call c(x) and return its result.
-        return c(x);
-      };
+      // 1. Return EmptyMatcher().
+      return EmptyMacher();
     }
     // 1. Evaluate Alternative with argument direction to obtain a Matcher m1.
-    const m1 = CompileSubpattern(Alternative!, direction, modifiers);
+    const m1 = CompileSubpattern(Alternative!, rer, direction);
     // 2. Evaluate Term with argument direction to obtain a Matcher m2.
-    const m2 = CompileSubpattern(Term!, direction, modifiers);
-    // 3. If direction is equal to +1, then
-    if (direction === FORWARD) {
-      // a. Return a new Matcher with parameters (x, c) that captures m1 and m2 and performs the following steps when called:
-      return (x, c) => {
-        // i. Assert: x is a State.
-        Assert(x instanceof MatchState);
-        // ii. Assert: c is a Continuation.
-        Assert(isContinuation(c));
-        // iii. Let d be a new Continuation with parameters (y) that captures c and m2 and performs the following steps when called:
-        const d: MatcherContinuation = (y) => {
-          // 1. Assert: y is a State.
-          Assert(y instanceof MatchState);
-          // 2. Call m2(y, c) and return its result.
-          return m2(y, c);
-        };
-        // iv. Call m1(x, d) and return its result.
-        return m1(x, d);
-      };
-    } else { // 4. Else,
-      // a. Assert: direction is equal to -1.
-      Assert(direction === BACKWARD);
-      // b. Return a new Matcher with parameters (x, c) that captures m1 and m2 and performs the following steps when called:
-      return (x, c) => {
-        // i. Assert: x is a State.
-        Assert(x instanceof MatchState);
-        // ii. Assert: c is a Continuation.
-        Assert(isContinuation(c));
-        // iii. Let d be a new Continuation with parameters (y) that captures c and m1 and performs the following steps when called:
-        const d: MatcherContinuation = (y) => {
-          // 1. Assert: y is a State.
-          Assert(y instanceof MatchState);
-          // 2. Call m1(y, c) and return its result.
-          return m1(y, c);
-        };
-        // iv. Call m2(x, d) and return its result.
-        return m2(x, d);
-      };
-    }
+    const m2 = CompileSubpattern(Term!, rer, direction);
+    // 3. Return MatchSequence(m1, m2, direction).
+    return MatchSequence(m1, m2, direction);
   }
 
   /** https://tc39.es/ecma262/#sec-term */
   //   Term ::
   //     Atom
   //     Atom Quantifier
-  function CompileSubpattern_Term(Term: ParseNode.RegExp.Term_Atom, direction: Direction, modifiers: ModifiersRecord): Matcher {
+  function CompileSubpattern_Term(Term: ParseNode.RegExp.Term_Atom, rer: RegExpRecord, direction: Direction): Matcher {
     const { Atom, Quantifier } = Term;
     if (!Quantifier) {
-      // 1. Return the Matcher that is the result of evaluating Atom with argument direction.
-      return CompileAtom(Atom, direction, modifiers);
+      // 1. Return CompileAtom of Atom with arguments rer and direction.
+      return CompileAtom(Atom, rer, direction);
     }
-    // 1. Evaluate Atom with argument direction to obtain a Matcher m.
-    const m = CompileAtom(Atom, direction, modifiers);
-    // 2. Evaluate Quantifier to obtain the three results: an integer min, an integer (or ∞) max, and Boolean greedy.
-    const [min, max, greedy] = CompileQuantifier(Quantifier);
-    // 3. Assert: If max is finite, then max is not less than min.
-    Assert(!Number.isFinite(max) || (max >= min));
-    // 4. Let parenIndex be the number of left-capturing parentheses in the entire regular expression that occur to the
-    //    left of this Term. This is the total number of Atom :: `(` GroupSpecifier Disjunction `)` Parse Nodes prior to
-    //    or enclosing this Term.
-    const parenIndex = Term.capturingParenthesesBefore;
-    // 5. Let parenCount be the number of left-capturing parentheses in Atom. This is the total number of
-    //    Atom :: `(` GroupSpecifier Disjunction `)` Parse Nodes enclosed by Atom.
-    const parenCount = 'enclosedCapturingParentheses' in Atom ? Atom.enclosedCapturingParentheses : 0;
-    // 6. Return a new Matcher with parameters (x, c) that captures m, min, max, greedy, parenIndex, and parenCount and performs the following steps when called:
+    // 1. Let m be CompileAtom of Atom with arguments rer and direction.
+    const m = CompileAtom(Atom, rer, direction);
+    // 2. Let q be CompileQuantifier of Quantifier.
+    const q = CompileQuantifier(Quantifier);
+    // 3. Assert: q.[[Min]] <= q.[[Max]].
+    Assert(q.Min <= q.Max);
+    // 4. Let parenIndex be CountLeftCapturingParensBefore(Term).
+    const parenIndex = CountLeftCapturingParensBefore(Term);
+    // 5. Let parenCount be CountLeftCapturingParensWithin(Atom).
+    const parenCount = CountLeftCapturingParensWithin(Atom);
+    // 6. Return a new Matcher with parameters (x, c) that captures m, q, parenIndex, and parenCount and performs the following steps when called:
     return (x, c) => {
-      // a. Assert: x is a State.
+      // a. Assert: x is a MatchState.
       Assert(x instanceof MatchState);
-      // b. Assert: c is a Continuation.
+      // b. Assert: c is a MatcherContinuation.
       Assert(isContinuation(c));
-      // c. Call RepeatMatcher(m, min, max, greedy, x, c, parenIndex, parenCount) and return its result.
-      return RepeatMatcher(m, min, max, greedy, x, c, parenIndex, parenCount);
+      // c. Call RepeatMatcher(m, q.[[Min]], q.[[Max]], q.[[Greedy]], x, c, parenIndex, parenCount) and return its result.
+      return RepeatMatcher(m, q.Min, q.Max, q.Greedy, x, c, parenIndex, parenCount);
     };
   }
 
   /** https://tc39.es/ecma262/#sec-term */
   //   Term ::
   //     Assertion
-  function CompileSubpattern_Assertion(Assertion: ParseNode.RegExp.Assertion, _direction: Direction, modifiers: ModifiersRecord) {
-    // 1. Return CompileAssertion of Assertion with argument modifiers.
-    return CompileAssertion(Assertion, modifiers);
-  }
-
-  /** https://tc39.es/ecma262/#sec-runtime-semantics-repeatmatcher-abstract-operation */
-  function RepeatMatcher(m: Matcher, min: number, max: number, greedy: boolean, x: MatchState, c: MatcherContinuation, parenIndex: number, parenCount: number): MatchResult {
-    // 1. If max is zero, return c(x).
-    if (max === 0) {
-      return c(x);
-    }
-    // 2. Let d be a new Continuation with parameters (y) that captures m, min, max, greedy, x, c, parenIndex, and parenCount and performs the following steps when called:
-    const d: MatcherContinuation = (y) => {
-      // a. Assert: y is a State.
-      Assert(y instanceof MatchState);
-      // b. If min is zero and y's endIndex is equal to x's endIndex, return failure.
-      if (min === 0 && y.endIndex === x.endIndex) {
-        return 'failure';
-      }
-      // c. If min is zero, let min2 be zero; otherwise let min2 be min - 1.
-      let min2;
-      if (min === 0) {
-        min2 = 0;
-      } else {
-        min2 = min - 1;
-      }
-      // d. If max is ∞, let max2 be ∞; otherwise let max2 be max - 1.
-      let max2;
-      if (max === Infinity) {
-        max2 = Infinity;
-      } else {
-        max2 = max - 1;
-      }
-      // e. Call RepeatMatcher(m, min2, max2, greedy, y, c, parenIndex, parenCount) and return its result.
-      return RepeatMatcher(m, min2, max2, greedy, y, c, parenIndex, parenCount);
-    };
-    // 3. Let cap be a copy of x's captures List.
-    const cap = [...x.captures];
-    // 4. For each integer k that satisfies parenIndex < k and k ≤ parenIndex + parenCount, set cap[k] to undefined.
-    for (let k = parenIndex + 1; k <= parenIndex + parenCount; k += 1) {
-      cap[k] = Value.undefined;
-    }
-    // 5. Let e be x's endIndex.
-    const e = x.endIndex;
-    // 6. Let xr be the State (e, cap).
-    const xr = new MatchState(e, cap);
-    // 7. If min is not zero, return m(xr, d).
-    if (min !== 0) {
-      return m(xr, d);
-    }
-    // 8. If greedy is false, then
-    if (greedy === false) {
-      // a. Call c(x) and let z be its result.
-      const z = c(x);
-      // b. If z is not failure, return z.
-      if (z !== 'failure') {
-        return z;
-      }
-      // c. Call m(xr, d) and return its result.
-      return m(xr, d);
-    }
-    // 9. Call m(xr, d) and let z be its result.
-    const z = m(xr, d);
-    // 10. If z is not failure, return z.
-    if (z !== 'failure') {
-      return z;
-    }
-    // 11. Call c(x) and return its result.
-    return c(x);
+  function CompileSubpattern_Assertion(Assertion: ParseNode.RegExp.Assertion, rer: RegExpRecord, _direction: Direction) {
+    // 1. Return CompileAssertion of Assertion with argument rer.
+    return CompileAssertion(Assertion, rer);
   }
 
   /** https://tc39.es/ecma262/#sec-assertion */
@@ -443,201 +496,215 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
   //     `(` `?` `!` Disjunction `)`
   //     `(` `?` `<=` Disjunction `)`
   //     `(` `?` `<!` Disjunction `)`
-  function CompileAssertion({ subtype, Disjunction }: ParseNode.RegExp.Assertion, modifiers: ModifiersRecord): Matcher {
+  function CompileAssertion({ subtype, Disjunction }: ParseNode.RegExp.Assertion, rer: RegExpRecord): Matcher {
     switch (subtype) {
       case '^':
-        // 1. Return a new Matcher with parameters (x, c) that captures nothing and performs the following steps when called:
+        // 1. Return a new Matcher with parameters (x, c) that captures rer and performs the following steps when called:
         return (x, c) => {
-          // a. Assert: x is a State.
+          // a. Assert: x is a MatchState.
           Assert(x instanceof MatchState);
-          // b. Assert: c is a Continuation.
+          // b. Assert: c is a MatcherContinuation.
           Assert(isContinuation(c));
-          // c. Let e be x's endIndex.
-          const e = x.endIndex;
-          // d. If e is zero, or if Multiline is true and the character Input[e - 1] is one of LineTerminator, then
-          if (e === 0 || (modifiers.Multiline && isLineTerminator(String.fromCodePoint(Input[e - 1])))) {
-            // i. Call c(x) and return its result.
+          // c. Let Input be x.[[Input]].
+          const Input = x.Input;
+          // d. Let e be x.[[EndIndex]].
+          const e = x.EndIndex;
+          // e. If e = 0, or if rer.[[Multiline]] is true and the character Input[e - 1] is one of LineTerminator, then
+          if (e === 0 || (rer.Multiline && isLineTerminator(String.fromCodePoint(Input[e - 1])))) {
+            // i. Return c(x).
             return c(x);
           }
-          // e. Return failure.
-          return 'failure';
+          // e. Return FAILURE.
+          return FAILURE;
         };
       case '$':
-        // 1. Return a new Matcher with parameters (x, c) that captures nothing and performs the following steps when called:
+        // 1. Return a new Matcher with parameters (x, c) that captures rer and performs the following steps when called:
         return (x, c) => {
-          // a. Assert: x is a State.
+          // a. Assert: x is a MatchState.
           Assert(x instanceof MatchState);
-          // b. Assert: c is a Continuation.
+          // b. Assert: c is a MatcherContinuation.
           Assert(isContinuation(c));
-          // c. Let e be x's endIndex.
-          const e = x.endIndex;
-          // d. If e is equal to InputLength, or if Multiline is true and the character Input[e] is one of LineTerminator, then
-          if (e === InputLength || (modifiers.Multiline && isLineTerminator(String.fromCodePoint(Input[e])))) {
-            // i. Call c(x) and return its result.
+          // c. Let Input be x.[[Input]].
+          const Input = x.Input;
+          // d. Let e be x.[[EndIndex]].
+          const e = x.EndIndex;
+          // e. Let InputLength be the number of elements of Input.
+          const InputLength = Input.length;
+          // f. If e = InputLength, or if rer.Multiline is true and the character Input[e] is one of LineTerminator, then
+          if (e === InputLength || (rer.Multiline && isLineTerminator(String.fromCodePoint(Input[e])))) {
+            // i. Return c(x).
             return c(x);
           }
-          // e. Return failure.
-          return 'failure';
+          // e. Return FAILURE.
+          return FAILURE;
         };
       case 'b':
-        // 1. Return a new Matcher with parameters (x, c) that captures nothing and performs the following steps when called:
+        // 1. Return a new Matcher with parameters (x, c) that captures rer and performs the following steps when called:
         return (x, c) => {
-          // a. Assert: x is a State.
+          // a. Assert: x is a MatchState.
           Assert(x instanceof MatchState);
-          // b. Assert: c is a Continuation.
+          // b. Assert: c is a MatcherContinuation.
           Assert(isContinuation(c));
-          // c. Let e be x's endIndex.
-          const e = x.endIndex;
-          // d. Call IsWordChar(e - 1) and let a be the Boolean result.
-          const a = IsWordChar(e - 1, modifiers);
-          // e. Call IsWordChar(e) and let b be the Boolean result.
-          const b = IsWordChar(e, modifiers);
+          // c. Let Input be x.[[Input]].
+          const Input = x.Input;
+          // d. Let e be x.[[EndIndex]].
+          const e = x.EndIndex;
+          // e. Let a be IsWordChar(e - 1).
+          const a = IsWordChar(rer, Input, e - 1);
+          // e. Let b be IsWordChar(e).
+          const b = IsWordChar(rer, Input, e);
           // f. If a is true and b is false, or if a is false and b is true, then
           if ((a && !b) || (!a && b)) {
-            // i. Call c(x) and return its result.
+            // i. Return c(x).
             return c(x);
           }
-          // g. Return failure.
-          return 'failure';
+          // g. Return FAILURE.
+          return FAILURE;
         };
       case 'B':
-        // 1. Return a new Matcher with parameters (x, c) that captures nothing and performs the following steps when called:
+        // 1. Return a new Matcher with parameters (x, c) that captures rer and performs the following steps when called:
         return (x, c) => {
-          // a. Assert: x is a State.
+          // a. Assert: x is a MatchState.
           Assert(x instanceof MatchState);
-          // b. Assert: c is a Continuation.
+          // b. Assert: c is a MatcherContinuation.
           Assert(isContinuation(c));
-          // c. Let e be x's endIndex.
-          const e = x.endIndex;
-          // d. Call IsWordChar(e - 1) and let a be the Boolean result.
-          const a = IsWordChar(e - 1, modifiers);
-          // e. Call IsWordChar(e) and let b be the Boolean result.
-          const b = IsWordChar(e, modifiers);
+          // c. Let Input be x.[[Input]].
+          const Input = x.Input;
+          // d. Let e be x.[[EndIndex]].
+          const e = x.EndIndex;
+          // e. Let a be IsWordChar(e - 1).
+          const a = IsWordChar(rer, Input, e - 1);
+          // f. Let b be IsWordChar(e).
+          const b = IsWordChar(rer, Input, e);
           // f. If a is true and b is true, or if a is false and b is false, then
           if ((a && b) || (!a && !b)) {
-            // i. Call c(x) and return its result.
+            // i. Return c(x).
             return c(x);
           }
-          // g. Return failure.
-          return 'failure';
+          // g. Return FAILURE.
+          return FAILURE;
         };
       case '?=': {
-        // 1. Evaluate Disjunction with +1 as its direction argument to obtain a Matcher m.
-        const m = CompileSubpattern(Disjunction!, FORWARD, modifiers);
+        // 1. Let m be CompileSubpattern of Disjunction with arguments rer and FORWARD.
+        const m = CompileSubpattern(Disjunction, rer, FORWARD);
         // 2. Return a new Matcher with parameters (x, c) that captures m and performs the following steps when called:
         return (x, c) => {
-          // a. Assert: x is a State.
+          // a. Assert: x is a MatchState.
           Assert(x instanceof MatchState);
-          // b. Assert: c is a Continuation.
+          // b. Assert: c is a MatcherContinuation.
           Assert(isContinuation(c));
-          // c. Let d be a new Continuation with parameters (y) that captures nothing and performs the following steps when called:
+          // c. Let d be a new MatcherContinuation with parameters (y) that captures nothing and performs the following steps when called:
           const d: MatcherContinuation = (y) => {
-            // i. Assert: y is a State.
+            // i. Assert: y is a MatchState.
             Assert(y instanceof MatchState);
             // ii. Return y.
             return y;
           };
-          // d. Call m(x, d) and let r be its result.
+          // d. Let r be m(x, d).
           const r = m(x, d);
-          // e. If r is failure, return failure.
-          if (r === 'failure') {
-            return 'failure';
+          // e. If r is FAILURE, return FAILURE.
+          if (r === FAILURE) {
+            return FAILURE;
           }
-          // f. Let y be r's State.
-          const y = r;
-          // g. Let cap be y's captures List.
-          const cap = y.captures;
-          // h. Let xe be x's endIndex.
-          const xe = x.endIndex;
-          // i. Let z be the State (xe, cap).
-          const z = new MatchState(xe, cap);
-          // j. Call c(z) and return its result.
+          // f. Assert: r is a MatchState.
+          Assert(r instanceof MatchState);
+          // g. Let cap be r.[[Captures]].
+          const cap = r.Captures;
+          // h. Let Input be x.[[Input]].
+          const Input = x.Input;
+          // i. Let xe be x.[[EndIndex]].
+          const xe = x.EndIndex;
+          // j. Let z be the MatchState { [[Input]]: Input, [[EndIndex]]: xe, [[Captures]]: cap }.
+          const z = new MatchState(Input, xe, cap);
+          // k. Return c(z).
           return c(z);
         };
       }
       case '?!': {
-        // 1. Evaluate Disjunction with +1 as its direction argument to obtain a Matcher m.
-        const m = CompileSubpattern(Disjunction!, FORWARD, modifiers);
+        // 1. Let m be CompileSubpattern of Disjunction with arguments rer and FORWARD.
+        const m = CompileSubpattern(Disjunction, rer, FORWARD);
         // 2. Return a new Matcher with parameters (x, c) that captures m and performs the following steps when called:
         return (x, c) => {
-          // a. Assert: x is a State.
+          // a. Assert: x is a MatchState.
           Assert(x instanceof MatchState);
-          // b. Assert: c is a Continuation.
+          // b. Assert: c is a MatcherContinuation.
           Assert(isContinuation(c));
-          // c. Let d be a new Continuation with parameters (y) that captures nothing and performs the following steps when called:
+          // c. Let d be a new MatcherContinuation with parameters (y) that captures nothing and performs the following steps when called:
           const d: MatcherContinuation = (y) => {
-            // i. Assert: y is a State.
+            // i. Assert: y is a MatchState.
             Assert(y instanceof MatchState);
             // ii. Return y.
             return y;
           };
-          // d. Call m(x, d) and let r be its result.
+          // d. Let r be m(x, d).
           const r = m(x, d);
-          // e. If r is not failure, return failure.
-          if (r !== 'failure') {
-            return 'failure';
+          // e. If r is not FAILURE, return FAILURE.
+          if (r !== FAILURE) {
+            return FAILURE;
           }
-          // f. Call c(x) and return its result.
+          // f. Return c(x).
           return c(x);
         };
       }
       case '?<=': {
-        // 1. Evaluate Disjunction with -1 as its direction argument to obtain a Matcher m.
-        const m = CompileSubpattern(Disjunction!, BACKWARD, modifiers);
+        // 1. Let m be CompileSubpattern of Disjunction with arguments rer and BACKWARD.
+        const m = CompileSubpattern(Disjunction, rer, BACKWARD);
         // 2. Return a new Matcher with parameters (x, c) that captures m and performs the following steps when called:
         return (x, c) => {
-          // a. Assert: x is a State.
+          // a. Assert: x is a MatchState.
           Assert(x instanceof MatchState);
-          // b. Assert: c is a Continuation.
+          // b. Assert: c is a MatcherContinuation.
           Assert(isContinuation(c));
-          // c. Let d be a new Continuation with parameters (y) that captures nothing and performs the following steps when called:
+          // c. Let d be a new MatcherContinuation with parameters (y) that captures nothing and performs the following steps when called:
           const d: MatcherContinuation = (y) => {
-            // i. Assert: y is a State.
+            // i. Assert: y is a MatchState.
             Assert(y instanceof MatchState);
             // ii. Return y.
             return y;
           };
-          // d. Call m(x, d) and let r be its result.
+          // d. Let r be m(x, d).
           const r = m(x, d);
-          // e. If r is failure, return failure.
-          if (r === 'failure') {
-            return 'failure';
+          // e. If r is FAILURE, return FAILURE.
+          if (r === FAILURE) {
+            return FAILURE;
           }
-          // f. Let y be r's State.
-          const y = r;
-          // g. Let cap be y's captures List.
-          const cap = y.captures;
-          // h. Let xe be x's endIndex.
-          const xe = x.endIndex;
-          // i. Let z be the State (xe, cap).
-          const z = new MatchState(xe, cap);
-          // j. Call c(z) and return its result.
+          // f. Assert: r is a MatchState.
+          Assert(r instanceof MatchState);
+          // g. Let cap be y.[[Captures]].
+          const cap = r.Captures;
+          // h: Let Input be x.[[Input]].
+          const Input = x.Input;
+          // i. Let xe be x.[[EndIndex]].
+          const xe = x.EndIndex;
+          // j. Let z be the MatchState { [[Input]]: Input, [[EndIndex]]: xe, [[Captures]]: cap }.
+          const z = new MatchState(Input, xe, cap);
+          // k. Return c(z).
           return c(z);
         };
       }
       case '?<!': {
-        // 1. Evaluate Disjunction with -1 as its direction argument to obtain a Matcher m.
-        const m = CompileSubpattern(Disjunction!, BACKWARD, modifiers);
+        // 1. Let m be CompileSubpattern of Disjunction with arguments rer and BACKWARD.
+        const m = CompileSubpattern(Disjunction, rer, BACKWARD);
         // 2. Return a new Matcher with parameters (x, c) that captures m and performs the following steps when called:
         return (x, c) => {
-          // a. Assert: x is a State.
+          // a. Assert: x is a MatchState.
           Assert(x instanceof MatchState);
-          // b. Assert: c is a Continuation.
+          // b. Assert: c is a MatcherContinuation.
           Assert(isContinuation(c));
-          // c. Let d be a new Continuation with parameters (y) that captures nothing and performs the following steps when called:
+          // c. Let d be a new MatcherContinuation with parameters (y) that captures nothing and performs the following steps when called:
           const d: MatcherContinuation = (y) => {
-            // i. Assert: y is a State.
+            // i. Assert: y is a MatchState.
             Assert(y instanceof MatchState);
             // ii. Return y.
             return y;
           };
-          // d. Call m(x, d) and let r be its result.
+          // d. Let r be m(x, d).
           const r = m(x, d);
-          // e. If r is not failure, return failure.
-          if (r !== 'failure') {
-            return 'failure';
+          // e. If r is not FAILURE, return FAILURE.
+          if (r !== FAILURE) {
+            return FAILURE;
           }
-          // f. Call c(x) and return its result.
+          // f. Return c(x).
           return c(x);
         };
       }
@@ -646,71 +713,23 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
     }
   }
 
-  /** https://tc39.es/ecma262/#sec-runtime-semantics-wordcharacters-abstract-operation */
-  function GetWordCharacters(modifiers: ModifiersRecord) {
-    // 1. Let A be a set of characters containing the sixty-three characters:
-    //   a b c d e f g h i j k l m n o p q r s t u v w x y z
-    //   A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
-    //   0 1 2 3 4 5 6 7 8 9 _
-    // 2. Let U be an empty set.
-    // 3. For each character c not in set A where Canonicalize(c) is in A, add c to U.
-    // 4. Assert: Unless Unicode and IgnoreCase are both true, U is empty.
-    // 5. Add the characters in set U to set A.
-    // Return A.
-    const A = new ConcreteCharSet([
-      'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '_',
-    ].map((c) => c.codePointAt(0)!));
-    if (Unicode && IgnoreCase) {
-      return new VirtualCharSet((c) => {
-        if (A.has(c)) {
-          return true;
-        }
-        if (A.has(Canonicalize(c, modifiers))) {
-          return true;
-        }
-        return false;
-      });
-    }
-    return A;
-  }
-
-  /** https://tc39.es/ecma262/#sec-runtime-semantics-iswordchar-abstract-operation */
-  function IsWordChar(e: number, modifiers: ModifiersRecord) {
-    // 1. If e is -1 or e is InputLength, return false.
-    if (e === -1 || e === InputLength) {
-      return false;
-    }
-    // 2. Let c be the character Input[e].
-    const c = Input[e];
-    // 3. Let wordChars be the result of ! WordCharacters().
-    const wordChars = X(GetWordCharacters(modifiers));
-    // 4. If c is in wordChars, return true.
-    if (wordChars.has(c)) {
-      return true;
-    }
-    // 5. Return false.
-    return false;
-  }
-
   /** https://tc39.es/ecma262/#sec-quantifier */
   //   Quantifier ::
   //     QuantifierPrefix
   //     QuantifierPrefix `?`
-  function CompileQuantifier({ QuantifierPrefix, greedy }: ParseNode.RegExp.Quantifier): [min: number, max: number, greedy: boolean] {
+  function CompileQuantifier({ QuantifierPrefix, greedy }: ParseNode.RegExp.Quantifier): { Min: number, Max: number, Greedy: boolean } {
     switch (QuantifierPrefix) {
       case '*':
-        return [0, Infinity, greedy];
+        return { Min: 0, Max: Infinity, Greedy: greedy };
       case '+':
-        return [1, Infinity, greedy];
+        return { Min: 1, Max: Infinity, Greedy: greedy };
       case '?':
-        return [0, 1, greedy];
+        return { Min: 0, Max: 1, Greedy: greedy };
       default:
         break;
     }
     const { DecimalDigits_a, DecimalDigits_b } = QuantifierPrefix;
-    return [DecimalDigits_a, DecimalDigits_b || DecimalDigits_a, greedy];
+    return { Min: DecimalDigits_a, Max: DecimalDigits_b || DecimalDigits_a, Greedy: greedy };
   }
 
   /** https://tc39.es/ecma262/#sec-atom */
@@ -722,96 +741,96 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
   //     `(` GroupSpecifier Disjunction `)`
   //     `(` `?` RegularExpressionFlags `:` Disjunction `)`
   //     `(` `?` RegularExpressionFlags `-` RegularExpressionFlags `:` Disjunction `)`
-  function CompileAtom(Atom: ParseNode.RegExp.Atom, direction: Direction, modifiers: ModifiersRecord): Matcher {
+  function CompileAtom(Atom: ParseNode.RegExp.Atom, rer: RegExpRecord, direction: Direction): Matcher {
     switch (true) {
-      case 'PatternCharacter' in Atom && !!Atom.PatternCharacter: {
+      case 'PatternCharacter' in Atom: {
         // 1. Let ch be the character matched by PatternCharacter.
         const ch = Atom.PatternCharacter.codePointAt(0)!;
         // 2. Let A be a one-element CharSet containing the character ch.
-        const A = new ConcreteCharSet([Canonicalize(ch, modifiers)]);
-        // 3. Call CharacterSetMatcher(A, false, direction) and return its Matcher result.
-        return CharacterSetMatcher(A, false, direction, modifiers);
+        const A = CharSet.of(ch);
+        // 3. Return CharacterSetMatcher(rer, A, false, direction).
+        return CharacterSetMatcher(rer, A, false, direction);
       }
-      case 'subtype' in Atom && Atom.subtype === '.': {
-        let A;
-        // 1. If DotAll is true, then
-        if (modifiers.DotAll) {
-          // a. Let A be the set of all characters.
-          A = new VirtualCharSet((_c) => true);
-        } else {
-          // 2. Otherwise, let A be the set of all characters except LineTerminator.
-          A = new VirtualCharSet((c) => !isLineTerminator(String.fromCodePoint(c)));
+      case 'subtype' in Atom: {
+        // 1. Let A be the set of all characters.
+        let A = AllCharacters(rer);
+        // 1. If DotAll is not true, then
+        if (!rer.DotAll) {
+          // a. Remove from A all characters corresponding to a code point on the right-hand side of the LineTerminator production.
+          A = A.except(CharSet.virtual((c) => isLineTerminator(String.fromCodePoint(c))));
         }
-        // 3. Call CharacterSetMatcher(A, false, direction) and return its Matcher result.
-        return CharacterSetMatcher(A, false, direction, modifiers);
+        // 3. Return CharacterSetMatcher(rer, A, false, direction).
+        return CharacterSetMatcher(rer, A, false, direction);
       }
       case Atom.type === 'AtomEscape':
-        return CompileAtom_AtomEscape(Atom, direction, modifiers);
+        return CompileAtom_AtomEscape(Atom, direction, rer);
 
-      case 'CharacterClass' in Atom && !!Atom.CharacterClass: {
-        // 1. Evaluate CharacterClass to obtain a CharSet A and a Boolean invert.
-        const { A, invert } = CompileCharacterClass(Atom.CharacterClass, modifiers);
-        // 2. Call CharacterSetMatcher(A, invert, direction) and return its Matcher result.
-        return CharacterSetMatcher(A, invert, direction, modifiers);
+      case 'CharacterClass' in Atom: {
+        // 1. Let cc be CompileCharacterClass of CharacterClass with argument rer.
+        const cc = CompileCharacterClass(Atom.CharacterClass, rer);
+        // 2. Let cs be cc.[[CharSet]]
+        const cs = cc.CharSet;
+        // 3. Return CharacterSetMatcher(rer, cs, cc.[[Invert], direction).
+        return CharacterSetMatcher(rer, cs, cc.Invert, direction);
       }
-      case 'capturing' in Atom && Atom.capturing && !!Atom.Disjunction: {
-        // 1. Evaluate Disjunction with argument direction to obtain a Matcher m.
-        const m = CompileSubpattern(Atom.Disjunction, direction, modifiers);
-        // 2. Let parenIndex be the number of left-capturing parentheses in the entire regular expression
-        //    that occur to the left of this Atom. This is the total number of Atom :: `(` GroupSpecifier Disjunction `)`
-        //    Parse Nodes prior to or enclosing this Atom.
-        const parenIndex = Atom.capturingParenthesesBefore;
+      case 'capturing' in Atom && Atom.capturing: {
+        // 1. Let m be CompileSubpattern of Disjunction with arguments rer and direction.
+        const m = CompileSubpattern(Atom.Disjunction, rer, direction);
+        // 2. Let parenIndex be CountLeftCapturingParensBefore(Atom).
+        const parenIndex = CountLeftCapturingParensBefore(Atom);
         // 3. Return a new Matcher with parameters (x, c) that captures direction, m, and parenIndex and performs the following steps when called:
         return (x, c) => {
-          // a. Assert: x is a State.
+          // a. Assert: x is a MatchState.
           Assert(x instanceof MatchState);
-          // b. Assert: c is a Continuation.
+          // b. Assert: c is a MatcherContinuation.
           Assert(isContinuation(c));
-          // c. Let d be a new Continuation with parameters (y) that captures x, c, direction, and parenIndex and performs the following steps when called:
+          // c. Let d be a new MatcherContinuation with parameters (y) that captures x, c, direction, and parenIndex and performs the following steps when called:
           const d: MatcherContinuation = (y) => {
-            // i. Assert: y is a State.
+            // i. Assert: y is a MatchState.
             Assert(y instanceof MatchState);
-            // ii. Let cap be a copy of y's captures List.
-            const cap = [...y.captures];
-            // iii. Let xe be x's endIndex.
-            const xe = x.endIndex;
-            // iv. Let ye be y's endIndex.
-            const ye = y.endIndex;
+            // ii. Let cap be a copy of y.[[Captures]].
+            const cap = [...y.Captures];
+            // iii. Let Input be x.[[Input]].
+            const Input = x.Input;
+            // iv. Let xe be x.[[EndIndex]].
+            const xe = x.EndIndex;
+            // v. Let ye be y.[[EndIndex]].
+            const ye = y.EndIndex;
             let s;
-            // v. If direction is equal to +1, then
-            if (direction === +1) {
+            // vi. If direction is FORWARD, then
+            if (direction === FORWARD) {
               // 1. Assert: xe ≤ ye.
               Assert(xe <= ye);
-              // 2. Let r be the Range (xe, ye).
-              s = new Range(xe, ye);
-            } else { // vi. Else,
-              // 1. Assert: direction is equal to -1.
-              Assert(direction === -1);
+              // 2. Let r be the CaptureRange { [[StartIndex]]: xe, [[EndIndex]]: ye }.
+              s = new CaptureRange(xe, ye);
+            } else { // vii. Else,
+              // 1. Assert: direction is BACKWARD.
+              Assert(direction === BACKWARD);
               // 2. Assert: ye ≤ xe.
               Assert(ye <= xe);
-              // 3. Let r be the Range (ye, xe).
-              s = new Range(ye, xe);
+              // 3. Let r be the CaptureRange { [[StartIndex]]: ye, [[EndIndex]]: xe }.
+              s = new CaptureRange(ye, xe);
             }
-            // vii. Set cap[parenIndex + 1] to s.
+            // viii. Set cap[parenIndex + 1] to r.
             cap[parenIndex + 1] = s;
-            // viii. Let z be the State (ye, cap).
-            const z = new MatchState(ye, cap);
-            // ix. Call c(z) and return its result.
+            // ix. Let z be the MatchState { [[Input]]: Input, [[EndIndex]]: ye, [[Captures]]: cap }.
+            const z = new MatchState(Input, ye, cap);
+            // ix. Return c(z).
             return c(z);
           };
-          // d. Call m(x, d) and return its result.
+          // d. Return m(x, d).
           return m(x, d);
         };
       }
-      case 'Disjunction' in Atom && !!Atom.Disjunction: {
+      case 'capturing' in Atom && !Atom.capturing: {
         // *1. Let addModifiers be the source text matched by the first RegularExpressionFlags.
         const addModifiers = Atom.RegularExpressionFlags_a ?? '';
         // *2. Let removeModifiers be the source text matched by the second RegularExpressionFlags.
         const removeModifiers = Atom.RegularExpressionFlags_b ?? '';
-        // *3. Let newModifiers be UpdateModifiers(modifiers, CodePointsToString(addModifiers), CodePointsToString(removeModifiers)).
-        const newModifiers = UpdateModifiers(modifiers, addModifiers, removeModifiers);
-        // *4. Return CompileSubpattern of Disjunction with arguments direction and newModifiers.
-        return CompileSubpattern(Atom.Disjunction, direction, newModifiers);
+        // *3. Let modifiedRer be UpdateModifiers(modifiers, CodePointsToString(addModifiers), CodePointsToString(removeModifiers)).
+        const modifiedRer = UpdateModifiers(rer, addModifiers, removeModifiers);
+        // *4. Return CompileSubpattern of Disjunction with arguments modifiedRer and direction.
+        return CompileSubpattern(Atom.Disjunction, modifiedRer, direction);
       }
       default:
         throw new OutOfRange('CompileAtom', Atom);
@@ -824,197 +843,44 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
   //   CharacterEscape
   //   CharacterClassEscape
   //   `k` GroupName
-  function CompileAtom_AtomEscape(AtomEscape: ParseNode.RegExp.AtomEscape, direction: Direction, modifiers: ModifiersRecord): Matcher {
+  function CompileAtom_AtomEscape(AtomEscape: ParseNode.RegExp.AtomEscape, direction: Direction, rer: RegExpRecord): Matcher {
     switch (true) {
       case !!AtomEscape.DecimalEscape: {
-        // 1. Evaluate DecimalEscape to obtain an integer n.
+        // 1. Let n be the CapturingGroupNumber of DecimalEscape.
         const n = CapturingGroupNumber(AtomEscape.DecimalEscape);
-        // 2. Assert: n ≤ NcapturingParens.
-        Assert(n <= NcapturingParens);
-        // 3. Call BackreferenceMatcher(n, direction) and return its Matcher result.
-        return BackreferenceMatcher(n, direction, modifiers);
+        // 2. Assert: n ≤ rer.[[CapturingGroupsCount]].
+        Assert(n <= rer.CapturingGroupsCount);
+        // 3. Return BackreferenceMatcher(rer, n, direction).
+        return BackreferenceMatcher(rer, n, direction);
       }
       case !!AtomEscape.CharacterEscape: {
-        // 1. Evaluate CharacterEscape to obtain a character ch.
+        // 1. Let cv be the CharacterValue of CharacterEscape.
+        // 2. Let ch be the character whose character value is cv.
         const ch = CharacterValue(AtomEscape.CharacterEscape);
-        // 2. Let A be a one-element CharSet containing the character ch.
-        const A = new ConcreteCharSet([Canonicalize(ch, modifiers)]);
-        // 3. Call CharacterSetMatcher(A, false, direction) and return its Matcher result.
-        return CharacterSetMatcher(A, false, direction, modifiers);
+        // 3. Let A be a one-element CharSet containing the character ch.
+        const A = CharSet.of(ch);
+        // 4. Return CharacterSetMatcher(rer, A, false, direction).
+        return CharacterSetMatcher(rer, A, false, direction);
       }
       case !!AtomEscape.CharacterClassEscape: {
-        // 1. Evaluate CharacterClassEscape to obtain a CharSet A.
-        const A = CompileToCharSet(AtomEscape.CharacterClassEscape, modifiers);
-        // 2. Call CharacterSetMatcher(A, false, direction) and return its Matcher result.
-        return CharacterSetMatcher(A, false, direction, modifiers);
+        // 1. Let cs be CompileToCharset of CharacterClassEscape with argument rer.
+        const cs = CompileToCharSet(AtomEscape.CharacterClassEscape, rer);
+        // 2. Return CharacterSetMatcher(rer, cs, false, direction).
+        return CharacterSetMatcher(rer, cs, false, direction);
       }
       case !!AtomEscape.GroupName: {
-        // 1. Search the enclosing Pattern for an instance of a GroupSpecifier for a RegExpIdentifierName which has a StringValue equal to the StringValue of the RegExpIdentifierName contained in GroupName.
-        // 2. Assert: A unique such GroupSpecifier is found.
-        // 3. Let parenIndex be the number of left-capturing parentheses in the entire regular expression that occur to the left of the located GroupSpecifier. This is the total number of Atom :: `(` GroupSpecifier Disjunction `)` Parse Nodes prior to or enclosing the located GroupSpecifier.
+        // 1. Let matchingGroupSpecifiers be GroupSpecifiersThatMatch(GroupName).
+        // 2. Assert: matchingGroupSpecifiers contains a single GroupSpecifier.
+        // 3. Let groupSpecifier be the sole element of matchingGroupSpecifiers.
+        // 4. Let parenIndex be CountLeftCapturingParensBefore(groupSpecifier).
         const parenIndex = Pattern.groupSpecifiers.get(AtomEscape.GroupName);
         Assert(parenIndex !== undefined);
-        // 4. Call BackreferenceMatcher(parenIndex, direction) and return its Matcher result.
-        return BackreferenceMatcher(parenIndex + 1, direction, modifiers);
+        // 5. Return BackreferenceMatcher(rer, parenIndex, direction).
+        return BackreferenceMatcher(rer, parenIndex + 1, direction);
       }
       default:
         throw new OutOfRange('CompileAtom_AtomEscape', AtomEscape);
     }
-  }
-
-  /** https://tc39.es/proposal-regexp-modifiers/#sec-updatemodifiers */
-  function UpdateModifiers(modifiers: ModifiersRecord, addModifiers: string, removeModifiers: string) {
-    let { DotAll, IgnoreCase, Multiline } = modifiers;
-    if (addModifiers.includes('s')) {
-      DotAll = true;
-    }
-    if (addModifiers.includes('i')) {
-      IgnoreCase = true;
-    }
-    if (addModifiers.includes('m')) {
-      Multiline = true;
-    }
-    if (removeModifiers.includes('s')) {
-      DotAll = false;
-    }
-    if (removeModifiers.includes('i')) {
-      IgnoreCase = false;
-    }
-    if (removeModifiers.includes('m')) {
-      Multiline = false;
-    }
-    return new ModifiersRecord(DotAll, IgnoreCase, Multiline);
-  }
-
-  /** https://tc39.es/ecma262/#sec-runtime-semantics-charactersetmatcher-abstract-operation */
-  function CharacterSetMatcher(A: CharSet, invert: boolean, direction: Direction, modifiers: ModifiersRecord): Matcher {
-    // 1. Return a new Matcher with parameters (x, c) that captures A, invert, and direction and performs the following steps when called:
-    return (x, c) => {
-      // a. Assert: x is a State.
-      Assert(x instanceof MatchState);
-      // b. Assert: c is a Continuation.
-      Assert(isContinuation(c));
-      // c. Let e be x's endIndex.
-      const e = x.endIndex;
-      // d. Let f be e + direction.
-      const f = e + direction;
-      // e. If f < 0 or f > InputLength, return failure.
-      if (f < 0 || f > InputLength) {
-        return 'failure';
-      }
-      // f. Let index be min(e, f).
-      const index = Math.min(e, f);
-      // g. Let ch be the character Input[index].
-      const ch = Input[index];
-      // h. Let cc be Canonicalize(ch).
-      const cc = Canonicalize(ch, modifiers);
-      // i. If invert is false, then
-      if (invert === false) {
-        // i. If there does not exist a member a of set A such that Canonicalize(a) is cc, return failure.
-        if (!A.has(cc)) {
-          return 'failure';
-        }
-      } else { // j. Else
-        // i. Assert: invert is true.
-        Assert(invert === true);
-        // ii. If there exists a member a of set A such that Canonicalize(a) is cc, return failure.
-        if (A.has(cc)) {
-          return 'failure';
-        }
-      }
-      // k. Let cap be x's captures List.
-      const cap = x.captures;
-      // Let y be the State (f, cap).
-      const y = new MatchState(f, cap);
-      // Call c(y) and return its result.
-      return c(y);
-    };
-  }
-
-  /** https://tc39.es/ecma262/#sec-runtime-semantics-canonicalize-ch */
-  function Canonicalize(ch: number, modifiers: ModifiersRecord) {
-    // 1. If IgnoreCase is false, return ch.
-    if (modifiers.IgnoreCase === false) {
-      return ch;
-    }
-    // 2. If Unicode is true, then
-    if (Unicode === true) {
-      const s = String.fromCodePoint(ch);
-      // a. If the file CaseFolding.txt of the Unicode Character Database provides a simple or common case folding mapping for ch, return the result of applying that mapping to ch.
-      if (unicodeCaseFoldingSimple.has(s)) {
-        return unicodeCaseFoldingSimple.get(s).codePointAt(0);
-      }
-      if (unicodeCaseFoldingCommon.has(s)) {
-        return unicodeCaseFoldingCommon.get(s).codePointAt(0);
-      }
-      // b. Return ch.
-      return ch;
-    } else { // 3. Else
-      // a. Assert: ch is a UTF-16 code unit.
-      // b. Let s be the String value consisting of the single code unit ch.
-      const s = String.fromCodePoint(ch);
-      // c. Let u be the same result produced as if by performing the algorithm for String.prototype.toUpperCase using s as the this value.
-      const u = s.toUpperCase();
-      // d. Assert: Type(u) is String.
-      Assert(typeof u === 'string');
-      // e. If u does not consist of a single code unit, return ch.
-      if (u.length !== 1) {
-        return ch;
-      }
-      // f. Let cu be u's single code unit element.
-      const cu = u.codePointAt(0)!;
-      // g. If the numeric value of ch ≥ 128 and the numeric value of cu < 128, return ch.
-      if (ch >= 128 && cu < 128) {
-        return ch;
-      }
-      // h. Return cu.
-      return cu;
-    }
-  }
-
-  /** https://tc39.es/ecma262/#sec-backreference-matcher */
-  function BackreferenceMatcher(n: number, direction: Direction, modifiers: ModifiersRecord): Matcher {
-    // 1. Return a new Matcher with parameters (x, c) that captures n and direction and performs the following steps when called:
-    return (x, c) => {
-      // a. Assert: x is a State.
-      Assert(x instanceof MatchState);
-      // b. Assert: c is a Continuation.
-      Assert(isContinuation(c));
-      // c. Let cap be x's captures List.
-      const cap = x.captures;
-      // d. Let s be cap[n].
-      const s = cap[n];
-      // e. If s is undefined, return c(x).
-      if (s instanceof UndefinedValue) {
-        return c(x);
-      }
-      // f. Let e be x's endIndex.
-      const e = x.endIndex;
-      // g. Let rs be r's startIndex.
-      const rs = s.startIndex;
-      // h. Let re be r's endIndex.
-      const re = s.endIndex;
-      // i. Let len be the number of elements in re - rs.
-      const len = re - rs;
-      // h. Let f be e + direction × len.
-      const f = e + direction * len;
-      // i. If f < 0 or f > InputLength, return failure.
-      if (f < 0 || f > InputLength) {
-        return 'failure';
-      }
-      // j. Let g be min(e, f).
-      const g = Math.min(e, f);
-      // k. If there exists an integer i between 0 (inclusive) and len (exclusive) such that Canonicalize(s[i]) is not the same character value as Canonicalize(Input[g + i]), return failure.
-      for (let i = 0; i < len; i += 1) {
-        if (Canonicalize(Input[s.startIndex + i], modifiers) !== Canonicalize(Input[g + i], modifiers)) {
-          return 'failure';
-        }
-      }
-      // l. Let y be the State (f, cap).
-      const y = new MatchState(f, cap);
-      // m. Call c(y) and return its result.
-      return c(y);
-    };
   }
 
   /** https://tc39.es/ecma262/#sec-decimalescape */
@@ -1024,17 +890,54 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
     return DecimalEscape.value;
   }
 
-  function CompileToCharSet(node: ParseNode.RegExp.ClassAtom, modifiers: ModifiersRecord): CharSet {
+  /** https://tc39.es/ecma262/#sec-characterclass */
+  //  CharacterClass ::
+  //    `[` ClassRanges `]`
+  //    `[` `^` ClassRanges `]`
+  function CompileCharacterClass({ invert, ClassRanges }: ParseNode.RegExp.CharacterClass, rer: RegExpRecord) {
+    if (invert) {
+      // 1. Let A be CompileToCharSet of ClassContents with argument rer
+      const A = CompileToCharSet_ClassContents(ClassRanges, rer);
+      // 2. NOTE: Reserved for future UnicodeSets support.
+      // 3. Return the Record { [[CharSet]]: A, [[Invert]]: true }.
+      return { CharSet: A, Invert: true };
+    }
+    // 1. Let A be CompileToCharSet of ClassContents with argument rer
+    const A = CompileToCharSet_ClassContents(ClassRanges, rer);
+    // 2. Return the Record { [[CharSet]]: A, [[Invert]]: false }.
+    return { CharSet: A, Invert: false };
+  }
+
+  /** https://tc39.es/ecma262/#sec-compiletocharset */
+  function CompileToCharSet(node: ParseNode.RegExp.ClassAtom, rer: RegExpRecord): CharSet {
     switch (node.type) {
       case 'CharacterClassEscape':
-        return CompileToCharSet_CharacterClassEscape(node, modifiers);
+        return CompileToCharSet_CharacterClassEscape(node, rer);
       case 'ClassAtom':
-        return CompileToCharSet_ClassAtom(node, modifiers);
+        return CompileToCharSet_ClassAtom(node);
       case 'ClassEscape':
-        return CompileToCharSet_ClassEscape(node, modifiers);
+        return CompileToCharSet_ClassEscape(node);
       default:
         throw new OutOfRange('CompileToCharSet', node);
     }
+  }
+
+  /** https://tc39.es/ecma262/#sec-compiletocharset */
+  function CompileToCharSet_ClassContents(nodes: readonly ParseNode.RegExp.ClassRange[], rer: RegExpRecord) {
+    // NOTE: This will need to be updated to support UnicodeSets
+    let A: CharSet = CharSet.empty();
+    for (const range of nodes) {
+      if (Array.isArray(range)) {
+        const B = CompileToCharSet(range[0], rer);
+        const C = CompileToCharSet(range[1], rer);
+        Assert(B.isConcrete() && C.isConcrete());
+        const D = CharacterRange(B, C);
+        A = A.union(D);
+      } else {
+        A = A.union(CompileToCharSet(range, rer));
+      }
+    }
+    return A;
   }
 
   /** https://tc39.es/ecma262/#sec-characterclassescape */
@@ -1047,41 +950,47 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
   //   `W`
   //   `p{` UnicodePropertyValueExpression `}`
   //   `P{` UnicodePropertyValueExpression `}`
-  function CompileToCharSet_CharacterClassEscape(node: ParseNode.RegExp.CharacterClassEscape, modifiers: ModifiersRecord): CharSet {
+  function CompileToCharSet_CharacterClassEscape(node: ParseNode.RegExp.CharacterClassEscape, rer: RegExpRecord): CharSet {
     switch (node.value) {
       case 'd':
-        // 1. Return the ten-element set of characters containing the characters 0 through 9 inclusive.
-        return new ConcreteCharSet(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].map((c) => c.codePointAt(0)!));
-      case 'D':
-        // 1. Return the set of all characters not included in the set returned by CharacterClassEscape :: `d`.
-        return new VirtualCharSet((c) => !isDecimalDigit(String.fromCodePoint(c)));
+        // 1. Return the ten-element CharSet containing the characters 0, 1, 2, 3, 4, 5, 6, 7, 8, and 9.
+        return CharSet.from(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].map((c) => c.codePointAt(0)!));
+      case 'D': {
+        // 1. Let S be the CharSet returned by CharacterClassEscape :: d.
+        const S = CompileToCharSet_CharacterClassEscape({ type: 'CharacterClassEscape', value: 'd' }, rer);
+        // 2. Return CharacterComplement(rer, S).
+        return CharacterComplement(rer, S);
+      }
       case 's':
-        // 1. Return the set of characters containing the characters that are on the right-hand side of the WhiteSpace or LineTerminator productions.
-        return new VirtualCharSet((c) => {
+        // 1. Return the CharSet of all characters corresponding to a code point on the right-hand side of the WhiteSpace or LineTerminator productions.
+        return CharSet.virtual((c) => {
           const s = String.fromCodePoint(c);
           return isWhitespace(s) || isLineTerminator(s);
         });
-      case 'S':
-        // 1. Return the set of all characters not included in the set returned by CharacterClassEscape :: `s`.
-        return new VirtualCharSet((c) => {
-          const s = String.fromCodePoint(c);
-          return !isWhitespace(s) && !isLineTerminator(s);
-        });
+      case 'S': {
+        // 1. Let S be the CharSet returned by CharacterClassEscape :: s.
+        const S = CompileToCharSet_CharacterClassEscape({ type: 'CharacterClassEscape', value: 's' }, rer);
+        // 1. Return CharacterComplement(rer, S).
+        return CharacterComplement(rer, S);
+      }
       case 'w':
-        // 1. Return the set of all characters returned by WordCharacters().
-        return GetWordCharacters(modifiers);
+        // 1. Return MaybeSimpleCasefolding(rer, WordCharacters(rer)).
+        return MaybeSimpleCaseFolding(rer, WordCharacters(rer));
       case 'W': {
-        // 1. Return the set of all characters not included in the set returned by CharacterClassEscape :: `w`.
-        const s = GetWordCharacters(modifiers);
-        return new VirtualCharSet((c) => !s.has(c));
+        // 1. Let S be the CharSet returned by CharacterClassEscape :: `w`.
+        const S = CompileToCharSet_CharacterClassEscape({ type: 'CharacterClassEscape', value: 'w' }, rer);
+        // 2. Return CharacterComplement(rer, S).
+        return CharacterComplement(rer, S);
       }
       case 'p':
-        // 1. Return the CharSet containing all Unicode code points included in the CharSet returned by UnicodePropertyValueExpression.
-        return CompileToCharSet_UnicodePropertyValueExpression(node.UnicodePropertyValueExpression!);
+        // 1. Return CompileToCharSet of UnicodePropertyValueExpression with argument rer.
+        return CompileToCharSet_UnicodePropertyValueExpression(node.UnicodePropertyValueExpression!, rer);
       case 'P': {
-        // 1. Return the CharSet containing all Unicode code points not included in the CharSet returned by UnicodePropertyValueExpression.
-        const s = CompileToCharSet_UnicodePropertyValueExpression(node.UnicodePropertyValueExpression!);
-        return new VirtualCharSet((c) => !s.has(c));
+        // 1. Let S be CompileToCharSet of UnicodePropertyValueExpression with argument rer.
+        const S = CompileToCharSet_UnicodePropertyValueExpression(node.UnicodePropertyValueExpression!, rer);
+        // 2. Assert: S contains only single code points.
+        // 3. Return CharacterComplement(rer, S);
+        return CharacterComplement(rer, S);
       }
       default:
         throw new OutOfRange('CompileToCharSet_CharacterClassEscape', node);
@@ -1091,59 +1000,43 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
   // UnicodePropertyValueExpression ::
   //   UnicodePropertyName `=` UnicodePropertyValue
   //   LoneUnicodePropertyNameOrValue
-  function CompileToCharSet_UnicodePropertyValueExpression(UnicodePropertyValueExpression: ParseNode.RegExp.UnicodePropertyValueExpression): CharSet {
+  function CompileToCharSet_UnicodePropertyValueExpression(UnicodePropertyValueExpression: ParseNode.RegExp.UnicodePropertyValueExpression, rer: RegExpRecord): CharSet {
     if (UnicodePropertyValueExpression.LoneUnicodePropertyNameOrValue) {
-      // 1. Let s be SourceText of LoneUnicodePropertyNameOrValue.
+      // 1. Let s be the source text matched by LoneUnicodePropertyNameOrValue.
       const s = UnicodePropertyValueExpression.LoneUnicodePropertyNameOrValue;
-      // 2. If ! UnicodeMatchPropertyValue(General_Category, s) is identical to a List of Unicode code points that is the name of a Unicode general category or general category alias listed in the “Property value and aliases” column of Table 57, then
-      if (X(UnicodeMatchPropertyValue('General_Category', s) in UnicodeGeneralCategoryValues)) {
+      // 2. If UnicodeMatchPropertyValue(General_Category, s) is a Unicode property value or property value alias for the General_Category (gc) property listed in PropertyValueAliases.txt, then
+      if (UnicodeMatchPropertyValue('General_Category', s) in UnicodeGeneralCategoryValues) {
         // a. Return the CharSet containing all Unicode code points whose character database definition includes the property “General_Category” with value s.
         // @ts-expect-error -- 'string' is not a subtype of 'keyof typeof UnicodeGeneralCategoryValues'
-        return new ConcreteCharSet(getUnicodePropertyValueSet('General_Category', UnicodeGeneralCategoryValues[s]));
+        return CharSet.from(getUnicodePropertyValueSet('General_Category', UnicodeGeneralCategoryValues[s]));
       }
-      // 3. Let p be ! UnicodeMatchProperty(s).
-      const p = X(UnicodeMatchProperty(s));
-      // 4. Assert: p is a binary Unicode property or binary property alias listed in the “Property name and aliases” column of Table 56.
+      // 3. Let p be UnicodeMatchProperty(rer, s).
+      const p = UnicodeMatchProperty(rer, s);
+      // 4. Assert: p is a binary Unicode property or binary property alias listed in the “Property name and aliases” column of Table 68.
       Assert(p in BinaryUnicodeProperties);
-      // 5. Return the CharSet containing all Unicode code points whose character database definition includes the property p with value “True”.
-      return new ConcreteCharSet(getUnicodePropertyValueSet(p));
+      // 5. Let A be the CharSet containing all CharSetElements whose character database database definition includes the property p with value “True”.
+      const A = CharSet.from(getUnicodePropertyValueSet(p));
+      // 6. Return MaybeSimpleCaseFolding(rer, A);
+      return MaybeSimpleCaseFolding(rer, A);
     }
-    // 1. Let ps be SourceText of UnicodePropertyName.
+    // 1. Let ps be the source text matched by UnicodePropertyName.
     const ps = UnicodePropertyValueExpression.UnicodePropertyName!;
-    // 2. Let p be ! UnicodeMatchProperty(ps).
-    const p = X(UnicodeMatchProperty(ps));
-    // 3. Assert: p is a Unicode property name or property alias listed in the “Property name and aliases” column of Table 55.
+    // 2. Let p be UnicodeMatchProperty(rer, ps).
+    const p = UnicodeMatchProperty(rer, ps);
+    // 3. Assert: p is a Unicode property name or property alias listed in the “Property name and aliases” column of Table 67.
     Assert(p in NonbinaryUnicodeProperties);
-    // 4. Let vs be SourceText of UnicodePropertyValue.
+    // 4. Let vs be the source text matched by UnicodePropertyValue.
     const vs = UnicodePropertyValueExpression.UnicodePropertyValue;
-    // 5. Let v be ! UnicodeMatchPropertyValue(p, vs).
-    const v = X(UnicodeMatchPropertyValue(p, vs));
-    // 6. Return the CharSet containing all Unicode code points whose character database definition includes the property p with value v.
-    return new ConcreteCharSet(getUnicodePropertyValueSet(p, v));
-  }
-
-  /** https://tc39.es/ecma262/#sec-characterclass */
-  //  CharacterClass ::
-  //    `[` ClassRanges `]`
-  //    `[` `^` ClassRanges `]`
-  function CompileCharacterClass({ invert, ClassRanges }: ParseNode.RegExp.CharacterClass, modifiers: ModifiersRecord) {
-    let A: CharSet = new ConcreteCharSet([]);
-    for (const range of ClassRanges) {
-      if (Array.isArray(range)) {
-        const B = CompileToCharSet(range[0], modifiers);
-        const C = CompileToCharSet(range[1], modifiers);
-        Assert(B instanceof ConcreteCharSet && C instanceof ConcreteCharSet);
-        const D = CharacterRange(B, C, modifiers);
-        A = A.union(D);
-      } else {
-        A = A.union(CompileToCharSet(range, modifiers));
-      }
-    }
-    return { A, invert };
+    // 5. Let v be UnicodeMatchPropertyValue(p, vs).
+    const v = UnicodeMatchPropertyValue(p, vs);
+    // 6. Let A be the CharSet containing all Unicode code points whose character database definition includes the property p with value v.
+    const A = CharSet.from(getUnicodePropertyValueSet(p, v));
+    // 7. Return MaybeSimpleCaseFolding(rer, A).
+    return MaybeSimpleCaseFolding(rer, A);
   }
 
   /** https://tc39.es/ecma262/#sec-runtime-semantics-characterrange-abstract-operation */
-  function CharacterRange(A: ConcreteCharSet, B: ConcreteCharSet, modifiers: ModifiersRecord) {
+  function CharacterRange(A: ConcreteCharSet, B: ConcreteCharSet) {
     // 1. Assert: A and B each contain exactly one character.
     Assert(A.size === 1 && B.size === 1);
     // 2. Let a be the one character in CharSet A.
@@ -1156,12 +1049,12 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
     const j = b;
     // 6. Assert: i ≤ j.
     Assert(i <= j);
-    // 7. Return the set containing all characters numbered i through j, inclusive.
+    // 7. Return the CharSet containing all characters with a character value in the inclusive interval from i to j.
     const set = new Set<number>();
     for (let k = i; k <= j; k += 1) {
-      set.add(Canonicalize(k, modifiers)); // TODO: should this really be using canonicalize?
+      set.add(k);
     }
-    return new ConcreteCharSet(set);
+    return CharSet.from(set);
   }
 
   /** https://tc39.es/ecma262/#sec-classatom */
@@ -1171,14 +1064,14 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
   // ClassAtomNoDash ::
   //   SourceCharacter
   //   `\` ClassEscape
-  function CompileToCharSet_ClassAtom(ClassAtom: ParseNode.RegExp.ClassAtom, modifiers: ModifiersRecord): CharSet {
+  function CompileToCharSet_ClassAtom(ClassAtom: ParseNode.RegExp.ClassAtom): CharSet {
     switch (true) {
       case 'SourceCharacter' in ClassAtom && !!ClassAtom.SourceCharacter:
         // 1. Return the CharSet containing the character matched by SourceCharacter.
-        return new ConcreteCharSet([Canonicalize(ClassAtom.SourceCharacter.codePointAt(0)!, modifiers)]);
+        return CharSet.of(ClassAtom.SourceCharacter.codePointAt(0)!);
       case ClassAtom.value === '-':
         // 1. Return the CharSet containing the single character - U+002D (HYPHEN-MINUS).
-        return new ConcreteCharSet([0x002D]);
+        return CharSet.of(0x002D);
       default:
         throw new OutOfRange('CompileToCharSet_ClassAtom', ClassAtom);
     }
@@ -1190,7 +1083,7 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
   //   `-`
   //   CharacterEscape
   //   CharacterClassEscape
-  function CompileToCharSet_ClassEscape(ClassEscape: ParseNode.RegExp.ClassEscape, modifiers: ModifiersRecord): CharSet {
+  function CompileToCharSet_ClassEscape(ClassEscape: ParseNode.RegExp.ClassEscape): CharSet {
     switch (true) {
       case ClassEscape.value === 'b':
       case ClassEscape.value === '-':
@@ -1200,10 +1093,391 @@ export function CompilePattern(Pattern: ParseNode.RegExp.Pattern, flags: string)
         // 2. Let c be the character whose character value is cv.
         const c = cv;
         // 3. Return the CharSet containing the single character c.
-        return new ConcreteCharSet([Canonicalize(c, modifiers)]);
+        return CharSet.of(c);
       }
       default:
         throw new OutOfRange('CompileToCharSet_ClassEscape', ClassEscape);
     }
+  }
+}
+
+/** https://tc39.es/ecma262/#sec-countleftcapturingparenswithin */
+function CountLeftCapturingParensWithin(Atom: ParseNode.RegExp.Atom | ParseNode.RegExp.Term_Atom) {
+  return 'enclosedCapturingParentheses' in Atom ? Atom.enclosedCapturingParentheses : 0;
+}
+
+/** https://tc39.es/ecma262/#sec-countleftcapturingparensbefore */
+function CountLeftCapturingParensBefore(Atom: ParseNode.RegExp.Atom | ParseNode.RegExp.Term_Atom) {
+  return 'capturingParenthesesBefore' in Atom ? Atom.capturingParenthesesBefore : 0;
+}
+
+/** https://tc39.es/ecma262/#sec-runtime-semantics-repeatmatcher-abstract-operation */
+function RepeatMatcher(m: Matcher, min: number, max: number, greedy: boolean, x: MatchState, c: MatcherContinuation, parenIndex: number, parenCount: number): MatchResult {
+  // 1. If max is zero, return c(x).
+  if (max === 0) {
+    return c(x);
+  }
+  // 2. Let d be a new MatcherContinuation with parameters (y) that captures m, min, max, greedy, x, c, parenIndex, and parenCount and performs the following steps when called:
+  const d: MatcherContinuation = (y) => {
+    // a. Assert: y is a MatchState.
+    Assert(y instanceof MatchState);
+    // b. If min = 0 and and y.[[EndIndex]] = x.[[EndIndex], return FAILURE.
+    if (min === 0 && y.EndIndex === x.EndIndex) {
+      return FAILURE;
+    }
+    // c. If min = 0, let min2 be 0; otherwise let min2 be min - 1.
+    let min2;
+    if (min === 0) {
+      min2 = 0;
+    } else {
+      min2 = min - 1;
+    }
+    // d. If max is ∞, let max2 be ∞; otherwise let max2 be max - 1.
+    let max2;
+    if (max === Infinity) {
+      max2 = Infinity;
+    } else {
+      max2 = max - 1;
+    }
+    // e. Return RepeatMatcher(m, min2, max2, greedy, y, c, parenIndex, parenCount).
+    return RepeatMatcher(m, min2, max2, greedy, y, c, parenIndex, parenCount);
+  };
+  // 3. Let cap be a copy of x.[[Captures]].
+  const cap = [...x.Captures];
+  // 4. For each integer k in the inclusive interval from parenIndex + 1 to parenIndex + parenCount, set cap[k] to undefined.
+  for (let k = parenIndex + 1; k <= parenIndex + parenCount; k += 1) {
+    cap[k] = Value.undefined;
+  }
+  // 5. Let Input be x.[[Input]].
+  const Input = x.Input;
+  // 6. Let e be x.[[EndIndex]].
+  const e = x.EndIndex;
+  // 7. Let xr be the MatchState { [[Input]]: Input, [[EndIndex]]: e, [[Captures]]: cap }.
+  const xr = new MatchState(Input, e, cap);
+  // 8. If min != 0, return m(xr, d).
+  if (min !== 0) {
+    return m(xr, d);
+  }
+  // 9. If greedy is false, then
+  if (greedy === false) {
+    // a. Let z be c(x).
+    const z = c(x);
+    // b. If z is not FAILURE, return z.
+    if (z !== FAILURE) {
+      return z;
+    }
+    // c. Return m(xr, d).
+    return m(xr, d);
+  }
+  // 10. Let z be m(xr, d).
+  const z = m(xr, d);
+  // 11. If z is not FAILURE, return z.
+  if (z !== FAILURE) {
+    return z;
+  }
+  // 12. Return c(x).
+  return c(x);
+}
+
+/** https://tc39.es/ecma262/#sec-emptymatcher */
+function EmptyMacher(): Matcher {
+  // 1. Return a new Matcher with parameters (x, c) that captures nothing and performs the following steps when called:
+  return (x, c) => {
+    // 1. Assert: x is a MatchState.
+    Assert(x instanceof MatchState);
+    // 2. Assert: c is a MatcherContinuation.
+    Assert(isContinuation(c));
+    // 3. Call c(x) and return its result.
+    return c(x);
+  };
+}
+
+/** https://tc39.es/ecma262/#sec-matchtwoalternatives */
+function MatchTwoAlternatives(m1: Matcher, m2: Matcher): Matcher {
+  // 3. Return a new Matcher with parameters (x, c) that captures m1 and m2 and performs the following steps when called:
+  return (x, c) => {
+    // a. Assert: x is a MatchState.
+    Assert(x instanceof MatchState);
+    // b. Assert: c is a MatcherContinuation.
+    Assert(isContinuation(c));
+    // c. Call m1(x, c) and let r be its result.
+    const r = m1(x, c);
+    // d. If r is not failure, return r.
+    if (r !== 'failure') {
+      return r;
+    }
+    // e. Call m2(x, c) and return its result.
+    return m2(x, c);
+  };
+}
+
+/** https://tc39.es/ecma262/#sec-matchsequence */
+function MatchSequence(m1: Matcher, m2: Matcher, direction: Direction): Matcher {
+  // 3. If direction is FORWARD, then
+  if (direction === FORWARD) {
+    // a. Return a new Matcher with parameters (x, c) that captures m1 and m2 and performs the following steps when called:
+    return (x, c) => {
+      // i. Assert: x is a MatchState.
+      Assert(x instanceof MatchState);
+      // ii. Assert: c is a MatcherContinuation.
+      Assert(isContinuation(c));
+      // iii. Let d be a new MatcherContinuation with parameters (y) that captures c and m2 and performs the following steps when called:
+      const d: MatcherContinuation = (y) => {
+        // 1. Assert: y is a MathcState.
+        Assert(y instanceof MatchState);
+        // 2. Return m2(y, c).
+        return m2(y, c);
+      };
+      // iv. Return m1(x, d).
+      return m1(x, d);
+    };
+  } else { // 4. Else,
+    // a. Assert: direction is BACKWARD.
+    Assert(direction === BACKWARD);
+    // b. Return a new Matcher with parameters (x, c) that captures m1 and m2 and performs the following steps when called:
+    return (x, c) => {
+      // i. Assert: x is a MatchState.
+      Assert(x instanceof MatchState);
+      // ii. Assert: c is a MatcherContinuation.
+      Assert(isContinuation(c));
+      // iii. Let d be a new MatcherContinuation with parameters (y) that captures c and m1 and performs the following steps when called:
+      const d: MatcherContinuation = (y) => {
+        // 1. Assert: y is a MatchState.
+        Assert(y instanceof MatchState);
+        // 2. Return m1(y, c).
+        return m1(y, c);
+      };
+      // iv. Return m2(x, d).
+      return m2(x, d);
+    };
+  }
+}
+
+/** https://tc39.es/ecma262/#sec-runtime-semantics-iswordchar-abstract-operation */
+function IsWordChar(rer: RegExpRecord, Input: number[], e: number) {
+  // 1. Let InputLength be the number of elements in Input.
+  const InputLength = Input.length;
+  // 2. If e = -1 or e = InputLength, return false.
+  if (e === -1 || e === InputLength) {
+    return false;
+  }
+  // 2. Let c be the character Input[e].
+  const c = Input[e];
+  // 3. If WordCharacters(rer) contains c, return true.
+  if (WordCharacters(rer).has(c)) {
+    return true;
+  }
+  // 4. Return false.
+  return false;
+}
+
+/** https://tc39.es/ecma262/#sec-runtime-semantics-wordcharacters-abstract-operation */
+function WordCharacters(rer: RegExpRecord) {
+  // 1. Let basicWordChars be the CharSet containing every character in the ASCII word characters.
+  // 2. Let extraWordChars be the CharSet containing all characters c such that c is not in basicWordChars but Canonicalize(rer, c) is in basicWordChars.
+  // 3. Assert: extraWordChars is empty unless rer.[[Unicode]] is true and rer.[[IgnoreCase]] is true.
+  // 4. Return the union of basicWordChars and extraWordChars
+  // Return A.
+  const basicWordChars = CharSet.from([
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '_',
+  ].map((c) => c.codePointAt(0)!));
+  let extraWordChars: CharSet;
+  if (rer.Unicode && rer.IgnoreCase) {
+    extraWordChars = CharSet.virtual((c) => !basicWordChars.has(c) && basicWordChars.has(Canonicalize(rer, c)));
+  } else {
+    extraWordChars = CharSet.empty();
+  }
+  return basicWordChars.union(extraWordChars);
+}
+
+/** https://tc39.es/ecma262/#sec-allcharacters */
+function AllCharacters(_rer: RegExpRecord) {
+  // NOTE: _rer is reserved for future support for UnicodeSets
+  return CharSet.all();
+}
+
+/** https://tc39.es/ecma262/#sec-maybesimplecasefolding */
+function MaybeSimpleCaseFolding(_rer: RegExpRecord, S: CharSet) {
+  // NOTE: _rer is reserved for future support for UnicodeSets
+  return S;
+}
+
+function CharacterComplement(rer: RegExpRecord, S: CharSet) {
+  // 1. Let A be AllCharacters(rer).
+  const A = AllCharacters(rer);
+  // 2. Return the CharSet containing the CharSetElements of A which are not also CharSetElements of S.
+  return A.except(S);
+}
+
+/** https://tc39.es/proposal-regexp-modifiers/#sec-updatemodifiers */
+function UpdateModifiers(rer: RegExpRecord, addModifiers: string, removeModifiers: string) {
+  let { DotAll, IgnoreCase, Multiline } = rer;
+  if (addModifiers.includes('s')) {
+    DotAll = true;
+  }
+  if (addModifiers.includes('i')) {
+    IgnoreCase = true;
+  }
+  if (addModifiers.includes('m')) {
+    Multiline = true;
+  }
+  if (removeModifiers.includes('s')) {
+    DotAll = false;
+  }
+  if (removeModifiers.includes('i')) {
+    IgnoreCase = false;
+  }
+  if (removeModifiers.includes('m')) {
+    Multiline = false;
+  }
+  return new RegExpRecord(IgnoreCase, Multiline, DotAll, rer.Unicode, rer.CapturingGroupsCount);
+}
+
+/** https://tc39.es/ecma262/#sec-runtime-semantics-charactersetmatcher-abstract-operation */
+function CharacterSetMatcher(rer: RegExpRecord, A: CharSet, invert: boolean, direction: Direction): Matcher {
+  // 1. Return a new Matcher with parameters (x, c) that captures rer, A, invert, and direction and performs the following steps when called:
+  return (x, c) => {
+    // a. Assert: x is a MatchState.
+    Assert(x instanceof MatchState);
+    // b. Assert: c is a MatcherContinuation.
+    Assert(isContinuation(c));
+    // c. Let Input be x.[[Input]].
+    const Input = x.Input;
+    // d. Let e be x.[[EndIndex]].
+    const e = x.EndIndex;
+    let f;
+    // e. If direction is FORWARD, let f be e + 1.
+    if (direction === FORWARD) {
+      f = e + 1;
+    }
+    else { // f. Else, let f be e - 1;
+      f = e - 1;
+    }
+    // g. Let InputLength be the number of elements in Input.
+    const InputLength = Input.length;
+    // h. If f < 0 or f > InputLength, return FAILURE.
+    if (f < 0 || f > InputLength) {
+      return FAILURE;
+    }
+    // i. Let index be min(e, f).
+    const index = Math.min(e, f);
+    // j. Let ch be the character Input[index].
+    const ch = Input[index];
+    // k. Let cc be Canonicalize(rer, ch).
+    const cc = Canonicalize(rer, ch);
+    // l. If there exists a CharSetElement in A containing exactly one character a such that Canonicalize(rer, a) is cc, let found be true. Otherwise, let found be false.
+    const found = A.some(a => Canonicalize(rer, a) === cc);
+    // m. If invert is false and found is false, return FAILURE.
+    if (invert === false && found === false) {
+      return FAILURE;
+    }
+    // n. If invert is true and found is true, return FAILURE.
+    if (invert === true && found === true) {
+      return FAILURE;
+    }
+    // o. Let cap be x.[[Captures]].
+    const cap = x.Captures;
+    // p. Let y be the MatchState { [[Input]]: Input, [[EndIndex]]: f, [[Captures]]: cap }.
+    const y = new MatchState(Input, f, cap);
+    // q. Return c(y).
+    return c(y);
+  };
+}
+
+/** https://tc39.es/ecma262/#sec-backreference-matcher */
+function BackreferenceMatcher(rer: RegExpRecord, n: number, direction: Direction): Matcher {
+  // 1. Assert: n ≥ 1.
+  // 2. Return a new Matcher with parameters (x, c) that captures rer, n, and direction and performs the following steps when called:
+  return (x, c) => {
+    // a. Assert: x is a MatchState.
+    Assert(x instanceof MatchState);
+    // b. Assert: c is a MatcherContinuation.
+    Assert(isContinuation(c));
+    // c. Let Input be x.[[Input]].
+    const Input = x.Input;
+    // d. Let cap be x.[[Captures]].
+    const cap = x.Captures;
+    // e. Let s be cap[n].
+    const s = cap[n];
+    // f. If s is undefined, return c(x).
+    if (s instanceof UndefinedValue) {
+      return c(x);
+    }
+    // g. Let e be x.[[EndIndex]].
+    const e = x.EndIndex;
+    // h. Let rs be r.[[StartIndex]].
+    const rs = s.StartIndex;
+    // i. Let re be r.[[EndIndex]].
+    const re = s.EndIndex;
+    // j. Let len be re - rs.
+    const len = re - rs;
+    let f;
+    // k. If direction is FORWARD, let f be e + len.
+    if (direction === FORWARD) {
+      f = e + len;
+    } else { // l. Else, let f be e - len.
+      f = e - len;
+    }
+    // m. Let InputLength be the number of elements in Input.
+    const InputLength = Input.length;
+    // n. If f < 0 or f > InputLength, return FAILURE.
+    if (f < 0 || f > InputLength) {
+      return FAILURE;
+    }
+    // o. Let g be min(e, f).
+    const g = Math.min(e, f);
+    // p. If there exists an integer i in the interval from 0 (inclusive) to len (exclusive) such that Canonicalize(rer, Input[rs + i]) is not Canonicalize(rer, Input[g + i]), return FAILURE.
+    for (let i = 0; i < len; i += 1) {
+      if (Canonicalize(rer, Input[rs + i]) !== Canonicalize(rer, Input[g + i])) {
+        return FAILURE;
+      }
+    }
+    // l. Let y be the MatchState { [[Input]]: Input, [[EndIndex]]: f, [[Captures]]: cap }.
+    const y = new MatchState(Input, f, cap);
+    // m. Return c(y).
+    return c(y);
+  };
+}
+
+/** https://tc39.es/ecma262/#sec-runtime-semantics-canonicalize-ch */
+function Canonicalize(rer: RegExpRecord, ch: number) {
+  // 1. If IgnoreCase is false, return ch.
+  if (rer.IgnoreCase === false) {
+    return ch;
+  }
+  // 2. If Unicode is true, then
+  if (rer.Unicode === true) {
+    const s = String.fromCodePoint(ch);
+    // a. If the file CaseFolding.txt of the Unicode Character Database provides a simple or common case folding mapping for ch, return the result of applying that mapping to ch.
+    if (unicodeCaseFoldingSimple.has(s)) {
+      return unicodeCaseFoldingSimple.get(s).codePointAt(0);
+    }
+    if (unicodeCaseFoldingCommon.has(s)) {
+      return unicodeCaseFoldingCommon.get(s).codePointAt(0);
+    }
+    // b. Return ch.
+    return ch;
+  } else { // 3. Else
+    // a. Assert: ch is a UTF-16 code unit.
+    // b. Let s be the String value consisting of the single code unit ch.
+    const s = String.fromCodePoint(ch);
+    // c. Let u be the same result produced as if by performing the algorithm for String.prototype.toUpperCase using s as the this value.
+    const u = s.toUpperCase();
+    // d. Assert: Type(u) is String.
+    Assert(typeof u === 'string');
+    // e. If u does not consist of a single code unit, return ch.
+    if (u.length !== 1) {
+      return ch;
+    }
+    // f. Let cu be u's single code unit element.
+    const cu = u.codePointAt(0)!;
+    // g. If the numeric value of ch ≥ 128 and the numeric value of cu < 128, return ch.
+    if (ch >= 128 && cu < 128) {
+      return ch;
+    }
+    // h. Return cu.
+    return cu;
   }
 }

--- a/src/runtime-semantics/Unicode.mts
+++ b/src/runtime-semantics/Unicode.mts
@@ -539,7 +539,7 @@ export function UnicodeMatchPropertyValue(p: string, v) {
 }
 
 const expandedSets = new Map();
-export function getUnicodePropertyValueSet(property, value) {
+export function getUnicodePropertyValueSet(property, value?) {
   const path = value ? `${property}/${value}` : `Binary_Property/${property}`;
   if (!expandedSets.has(path)) {
     const set = new Set();

--- a/src/runtime-semantics/Unicode.mts
+++ b/src/runtime-semantics/Unicode.mts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { Assert } from '../abstract-ops/all.mjs';
 import UnicodeSets from '../data-gen.json';
+import type { RegExpRecord } from './RegExp.mjs';
 
 export { UnicodeSets };
 
@@ -517,7 +518,8 @@ export const UnicodeScriptValues = {
 Object.setPrototypeOf(UnicodeScriptValues, null);
 
 /** https://tc39.es/ecma262/#sec-runtime-semantics-unicodematchproperty-p */
-export function UnicodeMatchProperty(p: string): string {
+export function UnicodeMatchProperty(_rer: RegExpRecord, p: string): string {
+  // NOTE: _rer is reserved here for future support for UnicodeSets support.
   // 1. Assert: p is a List of Unicode code points that is identical to a List of Unicode code points that is a Unicode property name or property alias listed in the “Property name and aliases” column of Table 55 or Table 56.
   Assert(p in NonbinaryUnicodeProperties || p in BinaryUnicodeProperties);
   // 2. Let c be the canonical property name of p as given in the “Canonical property name” column of the corresponding row.

--- a/test/test262/features
+++ b/test/test262/features
@@ -33,6 +33,22 @@
 
 -symbols-as-weakmap-keys
 
+-Array.fromAsync
+
+-iterator-helpers
+
+-arraybuffer-transfer
+
+-resizable-arraybuffer
+
+-promise-with-resolvers
+
+-import-attributes
+
+-json-parse-with-source
+
+-set-methods
+
 String.prototype.isWellFormed = is-usv-string
 String.prototype.toWellFormed = is-usv-string
 

--- a/test/test262/test262.js
+++ b/test/test262/test262.js
@@ -186,7 +186,7 @@ if (!process.send) {
     }
 
     for await (const file of files) {
-      if (/annexB|intl402|_FIXTURE/.test(file)) {
+      if (/annexB|intl402|_FIXTURE|\.md$/.test(file)) {
         continue;
       }
 
@@ -313,11 +313,13 @@ if (!process.send) {
       }
 
       {
-        const completion = realm.evaluateScript(`\
+        let script = `\
 var Test262Error = class Test262Error extends Error {};
 Test262Error.thrower = (...args) => {
   throw new Test262Error(...args);
-};
+};`;
+        if (test.attrs.flags.async) {
+          script += `
 
 function $DONE(error) {
   if (error) {
@@ -329,7 +331,10 @@ function $DONE(error) {
   } else {
     __consolePrintHandle__('Test262:AsyncTestComplete');
   }
-}`);
+}`;
+        }
+
+        const completion = realm.evaluateScript(script);
         if (completion instanceof AbruptCompletion) {
           return { status: 'FAIL', error: inspect(completion) };
         }


### PR DESCRIPTION
This adds support for the Stage 3 [RegExp Modifiers](https://github.com/tc39/proposal-regexp-modifiers) proposal, which passes the tests in https://github.com/tc39/test262/pull/3960.

This also makes a few changes to several RegExp-related function names to match a more recent version of the ECMAScript specification.