### PR TITLE
refactor(parser/Scope): Add `LabelType`

### DIFF
--- a/src/parser/Scope.mts
+++ b/src/parser/Scope.mts
@@ -123,7 +123,7 @@ export type ScopeFlagSetters =
     readonly variable?: boolean;
     readonly variableFunctions?: boolean;
     readonly private?: boolean;
-    readonly label?: string;
+    readonly label?: LabelType | 'boundary';
     readonly strict?: boolean;
   };
 
@@ -161,8 +161,10 @@ export interface AssignmentInfo {
   clear(): void;
 }
 
+export type LabelType = 'switch' | 'loop';
+
 export interface Label {
-  type: string | null;
+  type: LabelType | null;
   readonly name?: string;
   readonly nextToken?: TokenData | null;
 }

--- a/src/parser/StatementParser.mts
+++ b/src/parser/StatementParser.mts
@@ -2,7 +2,7 @@ import type { Mutable } from '../helpers.mts';
 import { Token, isAutomaticSemicolon } from './tokens.mts';
 import { ExpressionParser } from './ExpressionParser.mts';
 import { FunctionKind } from './FunctionParser.mts';
-import { getDeclarations } from './Scope.mts';
+import { getDeclarations, type LabelType } from './Scope.mts';
 import type { ParseNode } from './ParseNode.mts';
 
 export abstract class StatementParser extends ExpressionParser {
@@ -920,7 +920,7 @@ export abstract class StatementParser extends ExpressionParser {
       if (this.scope.labels.find((l) => l.name === LabelIdentifier.name)) {
         this.raiseEarly('AlreadyDeclared', node.LabelIdentifier, node.LabelIdentifier.name);
       }
-      let type = null;
+      let type: LabelType | null = null;
       switch (this.peek().type) {
         case Token.SWITCH:
           type = 'switch';


### PR DESCRIPTION
This adds type information to the `type` property of the `Label` interface and the `label` property of `ScopeFlagSetters` in `parser/Scope.mts`.