### PR TITLE
refactor(helpers): Use frozen proxy handler in `@callable` decorator

### DIFF
--- a/src/helpers.mts
+++ b/src/helpers.mts
@@ -506,11 +506,15 @@ export function captureStack(O: ObjectValue) {
   })));
 }
 
-export function callable<Class extends object>(onCalled = (target: Class, _thisArg: unknown, args: unknown[]) => Reflect.construct(target as new (...args: unknown[]) => unknown, args)) {
-  return function decoartor(classValue: Class, _classContext: unknown) {
-    return new Proxy(classValue, {
-      apply: onCalled,
-    });
+export function callable<Class extends object>(
+  onCalled = (target: Class, _thisArg: unknown, args: unknown[]) => Reflect.construct(target as new (...args: unknown[]) => unknown, args),
+) {
+  const handler: ProxyHandler<Class> = Object.freeze({
+    __proto__: null,
+    apply: onCalled,
+  });
+  return function decorator(classValue: Class, _classContext: ClassDecoratorContext<Class & (new (...args: readonly unknown[]) => unknown)>) {
+    return new Proxy(classValue, handler);
   };
 }
 


### PR DESCRIPTION
Using a frozen proxy handler with a `null` prototype can potentially be better optimised by **V8** and other engines as the `[[Get]]` operations to get the proxy trap will always return the same function or `undefined` and can’t ever be affected by prototype pollution, so engines don’t need to emit deoptimisation traps.

Also fixes a typo in the returned function’s name `decoartor` → `decorator` and adds type information to the `_classContext` parameter.