### PR TITLE
fix(scripts/transform): Emit supported c8 ignore comments

### DIFF
--- a/src/abstract-ops/notational-conventions.mts
+++ b/src/abstract-ops/notational-conventions.mts
@@ -7,10 +7,11 @@ import { ObjectValue } from '../value.mts';
 
 class AssertError extends Error {}
 export function Assert(invariant: boolean, source?: string, completion?: Completion<unknown>): asserts invariant {
-  /* c8 ignore next */
+  /* node:coverage disable */
   if (!invariant) {
     throw new AssertError(source, { cause: completion });
   }
+  /* node:coverage enable */
 }
 Assert.Error = AssertError;
 

--- a/src/completion.mts
+++ b/src/completion.mts
@@ -343,7 +343,7 @@ export { ReturnIfAbrupt as Q };
 
 /** https://tc39.es/ecma262/#sec-returnifabrupt-shorthands ! OperationName() */
 export function X<const T>(_completion: T | Evaluator<T>): ReturnIfAbrupt<T> {
-  /* c8 skip next */
+  /* node:coverage ignore next */
   throw new TypeError('X() requires build');
 }
 

--- a/src/completion.mts
+++ b/src/completion.mts
@@ -322,13 +322,13 @@ export type ReturnIfAbrupt<T> =
  * https://tc39.es/ecma262/#sec-returnifabrupt
  * https://tc39.es/ecma262/#sec-returnifabrupt-shorthands ? OperationName()
  */
-export function ReturnIfAbrupt<const T>(_completion: T): ReturnIfAbrupt<T>
 export function ReturnIfAbrupt<const T>(_completion: T): ReturnIfAbrupt<T> {
-  /* c8 skip next */
+  /* node:coverage ignore next */
   throw new TypeError('ReturnIfAbrupt requires build');
 }
 
 function ReturnIfAbruptRuntime<const T>(completion: T): ReturnIfAbrupt<T> {
+  /* node:coverage ignore next 3 */
   if (typeof completion === 'object' && completion && 'next' in completion) {
     throw new TypeError('Forgot to yield* on the completion.');
   }
@@ -348,6 +348,7 @@ export function X<const T>(_completion: T | Evaluator<T>): ReturnIfAbrupt<T> {
 }
 
 export function unwrapCompletion<const T>(completion: T | Evaluator<T>): ReturnIfAbrupt<T> {
+  /* node:coverage ignore next 3 */
   if (typeof completion === 'object' && completion && 'next' in completion) {
     completion = skipDebugger(completion);
   }
@@ -355,18 +356,19 @@ export function unwrapCompletion<const T>(completion: T | Evaluator<T>): ReturnI
   if (c instanceof NormalCompletion) {
     return c.Value as ReturnIfAbrupt<T>;
   }
-  throw new Error('Unexpected AbruptCompletion.', { cause: c });
+  /* node:coverage ignore next */
+  throw new Assert.Error('Unexpected AbruptCompletion.', { cause: c });
 }
 
 /** https://tc39.es/ecma262/#sec-ifabruptcloseiterator */
 export function IfAbruptCloseIterator<T>(_value: T, _iteratorRecord: IteratorRecord): ReturnIfAbrupt<T> {
-  /* c8 skip next */
+  /* node:coverage ignore next */
   throw new TypeError('IfAbruptCloseIterator() requires build');
 }
 
 /** https://tc39.es/ecma262/#sec-ifabruptrejectpromise */
 export function IfAbruptRejectPromise<T>(_value: T, _capability: PromiseCapabilityRecord): ReturnIfAbrupt<T> {
-  /* c8 skip next */
+  /* node:coverage ignore next */
   throw new TypeError('IfAbruptRejectPromise requires build');
 }
 

--- a/src/helpers.mts
+++ b/src/helpers.mts
@@ -260,14 +260,17 @@ export class JSStringSet {
 }
 
 export class OutOfRange extends RangeError {
+  /* node:coverage disable */
+  declare cause: unknown;
+
   detail: unknown;
 
-  /* c8 ignore next */
   constructor(fn: string, detail: unknown) {
     super(`${fn}() argument out of range`, { cause: detail });
     this.detail = detail;
   }
 }
+/* node:coverage enable */
 
 export function skipDebugger<T>(iterator: Evaluator<T>, maxSteps = Infinity): T {
   let steps = 0;
@@ -276,7 +279,7 @@ export function skipDebugger<T>(iterator: Evaluator<T>, maxSteps = Infinity): T 
     if (done) {
       return value;
     }
-    /* c8 ignore next */
+    /* node:coverage ignore next 4 */
     steps += 1;
     if (steps > maxSteps) {
       throw new RangeError('Max steps exceeded');

--- a/src/host-defined/test262-intrinsics.mts
+++ b/src/host-defined/test262-intrinsics.mts
@@ -20,7 +20,7 @@ export function createTest262Intrinsics(realm: ManagedRealm, printCompatMode: bo
       if (surroundingAgent.debugger_isPreviewing) {
         return NormalCompletion(Value.undefined);
       }
-      /* c8 ignore next */
+      /* node:coverage ignore next */
       if (test262PrintHandle) {
         if (args[0] instanceof JSStringValue) {
           test262PrintHandle(args[0].stringValue());

--- a/src/parser/Scope.mts
+++ b/src/parser/Scope.mts
@@ -385,7 +385,7 @@ export class Scope {
         return scope;
       }
     }
-    /* c8 ignore next */
+    /* node:coverage ignore next */
     throw new RangeError();
   }
 
@@ -396,7 +396,7 @@ export class Scope {
         return scope;
       }
     }
-    /* c8 ignore next */
+    /* node:coverage ignore next */
     throw new RangeError();
   }
 
@@ -493,8 +493,8 @@ export class Scope {
           }
           break;
         }
+        /* node:coverage ignore next 2 */
         default:
-          /* c8 ignore next */
           throw new RangeError(type);
       }
     });


### PR DESCRIPTION
**[c8](https://www.npmjs.com/package/c8)** doesn’t currently support `ignore if`, which is why the coverage was so abysmal, this migrates to using `node:coverage ignore next` and `node:coverage disable/enable`, which are supported by **c8** and **Node**’s experimental [coverage collector](https://nodejs.org/api/test.html#collecting-code-coverage).

This also makes it so that the <code>\`${name}.section = '${url}';\`</code> assignment happens before any trailing comments in case they contain coverage directives and adds `ignore next` comments to `throw new OutOfRange(…)` calls outside of the `default` `switch` clause, such as in: <https://github.com/engine262/engine262/blob/9bf790fe28af5147c9b600492d527b28ae16f384/src/runtime-semantics/Literal.mts#L18-L27>