### PR TITLE
fix: async module loader

### DIFF
--- a/lib-src/inspector/methods.mts
+++ b/lib-src/inspector/methods.mts
@@ -21,6 +21,8 @@ import {
   parseNodeToBreakpointLocation,
   performDevtoolsEval,
   isFunctionObject,
+  ModuleRecord,
+  GetModuleNamespace,
 } from '#self';
 
 export const Debugger: DebuggerNamespace = {
@@ -154,7 +156,7 @@ export const Runtime: RuntimeNamespace = {
     if (!realmDesc) {
       throw new Error('No realm found');
     }
-    const { Value: F } = realmDesc.realm.evaluateScript(`(${options.functionDeclaration})`, { doNotTrackScriptId: true }) as NormalCompletion<FunctionObject>;
+    const { Value: F } = realmDesc.realm.evaluateScriptSkipDebugger(`(${options.functionDeclaration})`, { doNotTrackScriptId: true }) as NormalCompletion<FunctionObject>;
     const thisValue = options.objectId
       ? context.getObject(options.objectId)!
       : Value.undefined;
@@ -336,14 +338,31 @@ function evaluate(options: {
       return;
     }
 
-    const completion = realm.realm.evaluate(toBeEvaluated, (completion) => {
-      resolve(context.createEvaluationResult(completion));
+    if (toBeEvaluated instanceof ModuleRecord) {
+      realm.realm.evaluateModule(toBeEvaluated, undefined, (completion) => {
+        if (completion instanceof ThrowCompletion) {
+          resolve(context.createEvaluationResult(completion));
+        } else {
+          resolve(context.createEvaluationResult(NormalCompletion(GetModuleNamespace(toBeEvaluated, 'evaluation'))));
+        }
+        runJobQueue();
+      });
+    } else if (toBeEvaluated instanceof ScriptRecord) {
+      let completion = realm.realm.evaluateScript(toBeEvaluated, {}, (c) => {
+        completion = c;
+        resolve(context.createEvaluationResult(completion));
+      });
+      if (!completion) surroundingAgent.resumeEvaluate();
       runJobQueue();
-    });
-    if (completion) {
-      return;
+    } else {
+      let completion;
+      surroundingAgent.evaluate(toBeEvaluated, (c) => {
+        completion = c;
+        resolve(context.createEvaluationResult(c));
+      });
+      if (!completion) surroundingAgent.resumeEvaluate();
+      runJobQueue();
     }
-    surroundingAgent.resumeEvaluate();
   });
   promise.then(() => {
     if (callOnFramePoppedLevel) {

--- a/lib-src/node/bin.mts
+++ b/lib-src/node/bin.mts
@@ -14,7 +14,6 @@ import { loadImportedModule } from './module.mts';
 import {
   setSurroundingAgent, FEATURES, inspect, Value, Completion, AbruptCompletion,
   type Arguments,
-  evalQ,
   Agent,
   ManagedRealm,
   type ValueCompletion,
@@ -31,8 +30,6 @@ import {
   PerformPromiseThen,
   CreateBuiltinFunction,
   runJobQueue,
-  NewPromiseCapability,
-  unwrapCompletion,
 } from '#self';
 
 const packageJson = createRequire(import.meta.url)('../../package.json');
@@ -187,28 +184,25 @@ function oneShotEval(inspector: NodeWebsocketInspector | undefined, source: stri
     const onErrorCallback = CreateBuiltinFunction.from((result = Value.undefined) => {
       quit(ThrowCompletion(result));
     });
-    const completion = evalQ((Q) => {
-      if (argv.values.module || filename.endsWith('.mjs')) {
-        const module = Q(realm.compileModule(source, { specifier: filename }));
-        realm.HostDefined.resolverCache?.set(filename, 'js', module);
-
-        const noop = CreateBuiltinFunction.from(() => { });
-
-        const loadPromise = module.LoadRequestedModules();
-        const runPromise = PerformPromiseThen(loadPromise, CreateBuiltinFunction.from(function* runModule() {
-          const link = module.Link();
-          if (link instanceof ThrowCompletion) return link;
-          return yield* module.Evaluate();
-        }), onErrorCallback, unwrapCompletion(NewPromiseCapability(surroundingAgent.intrinsic('%Promise%'))));
-        PerformPromiseThen(runPromise, noop, onErrorCallback);
+    // TODO: change exit time to idle.
+    if (argv.values.module || filename.endsWith('.mjs')) {
+      realm.evaluateModule(source, filename, (promise) => {
+        if (promise instanceof ThrowCompletion) {
+          quit(promise);
+          return;
+        }
+        PerformPromiseThen(ValueOfNormalCompletion(promise), Value.null, onErrorCallback);
         runJobQueue();
-      } else {
-        Q(realm.evaluateScript(source, { specifier: filename }));
-      }
-    });
-    quit(completion);
+      });
+    } else {
+      let completion = realm.evaluateScript(source, { specifier: filename }, (c) => {
+        completion = c;
+        if (completion instanceof ThrowCompletion) quit(completion);
+      });
+      if (!completion) surroundingAgent.resumeEvaluate();
+      runJobQueue();
+    }
   });
-
   inspector?.stop();
 
   function quit(completion: ThrowCompletion<Value> | NormalCompletion<void>) {

--- a/lib-src/node/example.mts
+++ b/lib-src/node/example.mts
@@ -42,12 +42,12 @@ const realm = new ManagedRealm({ resolverCache: new ModuleCache(), name: 'My Rea
 // Do not forget to use realm.scope when running code.
 realm.scope(() => {
   // Run ECMAScript code in the Realm.
-  realm.evaluateScript(`
+  realm.evaluateScriptSkipDebugger(`
     console.log('Hello from engine262!');
     console.log('2 + 2 =', 2 + 2);
   `, { specifier: 'example.mts' });
 
-  const result = realm.evaluateScript(`
+  const result = realm.evaluateScriptSkipDebugger(`
     throw new Error('This is an example error');
   `, { specifier: 'example.mts' });
   if (result instanceof NormalCompletion) {

--- a/lib-src/node/module.mts
+++ b/lib-src/node/module.mts
@@ -2,7 +2,8 @@ import { readFile, readFileSync } from 'node:fs';
 import path from 'node:path';
 import {
   EnsureCompletion,
-  ManagedRealm, Realm, Throw, ThrowCompletion, type AgentHostDefined,
+  ManagedRealm, Realm, Throw, ThrowCompletion, type AgentHostDefined, type AbstractModuleRecord, type PlainCompletion,
+  type ModuleCacheKey,
 } from '#self';
 
 export function createLoadImportedModule(getCache = (realm: ManagedRealm) => realm.HostDefined.resolverCache) {
@@ -44,26 +45,27 @@ export function createLoadImportedModule(getCache = (realm: ManagedRealm) => rea
 
       const base = path.dirname(referrer.HostDefined!.specifier!);
       const resolved = path.resolve(base, specifier);
-      const type = (attributes.get('type') as 'json' | 'text' | undefined) || 'js';
-      if (cache?.has(resolved, type)) {
-        finish(cache.get(resolved, type)!);
-        return;
-      }
-      readFile(resolved, (err, data) => {
-        realm.scope(() => {
-          if (err) {
-            finish(Throw.SyntaxError('Could not read module $1', specifier));
-            return;
-          }
-          const module = EnsureCompletion(parseModule(realm, resolved, attributes, data));
-          if (module.Type === 'throw') {
-            finish(module);
-          } else {
-            cache?.set(resolved, type, module.Value);
-            finish(module);
-          }
+      const attributeObject = Object.fromEntries(attributes);
+
+      const load = (callback: (completion: PlainCompletion<AbstractModuleRecord>) => void) => {
+        readFile(resolved, (err, data) => {
+          realm.scope(() => {
+            if (err) {
+              callback(Throw.SyntaxError('Could not read module $1', specifier));
+            } else {
+              callback(EnsureCompletion(parseModule(realm, resolved, attributes, data)));
+            }
+          });
         });
-      });
+      };
+
+      let cacheKey: ModuleCacheKey;
+      if (cache) {
+        cacheKey = cache.toCacheKey(resolved, attributes.get('type') || 'js', attributeObject);
+        cache.load(cacheKey, load, finish);
+      } else {
+        load(finish);
+      }
     });
   };
 

--- a/src/api.mts
+++ b/src/api.mts
@@ -23,6 +23,7 @@ import {
   type ParseScriptHostDefined,
 } from './parse.mts';
 import {
+  AbstractModuleRecord,
   ModuleRecord, SourceTextModuleRecord, type ModuleRecordHostDefined, type ModuleRecordHostDefinedPublic,
 } from './modules.mts';
 import { isWeakRef, type WeakRefObject } from './intrinsics/WeakRef.mts';
@@ -39,10 +40,13 @@ import {
   OrdinaryObjectCreate,
   Assert,
   CreateTextModule,
+  PerformPromiseThen,
+  CreateBuiltinFunction,
+  ValueOfNormalCompletion,
 } from '#self';
 import {
   Realm,
-  EnsureCompletion, GetModuleNamespace, GlobalEnvironmentRecord, type Intrinsics,
+  GlobalEnvironmentRecord, type Intrinsics,
   type ValueEvaluator,
 } from '#self';
 
@@ -316,148 +320,62 @@ export class ManagedRealm extends Realm {
     });
   }
 
-  /**
-   * Call surroundingAgent.resumeEvaluate() to continue evaluation.
-   *
-   * This function will synchronously return a completion if this is a nested evaluation and debugger cannot be triggered.
-   */
-  evaluate(sourceText: ScriptRecord | ModuleRecord | ValueEvaluator, callback: (completion: NormalCompletion<Value> | ThrowCompletion) => void) {
-    if (!sourceText) {
-      throw new TypeError('sourceText is null or undefined');
-    }
+  evaluateScript(sourceText: string | ScriptRecord, options: { specifier?: string, doNotTrackScriptId?: boolean } = {}, callback: (completion: NormalCompletion<Value> | ThrowCompletion) => void) {
+    if (sourceText === undefined || sourceText === null) throw new TypeError('sourceText must be a string or a ScriptRecord');
+    if (typeof sourceText === 'string') sourceText = Q(this.compileScript(sourceText, options));
+    if (!sourceText) throw new TypeError('sourceText is null or undefined');
+    using _ = this.scope();
     let result: ValueCompletion | undefined;
-
-    if (sourceText instanceof ModuleRecord) {
-      const old = this.active;
-      this.active = true;
-      surroundingAgent.executionContextStack.push(this.topContext);
-
-      const loadModuleCompletion = sourceText.LoadRequestedModules();
-      const link = ((): PlainCompletion<void> => {
-        if (loadModuleCompletion.PromiseState === 'rejected') {
-          Q(ThrowCompletion(loadModuleCompletion.PromiseResult!));
-        } else if (loadModuleCompletion.PromiseState === 'pending') {
-          throw new Error('Internal error: .LoadRequestedModules() returned a pending promise');
-        }
-        Q(sourceText.Link());
-      })();
-      if (link instanceof ThrowCompletion) {
-        callback(link);
-        return link;
-      }
-      surroundingAgent.evaluate(sourceText.Evaluate(), (completion) => {
-        if (completion instanceof NormalCompletion && completion.Value.PromiseState === 'fulfilled') {
-          result = GetModuleNamespace(sourceText, 'evaluation');
-        } else {
-          result = completion;
-        }
-        this.active = old;
-        surroundingAgent.executionContextStack.pop(this.topContext);
-        callback(EnsureCompletion(result));
-      });
-      return result;
-    } else if (sourceText instanceof ScriptRecord) {
-      const old = this.active;
-      this.active = true;
-      surroundingAgent.executionContextStack.push(this.topContext);
-
-      surroundingAgent.evaluate(ScriptEvaluation(sourceText), (completion) => {
-        this.active = old;
-        surroundingAgent.executionContextStack.pop(this.topContext);
-        result = completion;
-        callback(completion);
-      });
-      return result;
-    } else {
-      // this path only called by the inspector
-      Assert(!!surroundingAgent.hostDefinedOptions.onDebugger);
-      let emptyExecutionStack = false;
-      if (!surroundingAgent.runningExecutionContext) {
-        emptyExecutionStack = true;
-        this.active = true;
-        surroundingAgent.executionContextStack.push(this.topContext);
-      }
-      surroundingAgent.evaluate(sourceText, (completion) => {
-        result = completion;
-        if (emptyExecutionStack) {
-          this.active = false;
-          surroundingAgent.executionContextStack.pop(this.topContext);
-        }
-        callback(completion);
-      });
-      return result;
-    }
+    surroundingAgent.evaluate(ScriptEvaluation(sourceText), (completion) => {
+      result = completion;
+      callback(completion);
+    });
+    return result;
   }
 
-  evaluateScript(sourceText: string | ScriptRecord, { specifier, doNotTrackScriptId }: { specifier?: string, doNotTrackScriptId?: boolean } = {}): ValueCompletion {
-    if (sourceText === undefined || sourceText === null) {
-      throw new TypeError('sourceText must be a string or a ScriptRecord');
-    }
-    if (typeof sourceText === 'string') {
-      sourceText = Q(this.compileScript(sourceText, { specifier, doNotTrackScriptId }));
-    }
-
-    let completion;
-    completion = this.evaluate(sourceText, (c) => {
+  /**
+   * Evaluate a script (skip the debugger).
+   */
+  evaluateScriptSkipDebugger(sourceText: string | ScriptRecord, options: { specifier?: string, doNotTrackScriptId?: boolean } = {}): ValueCompletion {
+    let completion = this.evaluateScript(sourceText, options, (c) => {
       completion = c;
     });
-    if (!completion) {
-      surroundingAgent.resumeEvaluate({
-        noBreakpoint: true,
-      });
-    }
-    if (!completion) {
-      throw new Assert.Error('Expect evaluation completes synchronously');
-    }
+    if (!completion) surroundingAgent.resumeEvaluate({ noBreakpoint: true });
+    if (!completion) throw new Assert.Error('Expect evaluation completes synchronously');
     runJobQueue();
 
     return completion;
   }
 
-  evaluateModule(sourceText: string, specifier: string): PlainCompletion<SourceTextModuleRecord>
 
-  evaluateModule<T extends ModuleRecord>(sourceText: T, specifier: string): PlainCompletion<T>
+  evaluateModule<T extends ModuleRecord>(sourceText: string | T, specifier: string | undefined, finish: (completion: ValueCompletion<PromiseObject>) => void) {
+    using _ = this.scope();
+    if (sourceText === undefined || sourceText === null) throw new TypeError('sourceText must be a string or a ModuleRecord');
+    const moduleCompletion = typeof sourceText === 'string' ? this.compileModule(sourceText, { specifier }) as PlainCompletion<AbstractModuleRecord> : sourceText;
 
-  evaluateModule(sourceText: string | ModuleRecord, specifier: string): PlainCompletion<ModuleRecord> {
-    if (sourceText === undefined || sourceText === null) {
-      throw new TypeError('sourceText must be a string or a ModuleRecord');
-    }
-    if (typeof sourceText === 'string') {
-      sourceText = Q(this.compileModule(sourceText, { specifier }));
-    }
-
-    let completion;
-    completion = this.evaluate(sourceText, (c) => {
-      completion = c;
-      runJobQueue();
-    });
-    if (!completion) {
-      surroundingAgent.resumeEvaluate({
-        noBreakpoint: true,
-      });
+    if (this.HostDefined.resolverCache && typeof specifier === 'string') {
+      const key = this.HostDefined.resolverCache.toCacheKey(specifier, 'js', {});
+      this.HostDefined.resolverCache.set(key, moduleCompletion);
     }
 
-    return sourceText;
-  }
+    if (moduleCompletion instanceof ThrowCompletion) {
+      finish(moduleCompletion);
+      return;
+    }
+    const module = ValueOfNormalCompletion(moduleCompletion);
 
-  /**
-   * @deprecated use compileModule
-   */
-  createSourceTextModule(specifier: string, sourceText: string): PlainCompletion<SourceTextModuleRecord> {
-    if (typeof specifier !== 'string') {
-      throw new TypeError('specifier must be a string');
-    }
-    if (typeof sourceText !== 'string') {
-      throw new TypeError('sourceText must be a string');
-    }
-    const module = this.scope(() => ParseModule(sourceText, this, {
-      specifier,
-      SourceTextModuleRecord: ManagedSourceTextModuleRecord,
+    PerformPromiseThen(module.LoadRequestedModules(), CreateBuiltinFunction.from(function* linkAndEvaluate() {
+      const link = module.Link();
+      if (link instanceof ThrowCompletion) {
+        finish(link);
+        return Value.undefined;
+      }
+      finish(yield* module.Evaluate());
+      return Value.undefined;
+    }), CreateBuiltinFunction.from((err = Value.undefined) => {
+      finish(ThrowCompletion(err));
     }));
-    if (Array.isArray(module)) {
-      return ThrowCompletion(module[0]);
-    }
-    return module;
+    runJobQueue();
   }
 
   createJSONModule(sourceText: string) {

--- a/src/host-defined/test262-intrinsics.mts
+++ b/src/host-defined/test262-intrinsics.mts
@@ -21,42 +21,31 @@ import {
 /** https://github.com/tc39/test262/blob/main/INTERPRETING.md */
 export function createTest262Intrinsics(realm: ManagedRealm, printCompatMode: boolean, log: (...args: unknown[]) => void = Reflect.get(globalThis, 'console').log) {
   return realm.scope(() => {
-    let test262PrintHandle: ((str: string, value: Value) => void) | undefined;
-    const setPrintHandle = (f: typeof test262PrintHandle | undefined) => {
-      test262PrintHandle = f;
-    };
     const print = CreateBuiltinFunction((args: Arguments): ValueCompletion => {
       if (surroundingAgent.debugger_isPreviewing) {
         return NormalCompletion(Value.undefined);
       }
       /* node:coverage ignore next */
-      if (test262PrintHandle) {
-        if (args[0] instanceof JSStringValue) {
-          test262PrintHandle(args[0].stringValue(), args[1] || Value.undefined);
-          return Value.undefined;
-        }
-      } else {
-        if (printCompatMode) {
-          const str: string[] = [];
-          for (let i = 0; i < args.length; i += 1) {
-            const arg = args[i]!;
-            const s = EnsureCompletion(skipDebugger(ToString(arg)));
-            if (s.Type === 'throw') {
-              return s;
-            }
-            str.push(s.Value.stringValue());
+      if (printCompatMode) {
+        const str: string[] = [];
+        for (let i = 0; i < args.length; i += 1) {
+          const arg = args[i]!;
+          const s = EnsureCompletion(skipDebugger(ToString(arg)));
+          if (s.Type === 'throw') {
+            return s;
           }
-          log(...str);
-          return Value.undefined;
-        } else {
-          const formatted = args.map((a, i) => {
-            if (i === 0 && a instanceof JSStringValue) {
-              return a.stringValue();
-            }
-            return inspect(a);
-          }).join(' ');
-          log(formatted);
+          str.push(s.Value.stringValue());
         }
+        log(...str);
+        return Value.undefined;
+      } else {
+        const formatted = args.map((a, i) => {
+          if (i === 0 && a instanceof JSStringValue) {
+            return a.stringValue();
+          }
+          return inspect(a);
+        }).join(' ');
+        log(formatted);
       }
       return Value.undefined;
     }, 0, Value('print'), []);
@@ -116,7 +105,6 @@ export function createTest262Intrinsics(realm: ManagedRealm, printCompatMode: bo
     CreateNonEnumerableDataPropertyOrThrow(realm.GlobalObject, Value('$'), $262);
 
     return {
-      setPrintHandle,
       $262,
     };
   });
@@ -130,7 +118,7 @@ export function importBundledTest262Harness(
     const script = X(
       realm.compileScript(file, { specifier: nameMapper(specifier) }),
     );
-    realm.evaluateScript(script);
+    realm.evaluateScriptSkipDebugger(script);
   }
 }
 

--- a/src/index.mts
+++ b/src/index.mts
@@ -24,7 +24,7 @@ export { skipDebugger } from './utils/evaluator.mts';
 export {
   CallSite, CallFrame, captureStack, getHostDefinedErrorDetails, getCurrentStack,
 } from './utils/stack.mts';
-export { ModuleCache } from './utils/module.mts';
+export { ModuleCache, type ModuleCacheKey } from './utils/module.mts';
 
 export { isBoundFunctionObject, type BoundFunctionObject } from './intrinsics/FunctionPrototype.mts';
 export { isMapObject, type MapObject } from './intrinsics/Map.mts';

--- a/src/utils/module.mts
+++ b/src/utils/module.mts
@@ -1,24 +1,63 @@
-import type { AbstractModuleRecord } from '#self';
+import { type AbstractModuleRecord, type PlainCompletion } from '#self';
+
+type ModuleType = 'js' | 'json' | 'text' | 'bytes' | string;
+type ModuleAttributes = Record<string, string>;
+
+interface ModuleCacheEntry {
+  result?: PlainCompletion<AbstractModuleRecord>;
+  pending?: PromiseWithResolvers<PlainCompletion<AbstractModuleRecord>>;
+}
+
+export type ModuleCacheKey = string & { __ModuleCacheKey: never };
 
 export class ModuleCache {
-  private cache = new Map<string, Map<string, AbstractModuleRecord>>();
+  #cache = new Map<ModuleCacheKey, ModuleCacheEntry>();
 
-  get(specifier: string, attribute: 'js' | 'json' | 'text') {
-    return this.cache.get(specifier)?.get(attribute);
+  toCacheKey(specifier: string, type: ModuleType, attributes: ModuleAttributes): ModuleCacheKey {
+    const sorted: ModuleAttributes = {};
+    for (const key of Object.keys(attributes).sort()) {
+      sorted[key] = attributes[key];
+    }
+    sorted.type = type;
+    return JSON.stringify([specifier, sorted]) as ModuleCacheKey;
   }
 
-  getOrInsert(specifier: string, attribute: 'js' | 'json' | 'text', module: () => AbstractModuleRecord) {
-    if (!this.cache.has(specifier)) this.set(specifier, attribute, module());
-    return this.cache.get(specifier)!.get(attribute)!;
+  set(key: ModuleCacheKey, result: PlainCompletion<AbstractModuleRecord>): void {
+    if (!this.#cache.has(key)) {
+      this.#cache.set(key, { result });
+      return;
+    }
+    const entry = this.#cache.get(key);
+    if (entry?.pending) {
+      entry.pending.resolve(result);
+      this.#cache.set(key, { result });
+    } else {
+      // cache cannot be modified.
+    }
   }
 
-  has(specifier: string, attribute: 'js' | 'json' | 'text') {
-    return this.cache.get(specifier)?.has(attribute) ?? false;
+  load(key: ModuleCacheKey, loader: (setCache: (value: PlainCompletion<AbstractModuleRecord>) => void) => void, callback: (result: PlainCompletion<AbstractModuleRecord>) => void): void {
+    if (!this.#cache.has(key)) {
+      const promise = Promise.withResolvers<PlainCompletion<AbstractModuleRecord>>();
+      this.#cache.set(key, { pending: promise });
+      loader((value) => {
+        promise.resolve(value);
+        this.#cache.set(key, { result: value });
+        callback(value);
+      });
+      return;
+    }
+    const entry = this.#cache.get(key)!;
+    if (entry.result) callback(entry.result);
+    else if (entry.pending) entry.pending.promise.then(callback);
   }
 
-  set(specifier: string, attribute: 'js' | 'json' | 'text', module: AbstractModuleRecord) {
-    if (!this.cache.has(specifier)) this.cache.set(specifier, new Map());
-    const attributeCache = this.cache.get(specifier)!;
-    attributeCache.set(attribute, module);
+  hasUnfinishedRequests() {
+    return this.#cache.values().some((entry) => !entry.result);
+  }
+
+  untilAllRequestFinished() {
+    const pending = Array.from(this.#cache.values()).filter((entry) => !!entry.pending).map((entry) => entry.pending!.promise);
+    return Promise.all(pending);
   }
 }

--- a/test/base.mts
+++ b/test/base.mts
@@ -1,9 +1,8 @@
 import fs from 'node:fs';
-import { loadImportedModuleSync } from '../lib-src/node/module.mts';
+import { loadImportedModule, loadImportedModuleSync } from '../lib-src/node/module.mts';
 import { supportColor, type SkipReason } from './tui.mts';
 import {
   Agent, ManagedRealm, type OrdinaryObject, OrdinaryObjectCreate, createTest262Intrinsics,
-  Value,
   ModuleCache,
 } from '#self';
 
@@ -33,6 +32,8 @@ export class Test {
     this.content = contents;
     this.currentTestFlag = currentRunFlags;
   }
+
+  asyncModuleLoader = false;
 
   startTime: number | null = null;
 
@@ -68,9 +69,27 @@ export class Test {
   withDifferentTestFlag(newFlag: string, newContent = this.content) {
     return new Test(this.file, this.specifier, this.engineFeatures, this.attrs, newFlag, newContent);
   }
+
+  withAsyncModuleLoader() {
+    const test = this.withDifferentTestFlag(this.currentTestFlag ? `${this.currentTestFlag},async-loader` : 'async-loader');
+    test.asyncModuleLoader = true;
+    return test;
+  }
 }
 
 export type SupervisorToWorker = Exclude<Test, 'withDifferentTestFlag'>
+
+export type LogDetail = {
+  message: string;
+  stack: Stack[];
+}
+
+export type WorkerToSupervisor_Log = {
+  status: 'LOG';
+  file: undefined | string;
+  testId: undefined | number;
+} & LogDetail;
+
 export type WorkerToSupervisor_Running = {
   status: 'RUNNING';
   testId: number;
@@ -96,11 +115,10 @@ export type WorkerToSupervisor_Failed = {
   flags: string;
   testId: number;
   description: string;
-  error: string;
-  stack: Stack[]
-};
+} & LogDetail;
 
 export type WorkerToSupervisor =
+  | WorkerToSupervisor_Log
   | WorkerToSupervisor_Running
   | WorkerToSupervisor_Pass
   | WorkerToSupervisor_Failed
@@ -115,13 +133,14 @@ export function readList(path: string | URL) {
 
 export interface CreateAgentOptions {
   features?: readonly string[];
+  asyncModuleLoader?: boolean;
 }
 
-export function createAgent({ features = [] }: CreateAgentOptions) {
+export function createAgent({ features = [], asyncModuleLoader = false }: CreateAgentOptions) {
   const agent = new Agent({
     features,
     supportedImportAttributes: ['type'],
-    loadImportedModule: loadImportedModuleSync,
+    loadImportedModule: asyncModuleLoader ? loadImportedModule : loadImportedModuleSync,
     onDebugger() {
       // attach an empty debugger to make sure our debugger infrastructure does not break the engine
       agent.resumeEvaluate({ noBreakpoint: true });
@@ -134,14 +153,15 @@ export interface Test262CreateRealm {
   realm: ManagedRealm;
   $262: OrdinaryObject;
   resolverCache: ModuleCache;
-  setPrintHandle: (callback: ((str: string, value: Value) => void) | undefined) => void;
 }
 export interface CreateRealmOptions {
   printCompatMode?: boolean;
   specifier?: string;
+  log?: (...val: unknown[]) => void;
 }
 
-export function createRealm({ printCompatMode = false, specifier }: CreateRealmOptions = {}): Test262CreateRealm {
+// eslint-disable-next-line no-console
+export function createRealm({ printCompatMode = false, specifier, log = console.log }: CreateRealmOptions = {}): Test262CreateRealm {
   const resolverCache = new ModuleCache();
 
   const realm = new ManagedRealm({
@@ -151,13 +171,11 @@ export function createRealm({ printCompatMode = false, specifier }: CreateRealmO
 
   return realm.scope(() => {
     const $262 = OrdinaryObjectCreate(realm.Intrinsics['%Object.prototype%']);
-    // eslint-disable-next-line no-console
-    const { setPrintHandle } = createTest262Intrinsics(realm, printCompatMode, console.log);
+    createTest262Intrinsics(realm, printCompatMode, log);
     return {
       realm,
       $262,
       resolverCache,
-      setPrintHandle,
     };
   });
 }

--- a/test/engine262/WeakRef.test.mts
+++ b/test/engine262/WeakRef.test.mts
@@ -12,7 +12,7 @@ test('WeakRef (script)', () => {
   const agent = new Agent();
   setSurroundingAgent(agent);
   const realm = new ManagedRealm();
-  const result = realm.evaluateScript(`
+  const result = realm.evaluateScriptSkipDebugger(`
     const w = new WeakRef({});
     Promise.resolve()
       .then(() => {

--- a/test/engine262/debugger.test.mts
+++ b/test/engine262/debugger.test.mts
@@ -13,7 +13,7 @@ test('debugger statement should return undefined when no debugger is attached', 
   const agent = new Agent();
   setSurroundingAgent(agent);
   const realm = new ManagedRealm();
-  const result = realm.evaluateScript('debugger;') as NormalCompletion<UndefinedValue>;
+  const result = realm.evaluateScriptSkipDebugger('debugger;') as NormalCompletion<UndefinedValue>;
   expect(result).toBeInstanceOf(NormalCompletion);
   expect(result.Value).toBe(Value.undefined);
 });
@@ -28,7 +28,7 @@ test('debugger statement should return the value passed to resumeEvaluate', asyn
   evalQ((_Q, X) => {
     const script = X(realm.compileScript('debugger;'));
     let completion!: ValueCompletion;
-    realm.evaluate(script, (c) => {
+    realm.evaluateScript(script, {}, (c) => {
       completion = c;
     });
     // start the evaluation

--- a/test/engine262/error.test.mts
+++ b/test/engine262/error.test.mts
@@ -10,7 +10,7 @@ test('stack', () => {
   const agent = new Agent();
   setSurroundingAgent(agent);
   const realm = new ManagedRealm();
-  const result = realm.evaluateScript(`
+  const result = realm.evaluateScriptSkipDebugger(`
     function x() { throw new Error('owo'); }
     function y() { x(); }
     try {
@@ -33,7 +33,7 @@ test('async stack', () => {
   const agent = new Agent();
   setSurroundingAgent(agent);
   const realm = new ManagedRealm();
-  const result = realm.evaluateScript(`
+  const result = realm.evaluateScriptSkipDebugger(`
     async function x() { await 1; throw new Error('owo'); }
     async function y() { await x(); }
     y().catch((e) => e.stack);
@@ -57,7 +57,7 @@ test('native stack', () => {
   const realm = new ManagedRealm();
   // built-in functions
   {
-    const result = realm.evaluateScript(`
+    const result = realm.evaluateScriptSkipDebugger(`
       function x() { Reflect.get(); }
       try {
         x();
@@ -77,7 +77,7 @@ test('native stack', () => {
 
   // derived class constructors
   {
-    const result = realm.evaluateScript(`
+    const result = realm.evaluateScriptSkipDebugger(`
       class T {}
       try { T() } catch (e) { e.stack; }
     `) as NormalCompletion<JSStringValue>;
@@ -104,7 +104,7 @@ test('native function names', () => {
     });
     unwrapCompletion(CreateDataPropertyOrThrow(realm.GlobalObject, Value('getName'), f));
   });
-  const result = realm.evaluateScript(`
+  const result = realm.evaluateScriptSkipDebugger(`
   (${() => {
     // @ts-expect-error
     declare const getName: (f: object) => string;

--- a/test/engine262/module.test.mts
+++ b/test/engine262/module.test.mts
@@ -18,36 +18,38 @@ test('Import attributes', () => {
   setSurroundingAgent(agent);
   const realm = new ManagedRealm();
 
-  realm.evaluateModule('import "test" with {}', 'case 1');
+  const noop = () => {};
+
+  realm.evaluateModule('import "test" with {}', 'case 1', noop);
   expect([...attributes]).lengthOf(0);
 
-  realm.evaluateModule('import "test" with { fruit: "banana" }', 'case 2');
+  realm.evaluateModule('import "test" with { fruit: "banana" }', 'case 2', noop);
   expect([...attributes]).deep.equal([['fruit', 'banana']]);
 
-  realm.evaluateModule('import "test" with { fruit: "banana", animal: "monkey" }', 'case 3');
+  realm.evaluateModule('import "test" with { fruit: "banana", animal: "monkey" }', 'case 3', noop);
   expect([...attributes]).deep.equal([['animal', 'monkey'], ['fruit', 'banana']]);
 
-  realm.evaluateModule('import "test" with { animal: "monkey", fruit: "banana" }', 'case 4');
+  realm.evaluateModule('import "test" with { animal: "monkey", fruit: "banana" }', 'case 4', noop);
   expect([...attributes]).deep.equal([['animal', 'monkey'], ['fruit', 'banana']]);
 
   calls = 0;
-  realm.evaluateModule('import "test" with { fruit: "banana" }; import "test" with { fruit: "banana" }', 'case 5');
+  realm.evaluateModule('import "test" with { fruit: "banana" }; import "test" with { fruit: "banana" }', 'case 5', noop);
   expect(calls).toBe(1);
 
   calls = 0;
-  realm.evaluateModule('import "test" with { fruit: "banana" }; import "test" with { animal: "monkey" }', 'case 6');
+  realm.evaluateModule('import "test" with { fruit: "banana" }; import "test" with { animal: "monkey" }', 'case 6', noop);
   expect(calls).toBe(2);
 
   calls = 0;
-  realm.evaluateModule('import "test" with { fruit: "banana", animal: "monkey" }; import "test" with { animal: "monkey", fruit: "banana" };', 'case 7');
+  realm.evaluateModule('import "test" with { fruit: "banana", animal: "monkey" }; import "test" with { animal: "monkey", fruit: "banana" };', 'case 7', noop);
   expect(calls).toBe(1);
 
   calls = 0;
-  realm.evaluateModule('import "test" with { animal: "monkey" }; import "test" with { animal: "elephant" };', 'case 8');
+  realm.evaluateModule('import "test" with { animal: "monkey" }; import "test" with { animal: "elephant" };', 'case 8', noop);
   expect(calls).toBe(2);
 
   calls = 0;
-  realm.evaluateModule('import "test"; import "test" with {};', 'case 9');
+  realm.evaluateModule('import "test"; import "test" with {};', 'case 9', noop);
   expect(calls).toBe(1);
 });
 
@@ -111,7 +113,7 @@ test('Custom module records', () => {
     },
   });
 
-  realm.evaluateModule('import "dep"', 'entrypoint');
+  realm.evaluateModule('import "dep"', 'entrypoint', () => {});
 
   assert(calls.length >= 2); // there is a third call, for the promise of the entrypoint
   assert.deepStrictEqual(calls[0], [evaluationPromise!, 'reject'], "first call should be 'reject'");

--- a/test/engine262/section.test.mts
+++ b/test/engine262/section.test.mts
@@ -33,7 +33,7 @@ test('Every built-in function should have a section property', { timeout: 10000 
       CreateArrayFromList(targets),
     ));
   });
-  const result = realm.evaluateScript(`
+  const result = realm.evaluateScriptSkipDebugger(`
     'use strict';
 
     {

--- a/test/inspector/debugger.test.mts
+++ b/test/inspector/debugger.test.mts
@@ -61,7 +61,7 @@ test('evaluate on frame', async () => {
         "params": {
           "callFrames": [
             {
-              "callFrameId": "3",
+              "callFrameId": "2",
               "canBeRestarted": false,
               "functionLocation": {
                 "columnNumber": 17,
@@ -156,7 +156,7 @@ test('evaluate on frame', async () => {
               "url": "",
             },
             {
-              "callFrameId": "2",
+              "callFrameId": "1",
               "canBeRestarted": false,
               "functionLocation": {
                 "columnNumber": 17,
@@ -251,7 +251,7 @@ test('evaluate on frame', async () => {
               "url": "",
             },
             {
-              "callFrameId": "1",
+              "callFrameId": "0",
               "canBeRestarted": false,
               "functionLocation": undefined,
               "functionName": "<anonymous>",
@@ -387,7 +387,7 @@ test('evaluate on frame', async () => {
     ]
   `);
   expect(await inspector.debugger.evaluateOnCallFrame({
-    callFrameId: "3",
+    callFrameId: "2",
     expression: 'a',
   })).toMatchInlineSnapshot(`
     {
@@ -397,7 +397,7 @@ test('evaluate on frame', async () => {
     }
   `);
   expect(await inspector.debugger.evaluateOnCallFrame({
-    callFrameId: "2",
+    callFrameId: "1",
     expression: 'a',
   })).toMatchInlineSnapshot(`
     {
@@ -407,7 +407,7 @@ test('evaluate on frame', async () => {
     }
   `);
   expect(await inspector.debugger.evaluateOnCallFrame({
-    callFrameId: "1",
+    callFrameId: "0",
     expression: 'a',
   })).toMatchInlineSnapshot(`
     {

--- a/test/json/json.mts
+++ b/test/json/json.mts
@@ -43,7 +43,7 @@ function test(filename: string) {
   reporter.updateWorker(0, test.id);
   let result;
   try {
-    result = realm.evaluateScript(`JSON.parse(${JSON.stringify(source)});`);
+    result = realm.evaluateScriptSkipDebugger(`JSON.parse(${JSON.stringify(source)});`);
   } catch (error) {
     reporter.updateWorker(0, null);
     console.error(filename, error);

--- a/test/test262/slow
+++ b/test/test262/slow
@@ -6,6 +6,10 @@
 # Paths are relative to the `test262/test` directory.
 # Paths may contain globs.
 
+built-ins/encodeURI
+built-ins/decodeURI
+built-ins/encodeURIComponent
+built-ins/decodeURIComponent
 built-ins/RegExp/property-escapes/generated
 built-ins/RegExp/CharacterClassEscapes
 # temporal
@@ -20,12 +24,14 @@ built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-1.js
 built-ins/Array/prototype/lastIndexOf/15.4.4.15-9-1.js
 built-ins/Array/prototype/map/15.4.4.19-8-c-ii-1.js
 built-ins/Array/prototype/some/15.4.4.17-7-c-ii-2.js
-built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
-built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
-built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
-built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
 built-ins/Function/prototype/toString/built-in-function-object.js
+built-ins/Iterator/zip/basic-longest.js
+built-ins/Iterator/zip/basic-shortest.js
+built-ins/Iterator/zipKeyed/basic-longest.js
+built-ins/Iterator/zipKeyed/basic-shortest.js
+built-ins/parseFloat/S15.1.2.3_A6.js
 built-ins/parseInt/S15.1.2.2_A8.js
+built-ins/RegExp/character-class-escape-non-whitespace.js
 built-ins/Temporal/Duration/prototype/round/relativeto-largestunit-smallestunit-combinations.js
 built-ins/Temporal/Duration/prototype/round/roundingincrement-days-large.js
 built-ins/Temporal/Duration/prototype/round/singular-units.js
@@ -33,6 +39,7 @@ built-ins/Temporal/Duration/prototype/total/calendar-possibly-required.js
 built-ins/Temporal/Duration/prototype/total/relativeto-total-of-each-unit.js
 built-ins/Temporal/PlainDate/prototype/since/basic-conversions.js
 built-ins/Temporal/PlainDate/prototype/until/basic-conversions.js
+built-ins/Temporal/PlainDateTime/datetime-math.js
 built-ins/Temporal/PlainDateTime/prototype/since/argument-object.js
 built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-optional-properties.js
 built-ins/Temporal/PlainDateTime/prototype/since/argument-string.js

--- a/test/test262/test262-runner.mts
+++ b/test/test262/test262-runner.mts
@@ -1,9 +1,10 @@
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { join, resolve, relative } from 'node:path';
-import { createWriteStream } from 'node:fs';
-import { opendir, readFile, stat } from 'node:fs/promises';
-import { stripVTControlCharacters, styleText } from 'node:util';
+import { createWriteStream, mkdirSync, writeFileSync } from 'node:fs';
+import {
+  mkdir, opendir, readFile, stat,
+} from 'node:fs/promises';
+import { stripVTControlCharacters, styleText, type InspectColor } from 'node:util';
 import { fork } from 'node:child_process';
 import { cpus } from 'node:os';
 import { glob, isDynamicPattern } from 'tinyglobby';
@@ -14,6 +15,7 @@ import {
   readList,
   type WorkerToSupervisor_Failed,
   type Stack,
+  type WorkerToSupervisor_Log,
 } from '../base.mts';
 import { annotateFileWithURL, isCI } from '../tui.mts';
 import {
@@ -24,11 +26,12 @@ import {
 import { fatal_exit } from '../base.mts';
 import { args } from './test262.mts';
 
+const abort = new AbortController();
 const inputs = {
   Test262TestsPath: join(process.env.TEST262 || resolve(import.meta.dirname, 'test262'), 'test'),
-  AllTests: async () => {
+  AllTests: async (signal: AbortSignal) => {
     const files: string[] = [];
-    for await (const file of readdir(inputs.Test262TestsPath)) {
+    for await (const file of readdir(inputs.Test262TestsPath, signal)) {
       files.push(file);
     }
     inputs.AllTests = async () => files;
@@ -48,6 +51,15 @@ const outputs = {
 
 if (args.values['failed-only']) {
   args.positionals = (await readFile(outputs.LastRunFailedList, { encoding: 'utf-8' })).split('\n');
+}
+
+if (args.values.fyi) {
+  const target = resolve(process.cwd(), args.values.fyi);
+  await stat(target).then(((f) => {
+    if (!f.isDirectory()) {
+      fatal_exit(`The path provided by --fyi is not a directory: ${args.values.fyi}`);
+    }
+  }), () => mkdir(target));
 }
 
 const outputStreams = {
@@ -86,10 +98,10 @@ const [
   skipList,
   assertToBeFailedList,
 ] = await Promise.all([
-  readListPaths(inputs.SlowList, false),
-  readListPaths(inputs.SlowListCI, true),
-  readListPaths(inputs.SkipList, false),
-  readListPaths(inputs.AssertToBeFailedList, false),
+  readListPaths(inputs.SlowList, false, abort.signal),
+  readListPaths(inputs.SlowListCI, true, abort.signal),
+  readListPaths(inputs.SkipList, false, abort.signal),
+  readListPaths(inputs.AssertToBeFailedList, false, abort.signal),
 ]);
 
 if (outputStreams.AssertToBeFailedList) {
@@ -151,38 +163,42 @@ const visited = new Set<string>();
 reporter.start();
 reporter.addEventListener('exit', () => {
   workers.forEach((worker) => worker.kill());
+  abort.abort();
 });
 reporter.onExit.promise.then(() => {
-  if (args.values.verbose || args.values.vv) {
-    const skip: Record<SkipReason, Set<string>> = {
-      'feature-disabled': new Set<string>(),
-      'skip-list': new Set<string>(),
-      'slow-list': new Set<string>(),
-    };
-    const passed: Set<string> = new Set<string>();
-    const skipByFeature: Record<string, Set<string>> = {};
-    const failed: Set<string> = new Set<string>();
-    for (const test of reporter.tests.values()) {
-      if (test.status === 'skipped') {
-        if (test.skipFeature) {
-          (skipByFeature[test.skipFeature] ??= new Set()).add(test.file);
-        } else if (test.skipReason) {
-          skip[test.skipReason].add(test.file);
-        }
-      } else if (test.status === 'failed') {
-        failed.add(test.file);
-      } else if (args.values.vv && test.status === 'passed') {
-        passed.add(test.file);
+  if (!(args.values.verbose || args.values.vv || args.values.fyi)) return;
+  const skip: Record<SkipReason, Set<string>> = {
+    'feature-disabled': new Set<string>(),
+    'skip-list': new Set<string>(),
+    'slow-list': new Set<string>(),
+  };
+  const passed: Set<string> = new Set<string>();
+  const skipByFeature: Record<string, Set<string>> = {};
+  const failed: Set<string> = new Set<string>();
+  for (const test of reporter.tests.values()) {
+    // do not call annotateFileWithURL here, too much links will freeze the terminal
+    const t = `${test.file} ${test.currentTestFlag ? `[${test.currentTestFlag}]` : ''}`;
+    if (test.status === 'skipped') {
+      if (test.skipFeature) {
+        (skipByFeature[test.skipFeature] ??= new Set()).add(t);
+      } else if (test.skipReason) {
+        skip[test.skipReason].add(t);
       }
+    } else if (test.status === 'failed') {
+      failed.add(t);
+    } else if (args.values.vv && test.status === 'passed') {
+      passed.add(t);
     }
+  }
+  if (args.values.verbose || args.values.vv) {
     if (args.values.vv && passed.size > 0) {
-      console.log(styleText('green', 'The following tests passed:'));
+      reporter.stdout(styleText('green', 'The following tests passed:\n'));
       for (const test of passed) {
-        console.log(`- ./test/test262/test262/test/${test}`);
+        reporter.stdout(`- ./test/test262/test262/test/${test}\n`);
       }
     }
     let skipPrint = () => {
-      console.log(styleText('yellow', 'The following tests were skipped:'));
+      reporter.stdout(styleText('yellow', 'The following tests were skipped:\n'));
       skipPrint = () => { };
     };
     for (const [reason, tests] of Object.entries(skip)) {
@@ -190,34 +206,103 @@ reporter.onExit.promise.then(() => {
         continue;
       }
       skipPrint();
-      console.log(`- Reason: ${styleText('yellow', reason)} (${tests.size} tests)`);
+      reporter.stdout(`- Reason: ${styleText('yellow', reason)} (${tests.size} tests)\n`);
       for (const test of tests) {
-        console.log(`    - ./test/test262/test262/test/${test}`);
+        reporter.stdout(`    - ./test/test262/test262/test/${test}\n`);
       }
     }
     for (const [feature, tests] of Object.entries(skipByFeature)) {
       skipPrint();
-      console.log(`- Reason: ${styleText('yellow', `feature-disabled (${feature})`)} (${tests.size} tests)`);
+      reporter.stdout(`- Reason: ${styleText('yellow', `feature-disabled (${feature})`)} (${tests.size} tests)\n`);
       for (const test of tests) {
-        console.log(`    - ./test/test262/test262/test/${test}`);
+        reporter.stdout(`    - ./test/test262/test262/test/${test}\n`);
       }
     }
     if (failed.size > 0) {
-      console.log(styleText('red', '\nThe following tests failed:'));
+      reporter.stdout(styleText('red', '\nThe following tests failed:\n'));
       for (const test of failed) {
-        console.log(`- ./test/test262/test262/test/${test}`);
+        reporter.stdout(`- ./test/test262/test262/test/${test}\n`);
       }
     }
+  }
+  if (args.values.fyi) {
+    type test = {
+      total: number;
+      engines: Record<string, number>;
+      files: Record<string, {
+        total: number;
+        engines: Record<string, number>;
+      }>;
+    }
+    type features = Record<string, {
+        total: number;
+        engines: Record<string, number>;
+    }>
+    // type editions = features;
+
+    const all: test = {
+      total: 0,
+      engines: { engine262: 0 },
+      files: Object.create(null),
+    };
+    const files = new Map<string, test>([['index.json', all]]);
+    const features: features = Object.create(null);
+    // eslint-disable-next-line no-inner-declarations
+    function getPaths(test: string): [file: string, test: test][] {
+      const parts = test.split('/');
+      const paths: [string, test][] = [[parts[0], all]];
+      for (let index = 1; index < parts.length; index += 1) {
+        const reportFile = `${parts.slice(0, index).join('/')}.json`;
+        if (!files.has(reportFile)) {
+          files.set(reportFile, {
+            total: 0,
+            engines: { engine262: 0 },
+            files: Object.create(null),
+          });
+        }
+        paths.push([parts.slice(0, index + 1).join('/'), files.get(reportFile)!]);
+      }
+      return paths;
+    }
+    const testsByFileName = Map.groupBy(reporter.tests.values(), (test) => test.file);
+    for (const tests of testsByFileName.values()) {
+      let passed = 0;
+      if (tests.every((test) => test.status === 'passed')) passed = 1;
+      else if (args.values['fyi-slow-as-passed'] && tests.every((test) => test.status === 'passed' || (test.status === 'skipped' && test.skipReason === 'slow-list'))) passed = 1;
+
+      for (const feature of tests[0].attrs.features || []) {
+        features[feature] ??= { total: 0, engines: { engine262: 0 } };
+        features[feature].total += 1;
+        features[feature].engines.engine262 += passed;
+      }
+      for (const [file, t] of getPaths(tests[0].file)) {
+        t.files[file] ??= { total: 0, engines: { engine262: 0 } };
+        t.total += 1;
+        t.engines.engine262 += passed;
+        t.files[file].total += 1;
+        t.files[file].engines.engine262 += passed;
+      }
+    }
+
+    for (const [path, data] of files) {
+      const target = resolve(process.cwd(), args.values.fyi!, path);
+      mkdirSync(resolve(target, '..'), { recursive: true });
+      writeFileSync(target, JSON.stringify(data));
+    }
+
+    const featuresTarget = resolve(process.cwd(), args.values.fyi!, 'features.json');
+    writeFileSync(featuresTarget, JSON.stringify(features));
   }
 });
 
 const engineFeatures = [...args.values['engine-features'] || []];
 
 const promises = [];
-for await (const file of parsePositionals(args.positionals, true)) {
+for await (const file of parsePositionals(args.positionals, true, abort.signal)) {
   if (visited.has(file) || /_FIXTURE|README\.md|\.py|\.map|\.mts/.test(file)) {
     continue;
   }
+  if (abort.signal.aborted) break;
 
   visited.add(file);
   promises.push(readFile(file, 'utf8').then((contents) => {
@@ -237,15 +322,25 @@ for await (const file of parsePositionals(args.positionals, true)) {
 
     const test = new Test(relative(inputs.Test262TestsPath, file), file, engineFeatures, attrs, '', contents);
 
+    const useModuleLoader = test.attrs.features?.some((feature) => feature.includes('import') || feature.includes('export'));
     if (test.attrs.flags.module) {
-      discoverTest(test.withDifferentTestFlag('module'));
+      const t = test.withDifferentTestFlag('module');
+      discoverTest(t);
+      discoverTest(t.withAsyncModuleLoader());
     } else {
       if (!test.attrs.flags.onlyStrict && !args.values['strict-only'] && !args.values.fast) {
         discoverTest(test);
+        if (useModuleLoader) {
+          discoverTest(test.withAsyncModuleLoader());
+        }
       }
 
       if (!test.attrs.flags.noStrict && !test.attrs.flags.raw) {
-        discoverTest(test.withDifferentTestFlag('strict', `'use strict';${test.content}`));
+        const t = test.withDifferentTestFlag('strict', `'use strict';${test.content}`);
+        discoverTest(t);
+        if (useModuleLoader) {
+          discoverTest(t.withAsyncModuleLoader());
+        }
       }
     }
   }));
@@ -259,32 +354,33 @@ allTestsDiscovered = true;
 reporter.allTestsDiscovered();
 distributeTest();
 
-async function readListPaths(file: string, defaults: boolean) {
+async function readListPaths(file: string, defaults: boolean, signal: AbortSignal) {
   const list = readList(file);
   const files = new Set<string>();
-  for await (const file of parsePositionals(list, defaults)) {
+  for await (const file of parsePositionals(list, defaults, signal)) {
     files.add(relative(inputs.Test262TestsPath, file));
   }
   return files;
 }
 
-async function* readdir(dir: string): AsyncGenerator<string> {
+async function* readdir(dir: string, signal: AbortSignal): AsyncGenerator<string> {
   for await (const dirent of await opendir(dir)) {
+    if (signal.aborted) return;
     const p = join(dir, dirent.name);
     if (dirent.isDirectory()) {
-      yield* readdir(p);
+      yield* readdir(p, signal);
     } else {
       yield p;
     }
   }
 }
 
-async function* parsePositional(pattern: string): AsyncGenerator<string> {
+async function* parsePositional(pattern: string, signal: AbortSignal): AsyncGenerator<string> {
   if (!isDynamicPattern(pattern)) {
     const a_path = join(inputs.Test262TestsPath, pattern);
     const a = await stat(a_path).catch(() => undefined);
     if (a?.isDirectory()) {
-      return yield* readdir(a_path);
+      return yield* readdir(a_path, signal);
     } else if (a?.isFile()) {
       return yield a_path;
     }
@@ -292,12 +388,12 @@ async function* parsePositional(pattern: string): AsyncGenerator<string> {
     const b_path = join(process.cwd(), pattern);
     const b = await stat(b_path).catch(() => undefined);
     if (b?.isDirectory()) {
-      return yield* readdir(b_path);
+      return yield* readdir(b_path, signal);
     } else if (b?.isFile()) {
       return yield b_path;
     }
 
-    const files = await inputs.AllTests();
+    const files = await inputs.AllTests(signal);
     const matched = files.filter((f) => f.toLowerCase().includes(pattern.toLowerCase()));
     if (matched.length) {
       return yield* matched;
@@ -316,16 +412,16 @@ async function* parsePositional(pattern: string): AsyncGenerator<string> {
   return undefined;
 }
 
-async function* parsePositionals(pattern: string[], defaults: boolean): AsyncGenerator<string> {
+async function* parsePositionals(pattern: string[], defaults: boolean, signal: AbortSignal): AsyncGenerator<string> {
   if (!pattern.length) {
     if (defaults) {
-      yield* readdir(inputs.Test262TestsPath);
+      yield* readdir(inputs.Test262TestsPath, signal);
     }
     return;
   }
   for (const p of pattern) {
     if (p) {
-      yield* parsePositional(p);
+      yield* parsePositional(p, signal);
     }
   }
 }
@@ -334,6 +430,8 @@ function createWorker(workerId: number) {
   const c = fork(resolve(import.meta.dirname, './test262-worker.mts'));
   c.on('message', (message: WorkerToSupervisor) => {
     switch (message.status) {
+      case 'LOG':
+        return log(message, workerId);
       case 'RUNNING':
         return reporter.updateWorker(workerId, message.testId);
       case 'PASS':
@@ -348,7 +446,7 @@ function createWorker(workerId: number) {
             return fail({
               file: message.file,
               description: 'The test is declared to be failed, but passed.',
-              error: '',
+              message: '',
               flags: message.flags,
               status: 'FAIL',
               testId: message.testId,
@@ -375,13 +473,31 @@ function createWorker(workerId: number) {
         return fail(message, true);
       }
       default:
-        console.error(message);
+        reporter.stdout(`Unknown message from worker: ${JSON.stringify(message)}\n`);
         throw new RangeError('Unknown message from worker');
     }
   });
   c.on('exit', (code) => {
     if (code !== 0 && code !== null) {
-      fatal_exit(`Worker ${workerId} exited with code ${code}`);
+      const test = reporter.workers[workerId];
+      if (!test) {
+        fatal_exit(`Worker ${workerId} exited with code ${code}, `);
+      } else {
+        currentRunFailedTestFiles.add(test.file);
+        outputStreams.LastRunFailedList.write(`${test.file}\n`);
+        workers[workerId] = createWorker(workerId);
+        reporter.updateWorker(workerId, null);
+        fail({
+          file: test.file,
+          description: 'Worker crashed',
+          message: '',
+          flags: test.currentTestFlag,
+          status: 'FAIL',
+          testId: test.id,
+          stack: [],
+        }, false);
+        fatal_exit('');
+      }
     }
   });
   return c;
@@ -390,18 +506,22 @@ function createWorker(workerId: number) {
 
 function fail(message: WorkerToSupervisor_Failed, showSource: boolean) {
   const { description, testId, file } = message;
-  let error = message.error;
+  let error = message.message;
   error = error.replaceAll(`${process.cwd()}/`, '');
   process.exitCode = 1;
 
-  const desc = styleText('yellow', description.trim());
-  const descNeedOwnLine = desc.includes('\n') || desc.length > (process.stdout.columns - file.length - 8);
+  let flags = message.flags;
+  flags = flags.replace('module,', '');
+
+  const descText = (flags ? `[${flags}] ` : '') + description.trim();
+  const desc = styleText('yellow', descText);
+  const descNeedOwnLine = desc.includes('\n') || descText.length > (process.stdout.columns - file.length - 8);
   // FAILED filename.js
   const line1 = `${styleText(['bgRed', 'white', 'bold'], ' FAIL ')} ${annotateFileWithURL(file)}${descNeedOwnLine ? '' : ` ${desc}`}\n`;
   //   Test description in the header
   const line2 = descNeedOwnLine ? `${indent(desc, '   ')}\n` : '';
   //   Source code with error position annotated
-  const line3 = showSource ? annotateSourceWithErrorPosition(error, reporter.tests.get(testId)!.content, message.stack) : '';
+  const line3 = showSource ? annotateSourceWithPosition(error, reporter.tests.get(testId)!.content, 'error', message.stack) : '';
   //   Error message
   const line4 = `${indent(error, '  ')}\n`;
   const line5 = styleText('red', `${'⎯'.repeat(process.stdout.columns)}\n`);
@@ -411,12 +531,30 @@ function fail(message: WorkerToSupervisor_Failed, showSource: boolean) {
   reporter.testFailed(testId);
 }
 
+function log(message: WorkerToSupervisor_Log, workerId: unknown) {
+  const { file, testId } = message;
+  let log = message.message;
+  log = log.replaceAll(`${process.cwd()}/`, '');
+
+  // LOG filename.js
+  const line1 = `${styleText(['bgYellowBright', 'white', 'bold'], ' LOG ')} ${file ? annotateFileWithURL(file) : `Worker ${workerId}`}\n`;
+  //   Source code with log position annotated
+  const line2 = testId ? annotateSourceWithPosition(log, reporter.tests.get(testId)!.content, 'warn', message.stack) : '';
+  //   Log message
+  const line3 = `${indent(log, '  ')}\n`;
+  const line4 = styleText('yellowBright', `${'⎯'.repeat(process.stdout.columns)}\n`);
+  const output = line1 + line2 + line3 + line4;
+  reporter.stdout(output);
+  outputStreams.CurrentRunFailureLog.write(stripVTControlCharacters(output));
+}
+
 function indent(string: string, space: string) {
   return string.split('\n').map((line) => space + line).join('\n');
 }
 
-function annotateSourceWithErrorPosition(error: string, sourceCode: string, [stack]: Stack[]) {
+function annotateSourceWithPosition(error: string, sourceCode: string, type: 'error' | 'warn', [stack]: Stack[]) {
   sourceCode = stack?.source || sourceCode;
+  const color: InspectColor = type === 'error' ? 'red' : 'yellow';
   if (!stack) {
     return '';
   }
@@ -425,14 +563,14 @@ function annotateSourceWithErrorPosition(error: string, sourceCode: string, [sta
   }
   const highLightedLines = (supportColor ? highlight(sourceCode, { language: 'js' }) : sourceCode).split('\n');
   const linesPad = (highLightedLines.length + 1).toString().length;
-  const decoratedLines = highLightedLines.map((line, index) => `  ${styleText('red', (index + 1).toString().padStart(linesPad))} | ${line}`);
+  const decoratedLines = highLightedLines.map((line, index) => `  ${styleText(color, (index + 1).toString().padStart(linesPad))} | ${line}`);
   const LINES_BEFORE = 3;
   const LINES_AFTER = 2;
   const slicedLines = decoratedLines.slice(
     Math.max(0, Number(stack.line) - LINES_BEFORE),
     Math.min(decoratedLines.length, Number(stack.line)),
   );
-  slicedLines.push(''.padStart(linesPad + 5) + styleText('red', `${'-'.repeat(Math.max(Number(stack.column) - 1, 0))}^ ${error.split('\n')[0].trim()}`));
+  slicedLines.push(''.padStart(linesPad + 5) + styleText(color, `${'-'.repeat(Math.max(Number(stack.column) - 1, 0))}^ ${error.split('\n')[0].trim()}`));
   slicedLines.push(
     decoratedLines.slice(
       Number(stack.line),

--- a/test/test262/test262-worker.mts
+++ b/test/test262/test262-worker.mts
@@ -9,18 +9,28 @@ import {
 } from '../base.mts';
 import { createRealm, createAgent } from '../base.mts';
 import {
-  AbruptCompletion, ObjectValue, evalQ,
+  AbruptCompletion, ObjectValue,
   setSurroundingAgent,
   inspect,
   Value,
   IsCallable,
   IsDataDescriptor,
   JSStringValue,
-  skipDebugger,
   boostTest262Harness,
   ThrowCompletion,
   getHostDefinedErrorDetails,
   CallSite,
+  CreateBuiltinFunction,
+  PerformPromiseThen,
+  runJobQueue,
+  type PlainCompletion,
+  NormalCompletion,
+  Descriptor,
+  Throw,
+  captureStack,
+  CallFrame,
+  getCurrentStack,
+  ValueOfNormalCompletion,
 } from '#self';
 
 const TEST262 = process.env.TEST262 || path.resolve(import.meta.dirname, 'test262');
@@ -36,10 +46,10 @@ readList(path.resolve(import.meta.dirname, 'features')).forEach((f) => {
 
 const includeCache: Record<string, undefined | { source: string, specifier: string }> = {};
 
-process.on('message', (test: SupervisorToWorker) => {
+process.on('message', async (test: SupervisorToWorker) => {
   try {
     process.send!({ status: 'RUNNING', testId: test.id } satisfies WorkerToSupervisor, handleSendError);
-    const result = run(test);
+    const result = await run(test);
     if (result.status === 'PASS') {
       process.send!({
         status: 'PASS', file: test.file, flags: test.currentTestFlag, testId: test.id,
@@ -52,7 +62,13 @@ process.on('message', (test: SupervisorToWorker) => {
   }
 });
 
-function run(test: Test): WorkerToSupervisor {
+function log(test: Test | undefined, stack: Stack[], ...args: unknown[]) {
+  process.send!({
+    status: 'LOG', file: test?.file, testId: test?.id, message: args.join(' '), stack,
+  } satisfies WorkerToSupervisor, handleSendError);
+}
+
+async function run(test: Test): Promise<WorkerToSupervisor> {
   const features = [...test.engineFeatures];
   if (test.attrs.features) {
     test.attrs.features.forEach((f) => {
@@ -61,7 +77,7 @@ function run(test: Test): WorkerToSupervisor {
       }
     });
   }
-  const agent = createAgent({ features });
+  const agent = createAgent({ features, asyncModuleLoader: test.asyncModuleLoader });
   const parsedScripts = new Map<string, string>();
   setSurroundingAgent(agent);
   agent.hostDefinedOptions.errorStackAttachNativeStack = true;
@@ -69,16 +85,14 @@ function run(test: Test): WorkerToSupervisor {
     parsedScripts.set(id, script.ECMAScriptCode.sourceText);
   };
 
-
-  function fail(test: Test, error: Value): WorkerToSupervisor {
-    const { callStack } = getHostDefinedErrorDetails(error);
+  function toDisplayStack(stack: readonly (CallSite | CallFrame)[] | undefined) {
     const reportStack: Stack[] = [];
-    for (const stack of callStack || []) {
-      if (!(stack instanceof CallSite)) {
+    for (const site of stack || []) {
+      if (!(site instanceof CallSite)) {
         continue;
       }
-      const scriptId = stack.getScriptId();
-      if (!scriptId || stack.columnNumber === null || stack.lineNumber === null) {
+      const scriptId = site.getScriptId();
+      if (!scriptId || site.columnNumber === null || site.lineNumber === null) {
         continue;
       }
       const source = parsedScripts.get(scriptId);
@@ -87,11 +101,22 @@ function run(test: Test): WorkerToSupervisor {
         continue;
       }
       reportStack.push({
-        column: stack.columnNumber,
-        line: stack.lineNumber,
+        column: site.columnNumber,
+        line: site.lineNumber,
         source: source === test.content ? undefined : source,
-        specifier: stack.getSpecifier(),
+        specifier: site.getSpecifier(),
       });
+    }
+    return reportStack;
+  }
+
+  function fail(test: Test, error: Value): WorkerToSupervisor {
+    const { message, callStack } = getHostDefinedErrorDetails(error);
+    const reportStack = toDisplayStack(callStack);
+    let msg = '';
+    for (const part of message || [realm.scope(() => inspect(error))]) {
+      if (typeof part === 'string') msg += part;
+      else if (part instanceof Value) msg += realm.scope(() => inspect(part));
     }
     return {
       status: 'FAIL',
@@ -99,16 +124,61 @@ function run(test: Test): WorkerToSupervisor {
       flags: test.currentTestFlag,
       testId: test.id,
       description: test.attrs.description,
-      error: inspect(error),
+      message: msg,
       stack: reportStack,
     };
   }
 
-  const { realm, resolverCache, setPrintHandle } = createRealm({ specifier: test.specifier });
-  const r = realm.scope((): WorkerToSupervisor => {
-    test.attrs.includes.unshift('assert.js', 'sta.js');
+  const { realm, resolverCache } = createRealm({
+    specifier: test.specifier,
+    log: (...args) => log(test, toDisplayStack(captureStack().stack), ...args),
+  });
+  console.log = (...args: unknown[]) => log(test, toDisplayStack(captureStack().stack), ...args);
+  async function untilFinished() {
+    while (resolverCache.hasUnfinishedRequests()) {
+      // eslint-disable-next-line no-await-in-loop
+      await resolverCache.untilAllRequestFinished();
+      runJobQueue();
+    }
+  }
+
+  const finishTest = Promise.withResolvers<PlainCompletion<unknown>>();
+  const result = Promise.withResolvers<WorkerToSupervisor>();
+  realm.scope(() => {
+    test.attrs.includes.unshift('assert.js');
+    const asyncTestPromise = Promise.withResolvers<WorkerToSupervisor>();
+    let asyncTestCompleted = false;
+
+    // doneprintHandle.js
     if (test.attrs.flags.async) {
-      test.attrs.includes.unshift('doneprintHandle.js');
+      const $DONE = CreateBuiltinFunction.from(function* $DONE(error = Value.undefined) {
+        if (asyncTestCompleted) {
+          log(test, toDisplayStack(getCurrentStack()), '$DONE called after test completion');
+          return;
+        }
+        asyncTestCompleted = true;
+        if (error !== Value.undefined) {
+          asyncTestPromise.resolve(fail(test, error));
+        } else {
+          asyncTestPromise.resolve({
+            status: 'PASS', flags: test.currentTestFlag, testId: test.id, file: test.file,
+          });
+        }
+      });
+      realm.GlobalObject.properties.set(Value('$DONE'), Descriptor({ Value: $DONE }));
+    }
+
+    // sta.js
+    {
+      const completion = realm.evaluateScriptSkipDebugger([
+        'var Test262Error = class Test262Error extends Error {};',
+        'Test262Error.thrower = (...args) => { throw new Test262Error(...args); };'].join('\n'));
+      if (completion instanceof AbruptCompletion) {
+        result.resolve(fail(test, completion.Value));
+        return;
+      }
+      const $DONOTEVALUATE = CreateBuiltinFunction.from(() => Throw.EvalError('Test262: This statement should not be evaluated.'));
+      realm.GlobalObject.properties.set(Value('$DONOTEVALUATE'), Descriptor({ Value: $DONOTEVALUATE }));
     }
 
     for (const include of test.attrs.includes) {
@@ -120,100 +190,65 @@ function run(test: Test): WorkerToSupervisor {
         };
       }
       const entry = includeCache[include];
-      const completion = realm.evaluateScript(entry.source, { specifier: entry.specifier });
+      const completion = realm.evaluateScriptSkipDebugger(entry.source, { specifier: entry.specifier });
       if (completion instanceof AbruptCompletion) {
-        return fail(test, completion.Value);
+        result.resolve(fail(test, completion.Value));
+        return;
       }
     }
     boostTest262Harness(realm);
 
-    {
-      const DONE = `
-function $DONE(error) {
-  if (error) {
-    if (typeof error === 'object' && error !== null && 'stack' in error) {
-      print('Test262:AsyncTestFailure:' + error.stack, error);
-    } else {
-      print('Test262:AsyncTestFailure:Test262Error: ' + error, error);
-    }
-  } else {
-    print('Test262:AsyncTestComplete');
-  }
-}`;
-      const completion = realm.evaluateScript(`\
-var Test262Error = class Test262Error extends Error {};
-Test262Error.thrower = (...args) => {
-  throw new Test262Error(...args);
-};
-${test.attrs.flags.async ? DONE : ''}`);
-      if (completion instanceof AbruptCompletion) {
-        return fail(test, completion.Value);
-      }
-    }
-
-    let asyncResult: WorkerToSupervisor | undefined;
-    if (test.attrs.flags.async) {
-      setPrintHandle((m, value) => {
-        if (m === 'Test262:AsyncTestComplete') {
-          asyncResult = {
-            status: 'PASS', flags: test.currentTestFlag, testId: test.id, file: test.file,
-          };
-        } else {
-          asyncResult = fail(test, value);
-        }
-        setPrintHandle(undefined);
-      });
-    }
 
     const specifier = path.resolve(TEST262_TESTS, test.file);
 
-    const completion = evalQ((Q) => {
-      if (test.attrs.flags.module) {
-        const module = Q(realm.compileModule(test.content, { specifier }));
-        resolverCache.set(specifier, 'js', module);
-        const loadModuleCompletion = module.LoadRequestedModules();
-        if (loadModuleCompletion.PromiseState === 'rejected') {
-          Q(ThrowCompletion(loadModuleCompletion.PromiseResult!));
-        } else if (loadModuleCompletion.PromiseState === 'pending') {
-          throw new Error('Internal error: .LoadRequestedModules() returned a pending promise');
+    finishTest.promise.then<WorkerToSupervisor>((completion) => {
+      if (completion instanceof ThrowCompletion) {
+        if (test.attrs.negative && isError(test.attrs.negative.type, completion.Value)) {
+          return {
+            status: 'PASS', flags: test.currentTestFlag, testId: test.id, file: test.file,
+          };
+        } else {
+          return fail(test, completion.Value);
         }
-        Q(module.Link());
-        const evaluateCompletion = Q(skipDebugger(module.Evaluate()));
-        if (evaluateCompletion.PromiseState === 'rejected') {
-          Q(ThrowCompletion(evaluateCompletion.PromiseResult!));
-        }
-      } else {
-        Q(realm.evaluateScript(test.content, { specifier }));
       }
-    });
 
-    if (completion.Type === 'throw') {
-      if (test.attrs.negative && isError(test.attrs.negative.type, completion.Value)) {
+      if (test.attrs.flags.async) return asyncTestPromise.promise;
+
+      if (test.attrs.negative) {
+        return fails(test, `Expected ${test.attrs.negative.type} during ${test.attrs.negative.phase}`, []);
+      } else {
         return {
           status: 'PASS', flags: test.currentTestFlag, testId: test.id, file: test.file,
         };
-      } else {
-        return fail(test, completion.Value);
       }
-    }
+    }).then(result.resolve, result.reject);
 
-    if (test.attrs.flags.async) {
-      if (!asyncResult) {
-        throw new Error('missing async result');
-      }
-      return asyncResult;
-    }
-
-    if (test.attrs.negative) {
-      return fails(test, `Expected ${test.attrs.negative.type} during ${test.attrs.negative.phase}`, []);
+    if (test.attrs.flags.module) {
+      realm.evaluateModule(test.content, specifier, (completion) => {
+        if (completion instanceof ThrowCompletion) {
+          finishTest.resolve(completion);
+          return;
+        }
+        const promise = ValueOfNormalCompletion(completion);
+        PerformPromiseThen(promise, CreateBuiltinFunction.from(function* waitIO() {
+          untilFinished().then(() => finishTest.resolve(NormalCompletion(undefined)));
+          return Value.undefined;
+        }), CreateBuiltinFunction.from((err = Value.undefined) => {
+          finishTest.resolve(ThrowCompletion(err));
+        }));
+        runJobQueue();
+      });
     } else {
-      return {
-        status: 'PASS', flags: test.currentTestFlag, testId: test.id, file: test.file,
-      };
+      const completion = realm.evaluateScriptSkipDebugger(test.content, { specifier });
+      if (completion instanceof AbruptCompletion) {
+        finishTest.resolve(completion);
+      }
     }
   });
+  await untilFinished();
+  finishTest.resolve(NormalCompletion(undefined));
 
-  return r;
+  return result.promise;
 }
 
 function handleSendError(e: any) {
@@ -254,7 +289,7 @@ function fails(test: Test, error: string, stack: Stack[]): WorkerToSupervisor {
     flags: test.currentTestFlag,
     testId: test.id,
     description: test.attrs.description,
-    error,
+    message: error,
     stack,
   };
 }

--- a/test/test262/test262.mts
+++ b/test/test262/test262.mts
@@ -25,6 +25,8 @@ export const args = util.parseArgs({
 
     'verbose': { type: 'boolean', short: 'v' },
     'vv': { type: 'boolean', short: 'V' },
+    'fyi': { type: 'string' },
+    'fyi-slow-as-passed': { type: 'boolean' },
   },
 });
 
@@ -72,6 +74,10 @@ async function main() {
           Print why tests are skipped or failed.
         ${styleText('green', '--vv / -V')}
           Print why tests are skipped or failed, and also print passed tests.
+        ${styleText('green', '--fyi')} ${styleText('gray', '[folder path]')}
+          Write test262-fyi format report files.
+        ${styleText('green', '--fyi-slow-as-passed')}
+          Treat slow tests as passed in the test262-fyi report.
 
       ${styleText('yellowBright', 'Files:')}
         ${link(styleText('yellow', 'features'), new URL('./features', import.meta.url))}

--- a/test/tui.mts
+++ b/test/tui.mts
@@ -153,18 +153,17 @@ function useExit(runner: TestReporter) {
     () => runner.exited,
   );
   const { exit } = useApp();
-  const [previousExitState, setExitState] = React.useState<boolean>(false);
-  if (exitRequested && !previousExitState) {
-    setExitState(true);
-    setTimeout(exit, 10);
+  const [exitingState, setExitingState] = React.useState<boolean>(false);
+  if (exitRequested && !exitingState) {
+    setExitingState(true);
+    queueMicrotask(exit);
   }
   useInput((input, key) => {
     if (input === 'q' || (key.ctrl && input === 'c')) {
-      setExitState(true);
       runner.exit();
     }
   });
-  return previousExitState;
+  return exitingState;
 }
 
 function useFlushStdout(runner: TerminalUIReporter) {
@@ -372,6 +371,10 @@ class TerminalUIReporter extends TestReporter {
   pending_stdout: string[] = [];
 
   stdout(...message: string[]) {
+    if (this.exited) {
+      process.stdout.write(message.join(''));
+      return;
+    }
     this.pending_stdout.push(...message);
     this.statsStale = true;
     this.dispatchEvent(new Event('flush'));


### PR DESCRIPTION
breaking changes:

```diff
- ManagedRealm.evaluateScript
+ ManagedRealm.evaluateScriptSkipDebugger
```

All API of the class ModuleCache have changed

`ManagedRealm.evaluate` removed
`ManagedRealm.evaluateModule` now has a new signature to support asynchronous host module loader

close #340