### PR TITLE
Implement `Iterator` constructor

### DIFF
--- a/src/abstract-ops/iterator-operations.mts
+++ b/src/abstract-ops/iterator-operations.mts
@@ -245,7 +245,7 @@ export function CreateListIteratorRecord(list: Iterable<Value>): IteratorRecord 
     }
     return NormalCompletion(Value.undefined);
   };
-  const iterator = CreateIteratorFromClosure(closure, undefined, surroundingAgent.intrinsic('%IteratorPrototype%'));
+  const iterator = CreateIteratorFromClosure(closure, undefined, surroundingAgent.intrinsic('%Iterator.prototype%'));
   return {
     Iterator: iterator,
     NextMethod: surroundingAgent.intrinsic('%GeneratorFunction.prototype.prototype.next%'),

--- a/src/abstract-ops/realms.mts
+++ b/src/abstract-ops/realms.mts
@@ -33,6 +33,7 @@ import { bootstrapErrorPrototype } from '../intrinsics/ErrorPrototype.mts';
 import { bootstrapError } from '../intrinsics/Error.mts';
 import { bootstrapNativeError } from '../intrinsics/NativeError.mts';
 import { bootstrapIteratorPrototype } from '../intrinsics/IteratorPrototype.mts';
+import { bootstrapIterator } from '../intrinsics/Iterator.mts';
 import { bootstrapAsyncIteratorPrototype } from '../intrinsics/AsyncIteratorPrototype.mts';
 import { bootstrapArrayIteratorPrototype } from '../intrinsics/ArrayIteratorPrototype.mts';
 import { bootstrapMapIteratorPrototype } from '../intrinsics/MapIteratorPrototype.mts';
@@ -205,7 +206,7 @@ export interface Intrinsics extends Intrinsics_Table6 {
   '%Int32Array%': FunctionObject;
   '%Int8Array.prototype%': ObjectValue;
   '%Int8Array%': FunctionObject;
-  '%IteratorPrototype%': ObjectValue;
+  '%Iterator.prototype%': ObjectValue;
   '%JSON.parse%': FunctionObject;
   '%JSON.stringify%': FunctionObject;
   '%Map.prototype%': ObjectValue;
@@ -326,6 +327,8 @@ export function CreateIntrinsics(realmRec: Realm) {
   bootstrapFunction(realmRec);
 
   bootstrapIteratorPrototype(realmRec);
+  bootstrapIterator(realmRec);
+
   bootstrapAsyncIteratorPrototype(realmRec);
   bootstrapArrayIteratorPrototype(realmRec);
   bootstrapMapIteratorPrototype(realmRec);
@@ -477,6 +480,7 @@ export function* SetDefaultGlobalBindings(realmRec: Realm): ValueEvaluator<Objec
     'Int8Array',
     'Int16Array',
     'Int32Array',
+    'Iterator',
     'Map',
     'Number',
     'Object',

--- a/src/intrinsics/ArrayIteratorPrototype.mts
+++ b/src/intrinsics/ArrayIteratorPrototype.mts
@@ -17,7 +17,7 @@ function* ArrayIteratorPrototype_next(_args: Arguments, { thisValue }: FunctionC
 export function bootstrapArrayIteratorPrototype(realmRec: Realm) {
   const proto = bootstrapPrototype(realmRec, [
     ['next', ArrayIteratorPrototype_next, 0],
-  ], realmRec.Intrinsics['%IteratorPrototype%'], 'Array Iterator');
+  ], realmRec.Intrinsics['%Iterator.prototype%'], 'Array Iterator');
 
   realmRec.Intrinsics['%ArrayIteratorPrototype%'] = proto;
 }

--- a/src/intrinsics/ForInIteratorPrototype.mts
+++ b/src/intrinsics/ForInIteratorPrototype.mts
@@ -114,7 +114,7 @@ function* ForInIteratorPrototype_next(_args: Arguments, { thisValue }: FunctionC
 export function bootstrapForInIteratorPrototype(realmRec: Realm) {
   const proto = bootstrapPrototype(realmRec, [
     ['next', ForInIteratorPrototype_next, 0],
-  ], realmRec.Intrinsics['%IteratorPrototype%']);
+  ], realmRec.Intrinsics['%Iterator.prototype%']);
 
   realmRec.Intrinsics['%ForInIteratorPrototype%'] = proto;
 }

--- a/src/intrinsics/GeneratorFunctionPrototypePrototype.mts
+++ b/src/intrinsics/GeneratorFunctionPrototypePrototype.mts
@@ -49,7 +49,7 @@ export function bootstrapGeneratorFunctionPrototypePrototype(realmRec: Realm) {
     ['next', GeneratorProto_next, 1],
     ['return', GeneratorProto_return, 1],
     ['throw', GeneratorProto_throw, 1],
-  ], realmRec.Intrinsics['%IteratorPrototype%'], 'Generator');
+  ], realmRec.Intrinsics['%Iterator.prototype%'], 'Generator');
 
   realmRec.Intrinsics['%GeneratorFunction.prototype.prototype%'] = generatorPrototype;
 

