### PR TITLE
Fix usage of wrong variable

### DIFF
--- a/src/abstract-ops/module-records.mts
+++ b/src/abstract-ops/module-records.mts
@@ -240,7 +240,7 @@ export function* InnerModuleEvaluation(module: AbstractModuleRecord, stack: Cycl
         requiredModule = requiredModule.CycleRoot!;
         Assert(requiredModule.Status === 'evaluating-async' || requiredModule.Status === 'evaluated');
         if (requiredModule.EvaluationError !== undefined) {
-          return EnsureCompletion(module.EvaluationError);
+          return EnsureCompletion(requiredModule.EvaluationError);
         }
       }
       if (typeof requiredModule.AsyncEvaluationOrder === 'number') {


### PR DESCRIPTION
I'm going to add a test262 test that would have caught this.

Spec: step 11.c.iv.3 of https://tc39.es/ecma262/#sec-innermoduleevaluation