### PR TITLE
Adjust invalid assertion about [[AsyncEvaluationOrder]]

### DIFF
--- a/src/modules.mts
+++ b/src/modules.mts
@@ -271,8 +271,8 @@ export abstract class CyclicModuleRecord extends AbstractModuleRecord {
       Assert(module.EvaluationError === undefined);
       // c. If module.[[Status]] is evaluated, then
       if (module.Status === 'evaluated') {
-        // i. Assert: module.[[AsyncEvaluationOrder]] is unset.
-        Assert(module.AsyncEvaluationOrder === 'unset');
+        // i. Assert: module.[[AsyncEvaluationOrder]] is not an integer.
+        Assert(typeof module.AsyncEvaluationOrder !== 'number');
         // ii. Perform ! Call(capability.[[Resolve]], undefined, «undefined»).
         X(Call(capability.Resolve, Value.undefined, [Value.undefined]));
       }


### PR DESCRIPTION
For https://github.com/tc39/ecma262/pull/3613. Tested by https://github.com/tc39/test262/pull/4501.