--- a/src/intrinsics/Iterator.mts
+++ b/src/intrinsics/Iterator.mts
@@ -1,0 +1,39 @@
+import {
+  OrdinaryCreateFromConstructor,
+  type BuiltinFunctionObject,
+  type Realm,
+} from '../abstract-ops/all.mts';
+import { Q, type ValueEvaluator } from '../completion.mts';
+import { surroundingAgent } from '../host-defined/engine.mts';
+import {
+  UndefinedValue,
+  type Arguments,
+  type FunctionCallContext,
+  type ObjectValue,
+} from '../value.mts';
+import { bootstrapConstructor } from './bootstrap.mts';
+
+/** https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-iterator-constructor */
+function* IteratorConstructor(
+  this: BuiltinFunctionObject,
+  _args: Arguments,
+  { NewTarget }: FunctionCallContext,
+): ValueEvaluator<ObjectValue> {
+  // 1. If NewTarget is either undefined or the active function object, throw a TypeError exception.
+  if (NewTarget instanceof UndefinedValue) {
+    return surroundingAgent.Throw('TypeError', 'ConstructorNonCallable', this);
+  }
+  if (NewTarget === surroundingAgent.activeFunctionObject) {
+    return surroundingAgent.Throw('TypeError', 'CannotConstructAbstractFunction', NewTarget);
+  }
+
+  // 2. Return ? OrdinaryCreateFromConstructor(NewTarget, "%Iterator.prototype%").
+  return Q(yield* OrdinaryCreateFromConstructor(NewTarget, '%Iterator.prototype%'));
+}
+
+export function bootstrapIterator(realmRec: Realm) {
+  const cons = bootstrapConstructor(realmRec, IteratorConstructor, 'Iterator', 0, realmRec.Intrinsics['%Iterator.prototype%'], [
+  ]);
+
+  realmRec.Intrinsics['%Iterator%'] = cons;
+}

--- a/src/intrinsics/IteratorPrototype.mts
+++ b/src/intrinsics/IteratorPrototype.mts
@@ -1,17 +1,61 @@
-import { wellKnownSymbols } from '../value.mts';
+import { SetterThatIgnoresPrototypeProperties, type Realm } from '../abstract-ops/all.mts';
+import { Q, type ValueEvaluator } from '../completion.mts';
+import { surroundingAgent } from '../host-defined/engine.mts';
+import {
+  UndefinedValue,
+  Value, wellKnownSymbols, type Arguments, type FunctionCallContext,
+} from '../value.mts';
 import { bootstrapPrototype } from './bootstrap.mts';
-import type { Arguments, FunctionCallContext, Realm } from '#self';
 
