### PR TITLE
Rethrow module parsing errors as-is

### DIFF
--- a/lib-src/node/module.mts
+++ b/lib-src/node/module.mts
@@ -71,7 +71,11 @@ export function createLoadImportedModule(getCache = (realm: ManagedRealm) => rea
         cache?.set(resolved, m);
         finish(m);
       } catch (error) {
-        finish(Throw('SyntaxError', 'CouldNotResolveModule', specifier));
+        if (error instanceof ThrowCompletion) {
+          finish(error);
+        } else {
+          finish(Throw('SyntaxError', 'CouldNotResolveModule', specifier));
+        }
       }
     });
   };


### PR DESCRIPTION
Before this PR, module parsing errors were suppressed and replaced by a CouldNotResolveModule error.