### PR TITLE
Make `%Object.prototype%` an immutable prototype exotic object

### DIFF
--- a/src/abstract-ops/realms.mts
+++ b/src/abstract-ops/realms.mts
@@ -4,7 +4,7 @@ import {
 } from '../value.mts';
 import { GlobalEnvironmentRecord } from '../environment.mts';
 import { Q, X } from '../completion.mts';
-import { bootstrapObjectPrototype } from '../intrinsics/ObjectPrototype.mts';
+import { bootstrapObjectPrototype, makeObjectPrototype } from '../intrinsics/ObjectPrototype.mts';
 import { bootstrapObject } from '../intrinsics/Object.mts';
 import { bootstrapArrayPrototype } from '../intrinsics/ArrayPrototype.mts';
 import { bootstrapArray } from '../intrinsics/Array.mts';
@@ -88,7 +88,6 @@ import {
   Assert,
   DefinePropertyOrThrow,
   F as toNumberValue,
-  OrdinaryObjectCreate,
 } from './all.mts';
 
 export interface LoadedModuleRequestRecord {
@@ -303,7 +302,7 @@ function AddRestrictedFunctionProperties(F: ObjectValue, realm: Realm) {
 export function CreateIntrinsics(realmRec: Realm) {
   const intrinsics = Object.create(null);
   (realmRec as Mutable<Realm>).Intrinsics = intrinsics;
-  intrinsics['%Object.prototype%'] = OrdinaryObjectCreate(Value.null);
+  makeObjectPrototype(realmRec);
 
   bootstrapFunctionPrototype(realmRec);
   bootstrapObjectPrototype(realmRec);

--- a/src/intrinsics/ObjectPrototype.mts
+++ b/src/intrinsics/ObjectPrototype.mts
@@ -285,7 +285,7 @@ function* ObjectProto__proto__Set([proto = Value.undefined]: Arguments, { thisVa
 const InternalMethods = {
   /** https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-immutable-prototype-exotic-objects-setprototypeof-v */
   * SetPrototypeOf(V) {
-    // 1. Return ? SetImmutablePrototype(O, V).
+    // 1. Return ? SetImmutablePrototype(O, V).
     return Q(yield* SetImmutablePrototype(this, V));
   },
 } satisfies Partial<ObjectInternalMethods<ImmutablePrototypeObject>>;


### PR DESCRIPTION
This wasn’t caught by the existing tests, as those fail due to the circularity check in [OrdinarySetPrototypeOf](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinarysetprototypeof): <https://github.com/engine262/engine262/blob/d840219fcd2b4918215d35d1fe600f23b9dd06b2/src/abstract-ops/objects.mts#L64-L65>

I’m adding tests that catch this in:
- <https://github.com/tc39/test262/pull/4446>