-/** https://tc39.es/ecma262/#sec-%iteratorprototype%-@@iterator */
+/** https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-iterator.prototype.constructor */
+function IteratorProto_constructorGetter() {
+  // 1. Return %Iterator%.
+  return surroundingAgent.intrinsic('%Iterator%');
+}
+
+/** https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-set-iterator.prototype.constructor */
+function* IteratorProto_constructorSetter([v]: Arguments, { thisValue }: FunctionCallContext): ValueEvaluator<UndefinedValue> {
+  // 1. Perform ? SetterThatIgnoresPrototypeProperties(this value, %Iterator.prototype%, "constructor", v).
+  Q(yield* SetterThatIgnoresPrototypeProperties(
+    thisValue,
+    surroundingAgent.intrinsic('%Iterator.prototype%'),
+    Value('constructor'),
+    v,
+  ));
+  // 2. Return undefined.
+  return Value.undefined;
+}
+
+/** https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-iterator.prototype-%symbol.iterator% */
 function IteratorPrototype_iterator(_args: Arguments, { thisValue }: FunctionCallContext) {
-  // 1. Return this value.
+  // 1. Return the this value.
   return thisValue;
+}
+
+/** https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-iterator.prototype-%symbol.tostringtag% */
+function IteratorPrototype_toStringTagGetter() {
+  return Value('Iterator');
+}
+
+/** https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-set-iterator.prototype-%symbol.tostringtag% */
+function* IteratorPrototype_toStringTagSetter([v]: Arguments, { thisValue }: FunctionCallContext): ValueEvaluator<UndefinedValue> {
+  // 1. Perform ? SetterThatIgnoresPrototypeProperties(this value, %Iterator.prototype%, %Symbol.toStringTag%, v).
+  Q(yield* SetterThatIgnoresPrototypeProperties(
+    thisValue,
+    surroundingAgent.intrinsic('%Iterator.prototype%'),
+    wellKnownSymbols.toStringTag,
+    v,
+  ));
+  // 2. Return undefined.
+  return Value.undefined;
 }
 
 export function bootstrapIteratorPrototype(realmRec: Realm) {
   const proto = bootstrapPrototype(realmRec, [
+    ['constructor', [IteratorProto_constructorGetter, IteratorProto_constructorSetter]],
     [wellKnownSymbols.iterator, IteratorPrototype_iterator, 0],
+    [wellKnownSymbols.toStringTag, [IteratorPrototype_toStringTagGetter, IteratorPrototype_toStringTagSetter]],
   ], realmRec.Intrinsics['%Object.prototype%']);
 
-  realmRec.Intrinsics['%IteratorPrototype%'] = proto;
+  realmRec.Intrinsics['%Iterator.prototype%'] = proto;
 }

--- a/src/intrinsics/MapIteratorPrototype.mts
+++ b/src/intrinsics/MapIteratorPrototype.mts
@@ -72,7 +72,7 @@ function* MapIteratorPrototype_next(_args: Arguments, { thisValue }: FunctionCal
 export function bootstrapMapIteratorPrototype(realmRec: Realm) {
   const proto = bootstrapPrototype(realmRec, [
     ['next', MapIteratorPrototype_next, 0],
-  ], realmRec.Intrinsics['%IteratorPrototype%'], 'Map Iterator');
+  ], realmRec.Intrinsics['%Iterator.prototype%'], 'Map Iterator');
 
   realmRec.Intrinsics['%MapIteratorPrototype%'] = proto;
 }

--- a/src/intrinsics/RegExpStringIteratorPrototype.mts
+++ b/src/intrinsics/RegExpStringIteratorPrototype.mts
@@ -74,7 +74,7 @@ function* RegExpStringIteratorPrototype_next(_args: Arguments, { thisValue }: Fu
 export function bootstrapRegExpStringIteratorPrototype(realmRec: Realm) {
   const proto = bootstrapPrototype(realmRec, [
     ['next', RegExpStringIteratorPrototype_next, 0],
-  ], realmRec.Intrinsics['%IteratorPrototype%'], 'RegExp String Iterator');
+  ], realmRec.Intrinsics['%Iterator.prototype%'], 'RegExp String Iterator');
 
   realmRec.Intrinsics['%RegExpStringIteratorPrototype%'] = proto;
 }

--- a/src/intrinsics/SetIteratorPrototype.mts
+++ b/src/intrinsics/SetIteratorPrototype.mts
@@ -69,7 +69,7 @@ function* SetIteratorPrototype_next(_args: Arguments, { thisValue }: FunctionCal
 export function bootstrapSetIteratorPrototype(realmRec: Realm) {
   const proto = bootstrapPrototype(realmRec, [
     ['next', SetIteratorPrototype_next, 0],
-  ], realmRec.Intrinsics['%IteratorPrototype%'], 'Set Iterator');
+  ], realmRec.Intrinsics['%Iterator.prototype%'], 'Set Iterator');
 
   realmRec.Intrinsics['%SetIteratorPrototype%'] = proto;
 }

