### PR TITLE
Implement Array.fromAsync

### DIFF
--- a/scripts/transform.mts
+++ b/scripts/transform.mts
@@ -23,7 +23,7 @@ function getEnclosingConditionalExpression(path: NodePath) {
   return null;
 }
 
-type NeededNames = 'Completion' | 'AbruptCompletion' | 'Assert' | 'Call' | 'IteratorClose' | 'Value' | 'skipDebugger';
+type NeededNames = 'Completion' | 'AbruptCompletion' | 'Assert' | 'Call' | 'IteratorClose' | 'AsyncIteratorClose' | 'Value' | 'skipDebugger';
 
 interface State extends PluginPass {
   needed: Partial<Record<NeededNames, boolean>>;
@@ -41,6 +41,7 @@ interface Macros {
   X: Macro<{ value: t.Identifier, checkYieldStar: t.Statement | null, source: t.StringLiteral }>;
   ReturnIfAbrupt: Macro<{ value: t.Identifier, checkYieldStar: t.Statement | null }>;
   IfAbruptCloseIterator: Macro<{ value: t.Identifier, iteratorRecord: t.Identifier }>;
+  IfAbruptCloseAsyncIterator: Macro<{ value: t.Identifier, iteratorRecord: t.Identifier }>;
   IfAbruptRejectPromise: Macro<{ value: t.Identifier, capability: t.Identifier }>;
 }
 
@@ -78,6 +79,12 @@ export default ({ types: t, template }: typeof import('@babel/core')): PluginObj
   function createImportIteratorClose() {
     return template.statement.ast`
       import { IteratorClose } from "#self";
+    `;
+  }
+
+  function createImportAsyncIteratorClose() {
+    return template.statement.ast`
+      import { AsyncIteratorClose } from "#self";
     `;
   }
 
@@ -156,6 +163,17 @@ export default ({ types: t, template }: typeof import('@babel/core')): PluginObj
       `, { preserveComments: true }),
       imports: ['IteratorClose', 'AbruptCompletion', 'Completion', 'skipDebugger'],
     },
+    IfAbruptAsyncCloseIterator: {
+      template: template(`
+      /* IfAbruptAsyncCloseIterator */
+      Assert(%%value%% instanceof CompletionRecord);
+      /* node:coverage ignore next */
+      if (%%value%% instanceof AbruptCompletion) return skipDebugger(AsyncIteratorClose(%%iteratorRecord%%, %%value%%));
+      /* node:coverage ignore next */
+      if (%%value%% instanceof Completion) %%value%% = %%value%%.Value;
+      `, { preserveComments: true }),
+      imports: ['Assert', 'AsyncIteratorClose', 'AbruptCompletion', 'Completion', 'skipDebugger'],
+    },
     IfAbruptRejectPromise: {
       template: template(`
       /* IfAbruptRejectPromise */
@@ -213,6 +231,9 @@ export default ({ types: t, template }: typeof import('@babel/core')): PluginObj
           }
           if (state.needed.IteratorClose) {
             path.unshiftContainer('body', createImportIteratorClose());
+          }
+          if (state.needed.AsyncIteratorClose) {
+            path.unshiftContainer('body', createImportAsyncIteratorClose());
           }
           if (state.needed.Value) {
             path.unshiftContainer('body', createImportValue());

--- a/src/completion.mts
+++ b/src/completion.mts
@@ -366,6 +366,12 @@ export function IfAbruptCloseIterator<T>(_value: T, _iteratorRecord: IteratorRec
   throw new TypeError('IfAbruptCloseIterator() requires build');
 }
 
+/** https://tc39.es/proposal-array-from-async/#sec-ifabruptcloseasynciterator */
+export function IfAbruptCloseAsyncIterator<T>(_value: T, _iteratorRecord: IteratorRecord): ReturnIfAbrupt<T> {
+  /* node:coverage ignore next */
+  throw new TypeError('IfAbruptCloseAsyncIterator() requires build');
+}
+
 /** https://tc39.es/ecma262/#sec-ifabruptrejectpromise */
 export function IfAbruptRejectPromise<T>(_value: T, _capability: PromiseCapabilityRecord): ReturnIfAbrupt<T> {
   /* node:coverage ignore next */

--- a/src/intrinsics/Array.mts
+++ b/src/intrinsics/Array.mts
@@ -2,6 +2,7 @@ import {
   surroundingAgent,
 } from '../host-defined/engine.mts';
 import {
+  Await,
   IfAbruptCloseIterator,
   Q,
   ThrowCompletion, X,
@@ -32,9 +33,16 @@ import {
   type FunctionObject,
   IteratorStepValue,
   GetIteratorFromMethod,
+  type IteratorRecord,
+  CreateAsyncFromSyncIterator,
+  AsyncIteratorClose,
+  IteratorComplete,
 } from '../abstract-ops/all.mts';
 import {
+  BooleanValue,
+  JSStringValue,
   NumberValue,
+  ObjectValue,
   UndefinedValue,
   Value,
   wellKnownSymbols,
@@ -43,6 +51,7 @@ import {
 } from '../value.mts';
 import { __ts_cast__, OutOfRange } from '../helpers.mts';
 import { bootstrapConstructor } from './bootstrap.mts';
+import { IfAbruptCloseAsyncIterator, IteratorValue } from '#self';
 
 /** https://tc39.es/ecma262/#sec-array-constructor */
 function* ArrayConstructor(argumentsList: Arguments, { NewTarget }: FunctionCallContext): ValueEvaluator {
@@ -171,6 +180,188 @@ function* Array_from([items = Value.undefined, mapper = Value.undefined, thisArg
   return A;
 }
 
+/** https://tc39.es/proposal-array-from-async/#sec-array.fromAsync */
+function* Array_fromAsync([asyncItems = Value.undefined, mapper = Value.undefined, thisArg = Value.undefined]: Arguments, { thisValue }: FunctionCallContext) {
+  /* 1. Let C be the this value. */
+  const C = thisValue;
+  /*
+  2. If mapper is undefined, then
+    a. Let mapping be false.
+  3. Else,
+    a. If IsCallable(mapper) is false, throw a TypeError exception.
+    b. Let mapping be true.
+  */
+  let mapping: boolean;
+  if (mapper === Value.undefined) {
+    mapping = false;
+  } else {
+    if (IsCallable(mapper) === false) {
+      return surroundingAgent.Throw('TypeError', 'NotAFunction', mapper);
+    }
+    mapping = true;
+  }
+  /*
+  4. Let usingAsyncIterator be ? GetMethod(asyncItems, %Symbol.asyncIterator%).
+  5. If usingAsyncIterator is undefined, then
+    a. Let usingSyncIterator be ? GetMethod(asyncItems, %Symbol.iterator%).
+  */
+  const usingAsyncIterator: UndefinedValue | FunctionObject = Q(yield* GetMethod(asyncItems, wellKnownSymbols.asyncIterator));
+  let usingSyncIterator: UndefinedValue | FunctionObject = Value.undefined;
+  if (usingAsyncIterator === Value.undefined) {
+    usingSyncIterator = Q(yield* GetMethod(asyncItems, wellKnownSymbols.iterator));
+  }
+
+  /*
+  6. Let iteratorRecord be undefined.
+  7. If usingAsyncIterator is not undefined, then
+    a. Set iteratorRecord to ? GetIteratorFromMethod(asyncItems, usingAsyncIterator).
+  8. Else if usingSyncIterator is not undefined, then
+    a. Set iteratorRecord to CreateAsyncFromSyncIterator(? GetIteratorFromMethod(asyncItems, usingSyncIterator)).
+  */
+  let iteratorRecord: IteratorRecord | undefined;
+  if (usingAsyncIterator !== Value.undefined) {
+    iteratorRecord = Q(yield* GetIteratorFromMethod(asyncItems, usingAsyncIterator as FunctionObject));
+  } else if (usingSyncIterator !== Value.undefined) {
+    iteratorRecord = CreateAsyncFromSyncIterator(Q(yield* GetIteratorFromMethod(asyncItems, usingSyncIterator as FunctionObject)));
+  }
+
+  if (iteratorRecord) {
+    // 9. If iteratorRecord is not undefined, then
+    // NOTE: This constant shows up a lot.  Can we move it to a constants file?
+    const MAX_SAFE_INTEGER = (2 ** 53) - 1;
+
+    /*
+    a. If IsConstructor(C) is true, then
+      i. Let A be ? Construct(C).
+    b. Else,
+      i. Let A be ! ArrayCreate(0).
+    c. Let k be 0.
+    */
+    let A: ObjectValue;
+    if (IsConstructor(C)) {
+      A = Q(yield* Construct(C));
+    } else {
+      A = X(ArrayCreate(0));
+    }
+
+    let k = 0;
+    while (true) {
+      /*
+      i. If k ≥ 2**53 - 1, then
+        1. Let error be ThrowCompletion(a newly created TypeError object).
+        2. Return ? AsyncIteratorClose(iteratorRecord, error).
+      ii. Let Pk be ! ToString(𝔽(k)).
+      iii. Let nextResult be ? Call(iteratorRecord.[[NextMethod]], iteratorRecord.[[Iterator]]).
+      iv. Set nextResult to ? Await(nextResult).
+      v. If nextResult is not an Object, throw a TypeError exception.
+      vi. Let done be ? IteratorComplete(nextResult).
+      vii. If done is true, then
+        1. Perform ? Set(A, "length", 𝔽(k), true).
+        2. Return A.
+      viii. Let nextValue be ? IteratorValue(nextResult).
+      ix. If mapping is true, then
+        1. Let mappedValue be Completion(Call(mapper, thisArg, « nextValue, 𝔽(k) »)).
+        2. IfAbruptCloseAsyncIterator(mappedValue, iteratorRecord).
+        3. Set mappedValue to Completion(Await(mappedValue)).
+        4. IfAbruptCloseAsyncIterator(mappedValue, iteratorRecord).
+      x. Else,
+        1. Let mappedValue be nextValue.
+      xi. Let defineStatus be Completion(CreateDataPropertyOrThrow(A, Pk, mappedValue)).
+      xii. IfAbruptCloseAsyncIterator(defineStatus, iteratorRecord).
+      xiii. Set k to k + 1.
+      */
+      if (k > MAX_SAFE_INTEGER) {
+        const error = ThrowCompletion(surroundingAgent.NewError('TypeError', 'OutOfRange', k));
+        return Q(yield* AsyncIteratorClose(iteratorRecord, error));
+      }
+
+      const Pk: JSStringValue = X(yield* ToString(F(k)));
+      let nextResult: Value = Q(yield* Call(iteratorRecord.NextMethod, iteratorRecord.Iterator));
+
+      // FIXME AssertError: completion.type === 'await-resume' (actual type = 'debugger-resume')
+      nextResult = Q(yield* Await(nextResult));
+      if (!(nextResult instanceof ObjectValue)) {
+        return surroundingAgent.Throw('TypeError', 'NotAnObject', nextResult);
+      }
+      const done: BooleanValue = Q(yield* IteratorComplete(nextResult));
+      if (done === Value.true) {
+        Q(yield* Set(A, Value('length'), F(k), Value.true));
+        return A;
+      }
+
+      const nextValue: ValueCompletion<Value> = Q(yield* IteratorValue(nextResult));
+      let mappedValue;
+      if (mapping) {
+        mappedValue = (yield* Call(mapper, thisArg, [nextValue, F(k)]));
+        IfAbruptCloseAsyncIterator(mappedValue, iteratorRecord);
+        __ts_cast__<Value>(mappedValue);
+        mappedValue = yield* Await(mappedValue);
+        IfAbruptCloseAsyncIterator(mappedValue, iteratorRecord);
+        __ts_cast__<Value>(mappedValue);
+      } else {
+        mappedValue = nextValue;
+      }
+
+      const defineStatus = yield* CreateDataPropertyOrThrow(A, Pk, mappedValue);
+      IfAbruptCloseAsyncIterator(defineStatus, iteratorRecord);
+      k += 1;
+    }
+  } else {
+    // 10. Else,
+    /*
+    a. NOTE: asyncItems is neither an AsyncIterable nor an Iterable so assume it is an array-like object.
+    b. Let arrayLike be ! ToObject(asyncItems).
+    c. Let len be ? LengthOfArrayLike(arrayLike).
+    d. If IsConstructor(C) is true, then
+      i. Let A be ? Construct(C, « 𝔽(len) »).
+    e. Else,
+      i. Let A be ? ArrayCreate(len).
+    f. Let k be 0.
+    g. Repeat, while k < len,
+      i. Let Pk be ! ToString(𝔽(k)).
+      ii. Let kValue be ? Get(arrayLike, Pk).
+      iii. Set kValue to ? Await(kValue).
+      iv. If mapping is true, then
+        1. Let mappedValue be ? Call(mapper, thisArg, « kValue, 𝔽(k) »).
+        2. Set mappedValue to ? Await(mappedValue).
+      v. Else,
+        1. Let mappedValue be kValue.
+      vi. Perform ? CreateDataPropertyOrThrow(A, Pk, mappedValue).
+      vii. Set k to k + 1.
+    h. Perform ? Set(A, "length", 𝔽(len), true).
+    i. Return A.
+    */
+    const arrayLike: ObjectValue = X(ToObject(asyncItems));
+    const len = Q(yield* LengthOfArrayLike(arrayLike));
+
+    let A: ObjectValue;
+    if (IsConstructor(C)) {
+      A = Q(yield* Construct(C));
+    } else {
+      A = X(ArrayCreate(0));
+    }
+
+    let k = 0;
+    while (k < len) {
+      const Pk = X(ToString(F(k)));
+      let kValue = Q(yield* Get(arrayLike, Pk));
+      kValue = Q(yield* Await(kValue));
+      let mappedValue: Value;
+      if (mapping) {
+        mappedValue = Q(yield* Call(mapper, thisArg, [kValue, F(k)]));
+        mappedValue = Q(yield* Await(mappedValue));
+      } else {
+        mappedValue = kValue;
+      }
+      Q(yield* CreateDataPropertyOrThrow(A, Pk, mappedValue));
+      k += 1;
+    }
+
+    Q(yield* Set(A, Value('length'), F(len), Value.true));
+    return A;
+  }
+}
+
 /** https://tc39.es/ecma262/#sec-array.isarray */
 function Array_isArray([arg = Value.undefined]: Arguments): ValueCompletion {
   return Q(IsArray(arg));
@@ -208,6 +399,7 @@ export function bootstrapArray(realmRec: Realm) {
 
   const cons = bootstrapConstructor(realmRec, ArrayConstructor, 'Array', 1, proto, [
     ['from', Array_from, 1],
+    ['fromAsync', Array_fromAsync, 1],
     ['isArray', Array_isArray, 1],
     ['of', Array_of, 0],
     [wellKnownSymbols.species, [Array_speciesGetter]],

--- a/test/test262/features
+++ b/test/test262/features
@@ -7,7 +7,6 @@ uint8array-base64 = uint8array-base64
 import-defer = import-defer
 
 # Update with test262 on Feb 2025, to be investigated/implemented
--Array.fromAsync
 -Float16Array
 -Math.sumPrecise
 -arraybuffer-transfer


### PR DESCRIPTION
This does not quite work:

```
> Array.fromAsync([0, 1, 2])
Uncaught AssertError: completion.type === 'await-resume'
    at Assert (/Users/ajvincent/engine262/engine262/src/abstract-ops/notational-conventions.mts:12:11)
    at Await (/Users/ajvincent/engine262/engine262/src/completion.mts:480:3)
    at Await.next (<anonymous>)
    at ObjectValue.Array_fromAsync (/Users/ajvincent/engine262/engine262/src/intrinsics/Array.mts:280:29)
    at Array_fromAsync.next (<anonymous>)
    at BuiltinCallOrConstruct (/Users/ajvincent/engine262/engine262/src/abstract-ops/function-operations.mts:545:5)
    at BuiltinCallOrConstruct.next (<anonymous>)
    at Call (/Users/ajvincent/engine262/engine262/src/abstract-ops/object-operations.mts:203:38)
    at Call.next (<anonymous>) {
  [cause]: undefined
```

At the point of assertion failure, `completion-type` is "debugger-resume".  The step I fail at is 9.d.iv of [the `Array.fromAsync` proposal spec](https://tc39.es/proposal-array-from-async/)... line 282 of Array.mts in this patch.

Once again, I don't know if the bug is something I've done wrong or in the existing code.

Also, since I'm introducing the `IfAbruptCloseAsyncIterator` abstract operation, I would recommend taking a very close look at that.  I made an educated guess based on nearby code on its macro implementation.