### PR TITLE
fix(bin): Exit process on REPL exit

### DIFF
--- a/lib-src/node/bin.mts
+++ b/lib-src/node/bin.mts
@@ -9,6 +9,7 @@ import { format as _format, inspect as _inspect, parseArgs } from 'node:util';
 // import packageJson from '../../package.json' with { type: 'json' };
 import { createRequire } from 'node:module';
 import { createConsole } from '../inspector/utils.mts';
+import type { NodeWebsocketInspector } from './inspector.mts';
 import {
   setSurroundingAgent, FEATURES, inspect, Value, Completion, AbruptCompletion,
   type Arguments,
@@ -25,7 +26,6 @@ import {
   ValueOfNormalCompletion,
   ScriptEvaluation,
 } from '#self';
-import type { NodeWebsocketInspector } from './inspector.mts';
 
 const packageJson = createRequire(import.meta.url)('../../package.json');
 const help = `


### PR DESCRIPTION
Currently, when the inspector is attached, the process is kept alive by the inspector’s web socket server even once the REPL has exited or the input was fully evaluated.

This fixes that by stopping the inspector once `oneShotEval` completes, or the REPL server exits.