--- a/src/intrinsics/StringIteratorPrototype.mts
+++ b/src/intrinsics/StringIteratorPrototype.mts
@@ -17,7 +17,7 @@ function* StringIteratorPrototype_next(_args: Arguments, { thisValue }: Function
 export function bootstrapStringIteratorPrototype(realmRec: Realm) {
   const proto = bootstrapPrototype(realmRec, [
     ['next', StringIteratorPrototype_next, 0],
-  ], realmRec.Intrinsics['%IteratorPrototype%'], 'String Iterator');
+  ], realmRec.Intrinsics['%Iterator.prototype%'], 'String Iterator');
 
   realmRec.Intrinsics['%StringIteratorPrototype%'] = proto;
 }

--- a/src/intrinsics/bootstrap.mts
+++ b/src/intrinsics/bootstrap.mts
@@ -19,9 +19,14 @@ import {
 } from '../value.mts';
 import { X } from '../completion.mts';
 
+type Accessor = [
+  getter: NativeSteps | UndefinedValue | FunctionObject,
+  setter?: NativeSteps | UndefinedValue | FunctionObject,
+];
+
 type Props = [
   name: string | JSStringValue | SymbolValue,
-  value: [getter: NativeSteps | UndefinedValue | FunctionObject, setter?: NativeSteps | UndefinedValue | FunctionObject] | NativeSteps | Value,
+  value: Accessor | NativeSteps | Value,
   fnLength?: number,
   desc?: DescriptorInit
 ];
@@ -132,12 +137,14 @@ export function bootstrapConstructor(realmRec: Realm, Constructor: NativeSteps, 
     Configurable: Value.false,
   })));
 
-  X(Prototype.DefineOwnProperty(Value('constructor'), Descriptor({
-    Value: cons,
-    Writable: Value.true,
-    Enumerable: Value.false,
-    Configurable: Value.true,
-  })));
+  if (!Prototype.properties.has('constructor')) {
+    X(Prototype.DefineOwnProperty(Value('constructor'), Descriptor({
+      Value: cons,
+      Writable: Value.true,
+      Enumerable: Value.false,
+      Configurable: Value.true,
+    })));
+  }
 
   assignProps(realmRec, cons, props);
 

--- a/src/messages.mts
+++ b/src/messages.mts
@@ -28,6 +28,7 @@ export const BufferContentTypeMismatch = () => 'Newly created TypedArray did not
 export const BufferDetachKeyMismatch = (k, b) => `${i(k)} is not the [[ArrayBufferDetachKey]] of ${i(b)}`;
 export const CannotAllocateDataBlock = () => 'Cannot allocate memory';
 export const CannotCreateProxyWith = (x, y) => `Cannot create a proxy with a ${x} as ${y}`;
+export const CannotConstructAbstractFunction = (c) => `Cannot construct abstract ${i(c)}`;
 export const CannotConvertDecimalToBigInt = (n) => `Cannot convert ${i(n)} to a BigInt because it is not an integer`;
 export const CannotConvertSymbol = (t) => `Cannot convert a Symbol value to a ${t}`;
 export const CannotConvertToBigInt = (v) => `Cannot convert ${i(v)} to a BigInt`;

--- a/test/inspector/console.test.mts
+++ b/test/inspector/console.test.mts
@@ -134,6 +134,7 @@ test('get local lexical names', async () => {
         "Int8Array",
         "Int16Array",
         "Int32Array",
+        "Iterator",
         "Map",
         "Number",
         "Object",


### PR DESCRIPTION
Blocks <https://github.com/engine262/engine262/pull/265>.

Implementing this correctly required making changes to engine262’s prototype and constructor bootstrapping process to avoid overwriting the `Iterator.prototype.constructor` accessor, which is why I did this part myself.

--------------------------------------------------------------------------------

Unfortunately, test262 doesn’t have a feature flag for just testing the `Iterator` constructor on its own.