### PR TITLE
fix: module

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 !.eslintrc.js
 lib
 bin/engine262.mjs
+test/engine262/fixture
 test/test262/test262
 test/json/JSONTestSuite
 website

--- a/lib-src/inspector/context.mts
+++ b/lib-src/inspector/context.mts
@@ -66,24 +66,6 @@ export class InspectorContext {
     });
     const oldInspector = realm.HostDefined.attachingInspector;
     realm.HostDefined.attachingInspector = this.#io;
-    const oldPromiseRejectionTracker = realm.HostDefined.promiseRejectionTracker;
-    realm.HostDefined.promiseRejectionTracker = (promise, operation) => {
-      oldPromiseRejectionTracker?.(promise, operation);
-      if (operation === 'reject') {
-        this.#io.sendEvent['Runtime.exceptionThrown']({
-          timestamp: Date.now(),
-          exceptionDetails: this.createExceptionDetails(promise, true),
-        });
-      } else {
-        const id = this.#exceptionMap.get(promise);
-        if (id) {
-          this.#io.sendEvent['Runtime.exceptionRevoked']({
-            reason: 'Handler added to rejected promise',
-            exceptionId: id,
-          });
-        }
-      }
-    };
     this.#io.sendEvent['Runtime.executionContextCreated']({ context: descriptor });
   }
 
@@ -256,15 +238,12 @@ export class InspectorContext {
     return { result: properties, internalProperties, privateProperties };
   }
 
-  #exceptionMap = new WeakMap<Value, number>();
-
   createExceptionDetails(completion: ThrowCompletion | Value, isPromise: boolean): Protocol.Runtime.ExceptionDetails {
     const value = completion instanceof ThrowCompletion ? completion.Value : completion;
     const { callStack } = getHostDefinedErrorDetails(value);
     const frames = InspectorContext.callSiteToCallFrame(callStack);
     const exceptionId = this.#objectCounter;
     this.#objectCounter += 1;
-    this.#exceptionMap.set(value, exceptionId);
     return {
       text: isPromise ? 'Uncaught (in promise)' : 'Uncaught',
       stackTrace: callStack ? { callFrames: frames } : undefined,

--- a/lib-src/inspector/index.mts
+++ b/lib-src/inspector/index.mts
@@ -4,7 +4,7 @@ import * as impl from './methods.mts';
 import type { DebuggerContext, DebuggerPreference, DevtoolEvents } from './types.mts';
 import { getParsedEvent } from './internal-utils.mts';
 import {
-  Agent, ManagedRealm, Realm, type Arguments,
+  Agent, HostPromiseRejectionTracker, ManagedRealm, Realm, Value, type Arguments,
 } from '#self';
 
 const ignoreNamespaces = ['Network'];
@@ -22,6 +22,8 @@ export abstract class Inspector {
 
   #agents: AgentRecord[] = [];
 
+  #unhandledExceptionIds = new WeakMap<Value, number>();
+
   attachAgent(agent: Agent, priorRealms: ManagedRealm[]) {
     const oldOnDebugger = agent.hostDefinedOptions.onDebugger;
     agent.hostDefinedOptions.onDebugger = (reason) => {
@@ -35,6 +37,28 @@ export abstract class Inspector {
       }
       this.sendEvent['Debugger.paused'](pausedEvent);
     };
+
+    agent.hostDefinedOptions.hostHooks ??= {};
+    agent.hostDefinedOptions.hostHooks.HostPromiseRejectionTrackers ??= new Set();
+    const tracker: HostPromiseRejectionTracker = (promise, operation) => {
+      if (operation === 'reject') {
+        const detail = this.#context.createExceptionDetails(promise, true);
+        this.#unhandledExceptionIds.set(promise, detail.exceptionId);
+        this.sendEvent['Runtime.exceptionThrown']({
+          timestamp: Date.now(),
+          exceptionDetails: detail,
+        });
+      } else {
+        const id = this.#unhandledExceptionIds.get(promise);
+        if (id) {
+          this.sendEvent['Runtime.exceptionRevoked']({
+            reason: 'Handler added to rejected promise',
+            exceptionId: id,
+          });
+        }
+      }
+    };
+    agent.hostDefinedOptions.hostHooks.HostPromiseRejectionTrackers.add(tracker);
 
     const oldOnRealmCreated = agent.hostDefinedOptions.onRealmCreated;
     agent.hostDefinedOptions.onRealmCreated = (realm) => {
@@ -57,6 +81,7 @@ export abstract class Inspector {
         agent.hostDefinedOptions.onDebugger = oldOnDebugger;
         agent.hostDefinedOptions.onRealmCreated = oldOnRealmCreated;
         agent.hostDefinedOptions.onScriptParsed = oldOnScriptParsed;
+        agent.hostDefinedOptions.hostHooks!.HostPromiseRejectionTrackers!.delete(tracker);
         this.#agents = this.#agents.filter((x) => x.agent !== agent);
       },
     });

--- a/lib-src/inspector/methods.mts
+++ b/lib-src/inspector/methods.mts
@@ -348,7 +348,8 @@ function evaluate(options: {
         runJobQueue();
       });
     } else if (toBeEvaluated instanceof ScriptRecord) {
-      let completion = realm.realm.evaluateScript(toBeEvaluated, {}, (c) => {
+      let completion;
+      realm.realm.evaluateScript(toBeEvaluated, {}, (c) => {
         completion = c;
         resolve(context.createEvaluationResult(completion));
       });

--- a/lib-src/node/bin.mts
+++ b/lib-src/node/bin.mts
@@ -3,20 +3,21 @@
 import { start } from 'node:repl';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { format as _format, inspect as _inspect, parseArgs } from 'node:util';
+import {
+  format as _format, inspect as _inspect, parseArgs, styleText,
+} from 'node:util';
 // let's try if the following message on old node causes test failure on test262.fyi
 // "ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time"
 // import packageJson from '../../package.json' with { type: 'json' };
 import { createRequire } from 'node:module';
 import { createConsole } from '../inspector/utils.mts';
 import type { NodeWebsocketInspector } from './inspector.mts';
-import { loadImportedModule } from './module.mts';
+import { fileSystemModuleLoader } from './module.mts';
 import {
-  setSurroundingAgent, FEATURES, inspect, Value, Completion, AbruptCompletion,
+  setSurroundingAgent, FEATURES, inspect, Value,
   type Arguments,
   Agent,
   ManagedRealm,
-  type ValueCompletion,
   createTest262Intrinsics,
   surroundingAgent,
   ThrowCompletion,
@@ -26,14 +27,24 @@ import {
   importBundledTest262Harness,
   boostTest262Harness,
   ModuleCache,
-  NormalCompletion,
   PerformPromiseThen,
   CreateBuiltinFunction,
   runJobQueue,
+  composeModuleLoaders,
+  Descriptor,
+  isFunctionObject,
+  Throw,
+  ToNumber,
+  R,
+  Call,
+  GetActiveScriptOrModule,
+  type PlainCompletion,
+  NormalCompletion,
+  type PromiseObject,
 } from '#self';
 
 const packageJson = createRequire(import.meta.url)('../../package.json');
-const help = `
+const help = () => `
 engine262 v${packageJson.version}
 
 Usage:
@@ -43,17 +54,43 @@ Usage:
     engine262 [input file]
 
 Options:
+  ${((str) => {
+    const options = [
+      ['-h, --help', 'Show help'],
+      ['-m, --module', 'Evaluate contents of input-file as a module.'],
+      ['-e, --eval', 'Evaluate the given string. (can be used with --module)'],
+      ['--features=...', 'A comma separated list of features.'],
+      ['-a, --features=all', 'Enable all features.'],
+      ['--no-test262', 'Do not expose $ and $262 for test262.'],
+      ['--[no-]inspect', 'Do [not] attach an inspector.'],
+      ['--no-preview', 'Do not enable preview in the inspector.'],
+      ['-t, --test262-harness', 'Import test262 harness files.'],
+    ];
+    const maxOptionLength = options.reduce((max, [flag]) => Math.max(max, flag.length), 0);
+    options.forEach(([flag, description]) => {
+      str += `    ${styleText('green', flag.padEnd(maxOptionLength))}  ${description}\n`;
+    });
+    return str;
+  })('\n')}
+Features:
+  ${((str) => {
+    const supportColor = styleText('red', 'test') !== 'test';
+    function link(text: string, url: string) {
+      if (!supportColor || !url) return text;
+      const OSC = '\u001B]';
+      const BEL = '\u0007';
+      return `${OSC}8;;${url}${BEL}${text}${OSC}8;;${BEL}`;
+    }
 
-    -h, --help         Show help (this screen)
-    -m, --module       Evaluate contents of input-file as a module.
-    -e, --eval         Evaluate the given string.
-    --features=...     A comma separated list of features.
-    --features=all     Enable all features.
-    --list-features    List available features.
-    --no-test262       Do not expose $ and $262 for test262.
-    --[no-]inspect     Do [not] attach an inspector.
-    --no-preview       Do not enable preview in the inspector.
-    --test262-harness  Import test262 harness files.
+    let maxFlagLength = 0;
+    for (const f of FEATURES) {
+      if (f.flag.length > maxFlagLength) maxFlagLength = f.flag.length;
+    }
+    FEATURES.forEach((f) => {
+      str += `    ${styleText('redBright', f.flag.padEnd(maxFlagLength))}  ${link(f.name, f.url)}\n`;
+    });
+    return str;
+  })('\n')}
 `;
 
 const argv = parseArgs({
@@ -66,42 +103,22 @@ const argv = parseArgs({
     'eval': { type: 'string', short: 'e' },
     'module': { type: 'boolean', short: 'm' },
     'features': { type: 'string' },
-    'list-features': { type: 'boolean' },
+    'features-all': { type: 'boolean', short: 'a' },
     'inspect': { type: 'boolean' },
     'test262': { type: 'boolean', default: true },
-    'test262-harness': { type: 'boolean' },
+    'test262-harness': { type: 'boolean', short: 't' },
     // hidden options
     'preview-debug': { type: 'boolean' },
   },
 });
 
 if (argv.values.help) {
-  process.stdout.write(help);
-  process.exit(0);
-} else if (argv.values['list-features']) {
-  let nameLength = 0;
-  let flagLength = 0;
-  FEATURES.forEach((f) => {
-    if (f.name.length > nameLength) {
-      nameLength = f.name.length;
-    }
-    if (f.flag.length > flagLength) {
-      flagLength = f.flag.length;
-    }
-  });
-  const log = (f: string, n: string, u: string) => {
-    process.stdout.write(`${f.padEnd(flagLength, ' ')} ${n.padEnd(nameLength, ' ')} ${u}\n`);
-  };
-  log('flag', 'name', 'url');
-  log('----', '----', '---');
-  FEATURES.forEach((f) => {
-    log(f.flag, f.name, f.url);
-  });
+  process.stdout.write(help());
   process.exit(0);
 }
 
 let features: string[];
-if (argv.values.features === 'all') {
+if (argv.values.features === 'all' || argv.values['features-all']) {
   features = FEATURES.map((f) => f.flag);
 } else if (argv.values.features) {
   features = argv.values.features.split(',');
@@ -109,14 +126,69 @@ if (argv.values.features === 'all') {
   features = [];
 }
 
+// exit code 1 if at least 1 unhandled rejection in the end.
+let unhandledExceptionCount = 0;
+process.on('exit', () => {
+  if (unhandledExceptionCount > 0) process.exitCode = 1;
+});
+const unhandledRejectionPendingLog = new Set<PromiseObject>();
+
 const agent = new Agent({
   features,
   supportedImportAttributes: ['type'],
-  loadImportedModule,
+  hostHooks: {
+    HostLoadImportedModule: composeModuleLoaders([fileSystemModuleLoader]),
+    HostPromiseRejectionTrackers: new Set([(promise, operation) => {
+      if (operation === 'reject') {
+        unhandledExceptionCount += 1;
+        unhandledRejectionPendingLog.add(promise);
+        const realm = surroundingAgent.currentRealmRecord as ManagedRealm;
+        setTimeout(() => {
+          if (!unhandledRejectionPendingLog.has(promise)) return;
+          unhandledRejectionPendingLog.delete(promise);
+          realm.scope(() => {
+            const err = inspect(promise.PromiseResult!);
+            process.stderr.write(`Unhandled promise rejection: ${err}\n`);
+          });
+        }, 10);
+      } else if (operation === 'handle') {
+        unhandledExceptionCount -= 1;
+        unhandledRejectionPendingLog.delete(promise);
+      }
+    }]),
+  },
+  uncaughtExceptionTrackers: new Set([(error) => {
+    unhandledExceptionCount += 1;
+    const err = inspect(error);
+    process.stderr.write(`Uncaught exception: ${err}\n`);
+  }]),
 });
 setSurroundingAgent(agent);
 
 const realm = new ManagedRealm({ resolverCache: new ModuleCache(), name: 'repl', specifier: process.cwd() });
+realm.scope(() => {
+  realm.GlobalObject.properties.set('setTimeout', Descriptor({
+    Value: CreateBuiltinFunction.from(function* timeout(f = Value.undefined, time = Value.undefined) {
+      if (!isFunctionObject(f)) return Throw.TypeError('setTimeout($1, ...) should be a function', f);
+      const delay = yield* ToNumber(time);
+      if (delay instanceof ThrowCompletion) return delay;
+      const delayTime = R(ValueOfNormalCompletion(delay));
+
+      const job = {
+        queueName: 'setTimeout resolve',
+        job: () => Call(f, Value.undefined, []),
+        callerRealm: surroundingAgent.runningExecutionContext.Realm,
+        callerScriptOrModule: GetActiveScriptOrModule(),
+      };
+      setTimeout(() => {
+        surroundingAgent.jobQueue.push(job);
+        runJobQueue();
+      }, delayTime);
+      return Value.undefined;
+    }),
+  }));
+});
+
 // Define console.log
 {
   const format = (function* format(args: Arguments): PlainEvaluator<string> {
@@ -179,37 +251,38 @@ async function setupInspector(mode: 'file' | 'eval' | 'pipe' | 'repl') {
   return inspector;
 }
 
+
 function oneShotEval(inspector: NodeWebsocketInspector | undefined, source: string, filename: string) {
   realm.scope(() => {
-    const onErrorCallback = CreateBuiltinFunction.from((result = Value.undefined) => {
-      quit(ThrowCompletion(result));
-    });
-    // TODO: change exit time to idle.
     if (argv.values.module || filename.endsWith('.mjs')) {
       realm.evaluateModule(source, filename, (promise) => {
         if (promise instanceof ThrowCompletion) {
-          quit(promise);
+          handleException(promise);
           return;
         }
-        PerformPromiseThen(ValueOfNormalCompletion(promise), Value.null, onErrorCallback);
+        PerformPromiseThen(ValueOfNormalCompletion(promise), Value.null, CreateBuiltinFunction.from((error = Value.undefined) => {
+          handleException(ThrowCompletion(error));
+        }));
         runJobQueue();
       });
     } else {
-      let completion = realm.evaluateScript(source, { specifier: filename }, (c) => {
+      let completion;
+      realm.evaluateScript(source, { specifier: filename }, (c) => {
         completion = c;
-        if (completion instanceof ThrowCompletion) quit(completion);
+        handleException(completion);
       });
       if (!completion) surroundingAgent.resumeEvaluate();
       runJobQueue();
     }
   });
+
   inspector?.stop();
 
-  function quit(completion: ThrowCompletion<Value> | NormalCompletion<void>) {
-    if (completion instanceof AbruptCompletion) {
+  function handleException(completion: PlainCompletion<void | Value>) {
+    if (completion instanceof ThrowCompletion) {
       const inspected = inspect(completion);
       process.stderr.write(`${inspected}\n`);
-      process.exit(1);
+      unhandledExceptionCount += 1;
     }
   }
 }
@@ -218,6 +291,9 @@ if (argv.positionals[0]) {
   const inspector = await setupInspector('file');
   const source = readFileSync(argv.positionals[0], 'utf8');
   oneShotEval(inspector, source, resolve(argv.positionals[0]));
+} else if (argv.values.eval) {
+  const inspector = await setupInspector('eval');
+  oneShotEval(inspector, argv.values.eval, '<eval>');
 } else if (!process.stdin.isTTY) {
   const inspector = await setupInspector('pipe');
   process.stdin.setEncoding('utf8');
@@ -226,16 +302,11 @@ if (argv.positionals[0]) {
     source += data;
   });
   process.stdin.once('end', () => {
-    oneShotEval(inspector, source, process.cwd());
+    oneShotEval(inspector, source, '<pipe>');
   });
-} else if (argv.values.eval) {
-  const inspector = await setupInspector('eval');
-  oneShotEval(inspector, argv.values.eval, process.cwd());
 } else {
   const inspector = await setupInspector('repl');
-  process.stdout.write(`Welcome to ${packageJson.name} v${String(packageJson.version).replace('0.0.1-', '')} Please report bugs to ${packageJson.bugs.url}
-Type ".help" for more information.
-`);
+  process.stdout.write(`Welcome to ${packageJson.name} v${String(packageJson.version).replace('0.0.1-', '')} Please report bugs to ${packageJson.bugs.url}\nType ".help" for more information.\n`);
   const server = start({
     prompt: '> ',
     eval: (cmd, _context, _filename, callback) => {
@@ -259,9 +330,9 @@ Type ".help" for more information.
     },
     preview: false,
     writer: (o) => realm.scope(() => {
-      if (o instanceof Value || o instanceof Completion) {
-        return inspect(o as Value | ValueCompletion);
-      }
+      if (o instanceof ThrowCompletion) o = o.Value;
+      if (o instanceof NormalCompletion && o.Value instanceof Value) o = o.Value;
+      if (o instanceof Value) return o === Value.undefined ? '' : inspect(o);
       return _inspect(o);
     }),
   });

--- a/lib-src/node/example.mts
+++ b/lib-src/node/example.mts
@@ -1,11 +1,40 @@
 /* eslint-disable no-console */
+import { NodeWebsocketInspector } from './inspector.mts';
+import { fileSystemModuleLoader } from './module.mts';
 import {
-  Agent, inspect, ManagedRealm, ModuleCache, NormalCompletion, setSurroundingAgent, ThrowCompletion, type Arguments, type PlainEvaluator,
+  Agent, composeModuleLoaders, CreateBuiltinFunction, createBuiltinModuleLoader, EnsureCompletion, inspect, ManagedRealm, ModuleCache, ModuleEnvironmentRecord, PerformPromiseThen, setSurroundingAgent, surroundingAgent, SyntheticModuleRecord, ThrowCompletion, ToString, unwrapCompletion, Value, ValueOfNormalCompletion, type Arguments, type PlainEvaluator,
+  type ValueCompletion,
 } from '#self';
 import { createConsole } from '#self/inspector';
 
 // Agent is the running environment.
 const agent = new Agent({
+  hostHooks: {
+    HostLoadImportedModule: composeModuleLoaders([
+      fileSystemModuleLoader,
+      createBuiltinModuleLoader({
+        builtinModules: new Map([[{ Specifier: 'builtin', Attributes: [] }, (realm) => {
+          const env = new ModuleEnvironmentRecord(Value.null);
+          const module = new SyntheticModuleRecord({
+            Environment: env,
+            ExportNames: [Value('foo')],
+            EvaluationSteps() {
+              // Create built-in function
+              const foo = CreateBuiltinFunction.from(function* foo(value = Value.undefined) {
+                console.log('Native function foo called with argument:', inspect(yield* ToString(value)));
+              }, 'foo');
+              unwrapCompletion(module.SetSyntheticExport(Value('foo'), foo));
+              console.log('Builtin module evaluated');
+            },
+            HostDefined: {},
+            Namespace: undefined,
+            Realm: realm,
+          });
+          return module;
+        }]]),
+      }),
+    ]),
+  },
 });
 // Only one agent can be active at a time.
 setSurroundingAgent(agent);
@@ -39,20 +68,76 @@ const realm = new ManagedRealm({ resolverCache: new ModuleCache(), name: 'My Rea
   });
 }
 
-// Do not forget to use realm.scope when running code.
-realm.scope(() => {
-  // Run ECMAScript code in the Realm.
-  realm.evaluateScriptSkipDebugger(`
+// Create a new inspector (devtools console)
+const inspector = await NodeWebsocketInspector.new();
+
+function printResult(value: ValueCompletion) {
+  realm.scope(() => {
+    if (value instanceof ThrowCompletion) {
+      console.error('Error: ', inspect(value.Value));
+    } else {
+      console.log('Result:', inspect(ValueOfNormalCompletion(value)));
+    }
+  });
+}
+
+// Run a script and skip debugger infra (get the result synchronously).
+{
+  console.log('--------- evaluateScriptSkipDebugger ---------');
+  const result = EnsureCompletion(realm.evaluateScriptSkipDebugger(`
     console.log('Hello from engine262!');
     console.log('2 + 2 =', 2 + 2);
-  `, { specifier: 'example.mts' });
+  `, { specifier: 'example.mts' }));
+  printResult(result);
+}
 
-  const result = realm.evaluateScriptSkipDebugger(`
-    throw new Error('This is an example error');
-  `, { specifier: 'example.mts' });
-  if (result instanceof NormalCompletion) {
-    console.log('No Error');
-  } else if (result instanceof ThrowCompletion) {
-    console.error('Caught error from evaluated script:', inspect(result.Value));
+inspector.attachAgent(surroundingAgent, [realm]);
+// Run a script with debugger support
+{
+  let completion;
+  // the evaluation may be sync or async.
+  console.log('--------- evaluateScript ---------');
+  realm.evaluateScript(`
+    function f() { debugger; return 1; }
+    f();
+  `, { specifier: 'vm://1' }, (result) => {
+    completion = result;
+    printResult(result);
+  });
+  // the evaluation will not start by default
+  if (!completion) {
+    // start the evaluation
+    surroundingAgent.resumeEvaluate();
+    // resume from the debugger;
+    surroundingAgent.resumeEvaluate();
   }
-});
+}
+
+// Run a module
+{
+  let completion;
+  console.log('--------- evaluateModule ---------');
+  realm.evaluateModule(`
+    import { foo } from "builtin";
+    foo({ toString() { return "X" } });
+  `, undefined, (result) => {
+    completion = result;
+    if (result instanceof ThrowCompletion) {
+      console.error('Module evaluate error: ', inspect(result.Value));
+    } else {
+      PerformPromiseThen(
+        ValueOfNormalCompletion(result),
+        CreateBuiltinFunction.from(() => {
+          console.log('Module evaluated successfully');
+        }),
+        CreateBuiltinFunction.from((error = Value.undefined) => {
+          console.error('Module evaluation error:', inspect(error));
+        }),
+      );
+    }
+  });
+  if (!completion) {
+    agent.resumeEvaluate();
+  }
+}
+inspector.stop();

--- a/lib-src/node/example.mts
+++ b/lib-src/node/example.mts
@@ -94,9 +94,9 @@ function printResult(value: ValueCompletion) {
 inspector.attachAgent(surroundingAgent, [realm]);
 // Run a script with debugger support
 {
-  let completion;
   // the evaluation may be sync or async.
   console.log('--------- evaluateScript ---------');
+  let completion;
   realm.evaluateScript(`
     function f() { debugger; return 1; }
     f();

--- a/lib-src/node/module.mts
+++ b/lib-src/node/module.mts
@@ -1,86 +1,187 @@
-import { readFile, readFileSync } from 'node:fs';
-import path from 'node:path';
+import { dirname, isAbsolute, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { readFileSync } from 'fs';
+import { readFile } from 'fs/promises';
 import {
-  EnsureCompletion,
-  ManagedRealm, Realm, Throw, ThrowCompletion, type AgentHostDefined, type AbstractModuleRecord, type PlainCompletion,
+  AbstractModuleRecord,
+  Assert,
+  ManagedRealm, ModuleCache, OutOfRange, Realm,
+  Throw,
+  type ImportAttributeRecord,
   type ModuleCacheKey,
+  type ModuleLoader,
+  type PlainCompletion,
 } from '#self';
 
-export function createLoadImportedModule(getCache = (realm: ManagedRealm) => realm.HostDefined.resolverCache) {
-  const validateType = (attributes: Map<string, string>, finish: (completion: ThrowCompletion) => void) => {
-    const type = attributes.get('type');
-    if (type && type !== 'json' && type !== 'text') {
-      finish(Throw.TypeError('Unsupported import type "$1" (only "json" and "text" are supported)', type));
-      return false;
-    }
-    return true;
-  };
+export interface FileSystemLoaderOptions {
+  getModuleCache?: (realm: ManagedRealm) => ModuleCache;
+  /** @default false */
+  sync?: boolean;
+  /**
+   * @default false
+   * If this loader accepts specifier like "/home/test/module.js".
+   * This conflicts with URL specifiers ("/root.js" relative to "http://example.com/").
+   *
+   * This will not reject Windows absolute path like "C:\path\to\module.js".
+   */
+  allowAbsoluteSpecifier?: boolean;
+  canImport?: (resolvedSpecifier: string, callback: (result: boolean) => void) => void;
+}
 
-  const parseModule = (realm: ManagedRealm, resolved: string, attributes: Map<string, string>, source: string) => {
-    if (attributes.get('type') === 'text') {
-      return realm.createTextModule(source);
-    } else if (attributes.get('type') === 'json' || resolved.endsWith('.json')) {
-      return realm.createJSONModule(source);
-    } else {
-      return realm.compileModule(source, { specifier: resolved });
-    }
-  };
+export type ResolvedResult = { type: undefined | 'text' | 'json' | 'bytes', path: string };
 
-  const loadImportedModuleSyncOrAsync = (
-    readFile: (path: string, callback: (err: NodeJS.ErrnoException | null, data: string) => void) => void,
-    ...[referrer, specifier, attributes, _hostDefined, finish]: Parameters<NonNullable<AgentHostDefined['loadImportedModule']>>
-  ) => {
+export function createFileSystemModuleLoader(options: FileSystemLoaderOptions = {}): ModuleLoader {
+  const {
+    getModuleCache = (realm) => realm.HostDefined.resolverCache,
+    sync,
+    allowAbsoluteSpecifier,
+    canImport,
+  } = options;
+
+  return (referrer, moduleRequest, _hostDefined, finish, suggestError) => {
     const realm = (referrer instanceof Realm ? referrer : referrer.Realm) as ManagedRealm;
     realm.scope(() => {
-      const cache = getCache(realm);
-
-      if (!referrer.HostDefined?.specifier) {
-        finish(Throw.SyntaxError('Could not resolve module "$1" from a module with no source location', specifier));
-        return;
+      let type: ResolvedResult['type'];
+      for (const attribute of moduleRequest.Attributes) {
+        if (attribute.Key === 'type') {
+          const value = attribute.Value;
+          if (value !== 'json' && value !== 'text' && value !== 'bytes') {
+            suggestError(`Unsupported import type "${value}" (only "json", "bytes" and "text" are supported)`);
+            finish(undefined);
+            return;
+          }
+          type = value;
+        } else {
+          suggestError(`Unsupported import attribute "${attribute.Key}"`);
+          finish(undefined);
+          return;
+        }
       }
+      const cache = getModuleCache(realm);
+      let resolvedPath: string;
 
-      if (!validateType(attributes, finish)) {
-        return;
-      }
-
-      const base = path.dirname(referrer.HostDefined!.specifier!);
-      const resolved = path.resolve(base, specifier);
-      const attributeObject = Object.fromEntries(attributes);
-
-      const load = (callback: (completion: PlainCompletion<AbstractModuleRecord>) => void) => {
-        readFile(resolved, (err, data) => {
-          realm.scope(() => {
-            if (err) {
-              callback(Throw.SyntaxError('Could not read module $1', specifier));
-            } else {
-              callback(EnsureCompletion(parseModule(realm, resolved, attributes, data)));
-            }
-          });
-        });
-      };
-
-      let cacheKey: ModuleCacheKey;
-      if (cache) {
-        cacheKey = cache.toCacheKey(resolved, attributes.get('type') || 'js', attributeObject);
-        cache.load(cacheKey, load, finish);
+      const isPathToRoot = moduleRequest.Specifier.startsWith('/');
+      const isFileURL = moduleRequest.Specifier.startsWith('file://');
+      const isRelativeSpecifier = moduleRequest.Specifier.startsWith('./') || moduleRequest.Specifier.startsWith('../');
+      if (isPathToRoot) {
+        if (allowAbsoluteSpecifier) resolvedPath = moduleRequest.Specifier;
+        else {
+          suggestError(`Root specifier "${moduleRequest.Specifier}" is not allowed for locating file system modules`);
+          finish(undefined);
+          return;
+        }
+      } else if (isFileURL) {
+        resolvedPath = moduleRequest.Specifier;
+      } else if (isRelativeSpecifier) {
+        const referrerSpecifier = referrer.HostDefined?.specifier;
+        if (!referrerSpecifier) {
+          finish(Throw.SyntaxError(`Cannot resolve relative module specifier "${moduleRequest.Specifier}" without referrer`));
+          return;
+        }
+        const specifierPath = referrerSpecifier.startsWith('file://') ? fileURLToPath(referrerSpecifier) : referrerSpecifier;
+        if (!isAbsolute(specifierPath)) {
+          suggestError(`Referrer "${referrerSpecifier}" cannot be used to locate module request "${moduleRequest.Specifier}"`);
+          finish(undefined);
+          return;
+        }
+        const dir = dirname(specifierPath);
+        resolvedPath = resolve(dir, moduleRequest.Specifier);
       } else {
-        load(finish);
+        finish(undefined);
+        return;
+      }
+
+      if (canImport) {
+        canImport(resolvedPath, (result) => {
+          if (!result) {
+            finish(realm.scope(() => Throw.SyntaxError(`Import module "${resolvedPath}" is not allowed`)));
+            return;
+          }
+          next();
+        });
+      } else {
+        next();
+      }
+
+      function next() {
+        let resolvedAttributes: readonly ImportAttributeRecord[];
+        if (resolvedPath.endsWith('.json') && type === undefined) {
+          type = 'json';
+          Assert(moduleRequest.Attributes.length === 0);
+          resolvedAttributes = [{ Key: 'type', Value: 'json' }];
+        } else {
+          resolvedAttributes = moduleRequest.Attributes;
+        }
+        let cacheKey: ModuleCacheKey;
+        if (cache) {
+          cacheKey = cache.toCacheKey({ Specifier: resolvedPath, Attributes: resolvedAttributes });
+          cache.load(cacheKey, loader, finish);
+        } else {
+          loader(finish);
+        }
+      }
+
+      function loader(callback: (result: PlainCompletion<AbstractModuleRecord>) => void) {
+        if (type === 'bytes') {
+          loadBytes(resolvedPath, (err, data) => {
+            realm.scope(() => {
+              if (err) callback(Throw.SyntaxError('$1', String((err as Error).message)));
+              else callback(realm.createBytesModule(data));
+            });
+          });
+        } else {
+          load(resolvedPath, (err, data) => {
+            realm.scope(() => {
+              if (err) {
+                callback(Throw.SyntaxError('$1', String((err as Error).message)));
+              } else if (type === undefined) {
+                callback(realm.compileModule(data, { specifier: resolvedPath }));
+              } else if (type === 'json') {
+                callback(realm.createJSONModule(data));
+              } else if (type === 'text') {
+                callback(realm.createTextModule(data));
+              } else {
+                Assert(type !== 'bytes');
+                throw OutOfRange.exhaustive(type);
+              }
+            });
+          });
+        }
+      }
+
+      function load(path: string, callback: (err: unknown, data: string) => void) {
+        if (sync) {
+          try {
+            const data = readFileSync(path, 'utf8');
+            callback(null, data);
+          } catch (err) {
+            callback(err, null!);
+          }
+        } else {
+          readFile(path, 'utf8').then(
+            (data) => callback(null, data),
+            (err) => callback(err, null!),
+          );
+        }
+      }
+      function loadBytes(path: string, callback: (err: unknown, data: Uint8Array) => void) {
+        if (sync) {
+          try {
+            const data = readFileSync(path);
+            callback(null, new Uint8Array(data));
+          } catch (err) {
+            callback(err, null!);
+          }
+        } else {
+          readFile(path).then(
+            (data) => callback(null, new Uint8Array(data)),
+            (err) => callback(err, null!),
+          );
+        }
       }
     });
   };
-
-  const loadImportedModule: NonNullable<AgentHostDefined['loadImportedModule']> = loadImportedModuleSyncOrAsync.bind(null, (path, callback) => {
-    readFile(path, 'utf8', callback);
-  });
-  const loadImportedModuleSync: NonNullable<AgentHostDefined['loadImportedModule']> = loadImportedModuleSyncOrAsync.bind(null, (path, callback) => {
-    try {
-      const data = readFileSync(path, 'utf8');
-      callback(null, data);
-    } catch (error) {
-      callback(error as NodeJS.ErrnoException, '');
-    }
-  });
-  return { loadImportedModule, loadImportedModuleSync };
 }
 
-export const { loadImportedModule, loadImportedModuleSync } = createLoadImportedModule();
+export const fileSystemModuleLoader = createFileSystemModuleLoader();
+export const fileSystemModuleLoaderSync = createFileSystemModuleLoader({ sync: true });

--- a/src/abstract-ops/module-records.mts
+++ b/src/abstract-ops/module-records.mts
@@ -27,6 +27,8 @@ import {
   Call,
   ContinueDynamicImport,
   PromiseCapabilityRecord,
+  Construct,
+  type ArrayBufferObject,
 } from './all.mts';
 import {
   Realm,
@@ -36,6 +38,7 @@ import {
   type Arguments, type ImportAttributeRecord, type ModuleRequestRecord, type PlainEvaluator, type ScriptRecord, type SourceTextModuleRecord,
   Throw,
   JSStringValue,
+  type HostLoadImportedModulePayloadOpaque,
 } from '#self';
 
 /** https://tc39.es/ecma262/#graphloadingstate-record */
@@ -86,7 +89,7 @@ export function InnerModuleLoading(state: GraphLoadingState, module: AbstractMod
           InnerModuleLoading(state, record.Module);
         } else { // iii. Else,
           // 1. Perform HostLoadImportedModule(module, request, state.[[HostDefined]], state).
-          HostLoadImportedModule(module, request, state.HostDefined, state);
+          HostLoadImportedModule(module, request, state.HostDefined, { data: state });
         }
       }
 
@@ -475,7 +478,8 @@ export function GetImportedModule(referrer: CyclicModuleRecord, request: ModuleR
 }
 
 /** https://tc39.es/ecma262/#sec-FinishLoadingImportedModule */
-export function FinishLoadingImportedModule(referrer: ScriptRecord | CyclicModuleRecord | Realm, moduleRequest: ModuleRequestRecord, result: PlainCompletion<AbstractModuleRecord>, state: GraphLoadingState | PromiseCapabilityRecord) {
+export function FinishLoadingImportedModule(referrer: ScriptRecord | CyclicModuleRecord | Realm, moduleRequest: ModuleRequestRecord, payload: HostLoadImportedModulePayloadOpaque, result: PlainCompletion<AbstractModuleRecord>) {
+  const payload_ = payload.data;
   result = EnsureCompletion(result);
   // 1. If result is a normal completion, then
   if (result.Type === 'normal') {
@@ -491,13 +495,13 @@ export function FinishLoadingImportedModule(referrer: ScriptRecord | CyclicModul
   }
 
   // 2. If payload is a GraphLoadingState Record, then
-  if (state instanceof GraphLoadingState) {
+  if (payload_ instanceof GraphLoadingState) {
     // a. Perform ContinueModuleLoading(payload, result).
-    ContinueModuleLoading(state, result);
+    ContinueModuleLoading(payload_, result);
     // 3. Else,
   } else {
     // a. Perform ContinueDynamicImport(payload, result).
-    ContinueDynamicImport(state, result, moduleRequest.Phase);
+    ContinueDynamicImport(payload_, result, moduleRequest.Phase);
   }
 
   // 4. Return unused.
@@ -511,7 +515,7 @@ export function AllImportAttributesSupported(attributes: readonly ImportAttribut
 
   const supported: readonly string[] = HostGetSupportedImportAttributes();
   for (const attribute of attributes) {
-    if (!supported.includes(attribute.Key.stringValue())) {
+    if (!supported.includes(attribute.Key)) {
       return attribute.Key;
     }
   }
@@ -574,4 +578,11 @@ export function CreateDefaultExportSyntheticModule(defaultExport: Value) {
 /** https://tc39.es/proposal-import-text/#sec-create-text-module */
 export function CreateTextModule(source: JSStringValue) {
   return CreateDefaultExportSyntheticModule(source);
+}
+
+export function CreateBytesModule(arrayBuffer: ArrayBufferObject) {
+  // TODO: immutable array buffer
+  // 1. Assert: IsImmutableBuffer(arrayBuffer) is true.
+  const uint8Array = X(Construct(surroundingAgent.intrinsic('%Uint8Array%'), [arrayBuffer]));
+  return CreateDefaultExportSyntheticModule(uint8Array);
 }

--- a/src/abstract-ops/promise-operations.mts
+++ b/src/abstract-ops/promise-operations.mts
@@ -8,7 +8,7 @@ import {
   HostCallJobCallback,
 } from '../execution-context/Job.mts';
 import {
-  ObjectValue, Value, UndefinedValue, BooleanValue, NullValue, type Arguments,
+  ObjectValue, Value, UndefinedValue, BooleanValue, type Arguments,
 } from '../value.mts';
 import {
   AbruptCompletion,
@@ -343,7 +343,7 @@ function NewPromiseReactionJob(reaction: PromiseReactionRecord, argument: Value)
     return undefined;
   }
   // 2. Let handlerRealm be null.
-  let handlerRealm: NullValue | Realm = Value.null;
+  let handlerRealm: null | Realm = null;
   // 3. If reaction.[[Handler]] is not empty, then
   if (reaction.Handler !== undefined) {
     // a. Let getHandlerRealmResult be GetFunctionRealm(reaction.[[Handler]].[[Callback]]).

--- a/src/abstract-ops/shadow-realm.mts
+++ b/src/abstract-ops/shadow-realm.mts
@@ -154,10 +154,10 @@ export function ShadowRealmImportValue(specifierString: JSStringValue, exportNam
   surroundingAgent.executionContextStack.push(evalContext);
   const referrer = evalContext.Realm;
   HostLoadImportedModule(referrer, {
-    Specifier: specifierString,
+    Specifier: specifierString.value,
     Phase: 'evaluation',
     Attributes: [],
-  }, undefined, innerCapability);
+  }, undefined, { data: innerCapability });
   surroundingAgent.executionContextStack.pop(evalContext);
   const onFullfilled = CreateBuiltinFunction(function* onFullfilled([exports = Value.undefined]) {
     Assert(isModuleNamespaceObject(exports));

--- a/src/api.mts
+++ b/src/api.mts
@@ -348,7 +348,8 @@ export class ManagedRealm extends Realm {
    * Evaluate a script (skip the debugger).
    */
   evaluateScriptSkipDebugger(sourceText: string | ScriptRecord, options: { specifier?: string, doNotTrackScriptId?: boolean } = {}): ValueCompletion {
-    let completion = this.evaluateScript(sourceText, options, (c) => {
+    let completion;
+    this.evaluateScript(sourceText, options, (c) => {
       completion = c;
     });
     if (!completion) surroundingAgent.resumeEvaluate({ noBreakpoint: true });

--- a/src/api.mts
+++ b/src/api.mts
@@ -23,8 +23,8 @@ import {
   type ParseScriptHostDefined,
 } from './parse.mts';
 import {
-  AbstractModuleRecord,
-  ModuleRecord, SourceTextModuleRecord, type ModuleRecordHostDefined, type ModuleRecordHostDefinedPublic,
+  CyclicModuleRecord,
+  SourceTextModuleRecord, SyntheticModuleRecord, type ModuleRecordHostDefined, type ModuleRecordHostDefinedPublic,
 } from './modules.mts';
 import { isWeakRef, type WeakRefObject } from './intrinsics/WeakRef.mts';
 import { isFinalizationRegistryObject, type FinalizationRegistryObject } from './intrinsics/FinalizationRegistry.mts';
@@ -42,6 +42,9 @@ import {
   CreateTextModule,
   PerformPromiseThen,
   CreateBuiltinFunction,
+  AllocateArrayBuffer,
+  skipDebugger,
+  CreateBytesModule,
   ValueOfNormalCompletion,
 } from '#self';
 import {
@@ -179,14 +182,17 @@ export function runJobQueue() {
     // 2. Call the abstract closure.
     let c;
     surroundingAgent.evaluate((function* job(): ValueEvaluator {
-      Q(yield* abstractClosure());
+      const completion = yield* abstractClosure();
+      if (completion instanceof ThrowCompletion) {
+        surroundingAgent.hostDefinedOptions.uncaughtExceptionTrackers?.forEach((tracker) => {
+          tracker(completion.Value);
+        });
+      }
       return Value.undefined;
     }()), (completion) => {
       c = completion;
     });
-    if (!c) {
-      surroundingAgent.resumeEvaluate();
-    }
+    if (!c) surroundingAgent.resumeEvaluate();
     // 3. Perform any host-defined cleanup steps, after which the execution context stack must be empty.
     ClearKeptObjects();
     gc();
@@ -195,7 +201,6 @@ export function runJobQueue() {
 }
 
 export interface ManagedRealmHostDefined {
-  promiseRejectionTracker?(promise: PromiseObject, operation: 'reject' | 'handle'): void;
   getImportMetaProperties?(module: ModuleRecordHostDefinedPublic): readonly { readonly Key: PropertyKeyValue, readonly Value: Value }[];
   finalizeImportMeta?(meta: ObjectValue, module: ModuleRecordHostDefinedPublic): PlainCompletion<void>;
   resolverCache?: ModuleCache;
@@ -320,9 +325,15 @@ export class ManagedRealm extends Realm {
     });
   }
 
-  evaluateScript(sourceText: string | ScriptRecord, options: { specifier?: string, doNotTrackScriptId?: boolean } = {}, callback: (completion: NormalCompletion<Value> | ThrowCompletion) => void) {
-    if (sourceText === undefined || sourceText === null) throw new TypeError('sourceText must be a string or a ScriptRecord');
-    if (typeof sourceText === 'string') sourceText = Q(this.compileScript(sourceText, options));
+  evaluateScript(sourceText: string | ScriptRecord, options: { specifier?: string, doNotTrackScriptId?: boolean } = {}, callback: (completion: NormalCompletion<Value> | ThrowCompletion) => void): ValueCompletion | undefined {
+    if (typeof sourceText === 'string') {
+      const completion = this.compileScript(sourceText, options);
+      if (completion instanceof ThrowCompletion) {
+        callback(completion);
+        return completion;
+      }
+      sourceText = ValueOfNormalCompletion(completion);
+    }
     if (!sourceText) throw new TypeError('sourceText is null or undefined');
     using _ = this.scope();
     let result: ValueCompletion | undefined;
@@ -348,13 +359,13 @@ export class ManagedRealm extends Realm {
   }
 
 
-  evaluateModule<T extends ModuleRecord>(sourceText: string | T, specifier: string | undefined, finish: (completion: ValueCompletion<PromiseObject>) => void) {
+  evaluateModule<T extends CyclicModuleRecord>(sourceText: string | T, specifier: string | undefined, finish: (completion: ValueCompletion<PromiseObject>) => void) {
     using _ = this.scope();
     if (sourceText === undefined || sourceText === null) throw new TypeError('sourceText must be a string or a ModuleRecord');
-    const moduleCompletion = typeof sourceText === 'string' ? this.compileModule(sourceText, { specifier }) as PlainCompletion<AbstractModuleRecord> : sourceText;
+    const moduleCompletion = typeof sourceText === 'string' ? this.compileModule(sourceText, { specifier }) : sourceText;
 
     if (this.HostDefined.resolverCache && typeof specifier === 'string') {
-      const key = this.HostDefined.resolverCache.toCacheKey(specifier, 'js', {});
+      const key = this.HostDefined.resolverCache.toCacheKey({ Specifier: specifier, Attributes: [] });
       this.HostDefined.resolverCache.set(key, moduleCompletion);
     }
 
@@ -362,7 +373,7 @@ export class ManagedRealm extends Realm {
       finish(moduleCompletion);
       return;
     }
-    const module = ValueOfNormalCompletion(moduleCompletion);
+    const module = X(moduleCompletion);
 
     PerformPromiseThen(module.LoadRequestedModules(), CreateBuiltinFunction.from(function* linkAndEvaluate() {
       const link = module.Link();
@@ -378,7 +389,7 @@ export class ManagedRealm extends Realm {
     runJobQueue();
   }
 
-  createJSONModule(sourceText: string) {
+  createJSONModule(sourceText: string): PlainCompletion<SyntheticModuleRecord> {
     if (typeof sourceText !== 'string') {
       throw new TypeError('sourceText must be a string');
     }
@@ -386,11 +397,20 @@ export class ManagedRealm extends Realm {
     return module;
   }
 
-  createTextModule(sourceText: string) {
+  createTextModule(sourceText: string): PlainCompletion<SyntheticModuleRecord> {
     if (typeof sourceText !== 'string') {
       throw new TypeError('sourceText must be a string');
     }
     const module = this.scope(() => CreateTextModule(Value(sourceText)));
+    return module;
+  }
+
+  createBytesModule(content: Uint8Array): PlainCompletion<SyntheticModuleRecord> {
+    if (!(content instanceof Uint8Array)) {
+      throw new TypeError('content must be a Uint8Array');
+    }
+    const arrayBuffer = Q(skipDebugger(AllocateArrayBuffer(surroundingAgent.intrinsic('%ArrayBuffer%'), content.buffer.byteLength)));
+    const module = this.scope(() => CreateBytesModule(arrayBuffer));
     return module;
   }
 }

--- a/src/execution-context/Agent.mts
+++ b/src/execution-context/Agent.mts
@@ -4,7 +4,7 @@ import {
 } from '../host-defined/engine.mts';
 import { isArray } from '../utils/language.mts';
 import {
-  ObjectValue, SymbolValue, type Job, type Intrinsics, Value, ThrowCompletion, GetActiveScriptOrModule, type ValueEvaluator, NormalCompletion, EnsureCompletion, skipDebugger, type ValueCompletion, type ScriptRecord, SourceTextModuleRecord, Realm, X, Construct,
+  ObjectValue, SymbolValue, type Job, type Intrinsics, Value, ThrowCompletion, type ValueEvaluator, NormalCompletion, EnsureCompletion, skipDebugger, type ValueCompletion, type ScriptRecord, SourceTextModuleRecord, Realm, X, Construct,
   ExecutionContextStack,
   type AgentHostDefined,
   DynamicParsedCodeRecord,
@@ -15,7 +15,6 @@ import {
   type ParseNode,
   type BreakpointLocation,
   getBreakpointCandidateNodes,
-  type PlainEvaluator,
   parseNodeToBreakpointLocation,
   type FunctionObject,
   performDevtoolsEval,
@@ -90,19 +89,6 @@ export class Agent {
 
   intrinsic<const T extends keyof Intrinsics>(name: T): Intrinsics[T] {
     return this.currentRealmRecord.Intrinsics[name];
-  }
-
-  queueJob(queueName: string, job: () => PlainEvaluator) {
-    const callerContext = this.runningExecutionContext;
-    const callerRealm = callerContext.Realm;
-    const callerScriptOrModule = GetActiveScriptOrModule();
-    const pending: Job = {
-      queueName,
-      job,
-      callerRealm,
-      callerScriptOrModule,
-    };
-    this.jobQueue.push(pending);
   }
 
   // NON-SPEC: Check if a feature is enabled in this agent.

--- a/src/execution-context/Job.mts
+++ b/src/execution-context/Job.mts
@@ -10,12 +10,13 @@ import {
   type ValueEvaluator,
   surroundingAgent,
   type PlainEvaluator,
+  GetActiveScriptOrModule,
 } from '#self';
 
 /** https://tc39.es/ecma262/#job */
 export interface Job {
   readonly queueName: string;
-  readonly job: () => PlainEvaluator;
+  readonly job: () => PlainEvaluator<unknown>;
   readonly callerRealm: Realm;
   readonly callerScriptOrModule: AbstractModuleRecord | ScriptRecord | NullValue;
 }
@@ -45,11 +46,19 @@ export function* HostCallJobCallback(jobCallback: JobCallbackRecord, V: Value, a
 // Atomics: HostEnqueueGenericJob
 
 /** https://tc39.es/ecma262/#sec-hostenqueuepromisejob */
-export function HostEnqueuePromiseJob(job: () => PlainEvaluator, _realm: Realm | NullValue) {
+export function HostEnqueuePromiseJob(job: () => PlainEvaluator, realm: Realm | null) {
   if (surroundingAgent.debugger_isPreviewing) {
     return;
   }
-  surroundingAgent.queueJob('PromiseJobs', job);
+
+  const callerRealm = realm || surroundingAgent.currentRealmRecord;
+  const scriptOrModule = GetActiveScriptOrModule();
+  surroundingAgent.jobQueue.push({
+    queueName: 'PromiseJobs',
+    job,
+    callerRealm,
+    callerScriptOrModule: scriptOrModule,
+  });
 }
 
 // Atomics: HostEnqueueTimeoutJob

--- a/src/execution-context/WeakReference.mts
+++ b/src/execution-context/WeakReference.mts
@@ -1,7 +1,7 @@
 import { surroundingAgent } from '../host-defined/engine.mts';
 import {
   type FinalizationRegistryObject, type PlainCompletion, Q, NormalCompletion, ObjectValue, SymbolValue, Assert, HostCallJobCallback, type JobCallbackRecord, UndefinedValue, Value, type ValueEvaluator, KeyForSymbol,
-  type PlainEvaluator,
+  GetActiveScriptOrModule,
 } from '#self';
 
 
@@ -13,9 +13,14 @@ export function HostEnqueueFinalizationRegistryCleanupJob(fg: FinalizationRegist
   } else {
     if (!surroundingAgent.scheduledForCleanup.has(fg)) {
       surroundingAgent.scheduledForCleanup.add(fg);
-      surroundingAgent.queueJob('FinalizationCleanup', function* finalizationJob(): PlainEvaluator {
-        surroundingAgent.scheduledForCleanup.delete(fg);
-        Q(yield* (CleanupFinalizationRegistry(fg)));
+      surroundingAgent.jobQueue.push({
+        queueName: 'FinalizationCleanup',
+        job: function finalizationJob() {
+          surroundingAgent.scheduledForCleanup.delete(fg);
+          return CleanupFinalizationRegistry(fg);
+        },
+        callerRealm: surroundingAgent.currentRealmRecord,
+        callerScriptOrModule: GetActiveScriptOrModule(),
       });
     }
   }

--- a/src/host-defined/engine.mts
+++ b/src/host-defined/engine.mts
@@ -12,7 +12,7 @@ import {
 } from '../evaluator.mts';
 import { kInternal } from '../utils/internal.mts';
 import {
-  AbstractModuleRecord, CyclicModuleRecord, ObjectValue, runJobQueue, type ValueCompletion, type ModuleRecordHostDefined, type ParseScriptHostDefined, type ScriptRecord,
+  AbstractModuleRecord, CyclicModuleRecord, ObjectValue, type ValueCompletion, type ModuleRecordHostDefined, type ParseScriptHostDefined, type ScriptRecord,
   ManagedRealm,
   SourceTextModuleRecord,
   type ModuleRequestRecord,
@@ -39,7 +39,7 @@ export interface Engine262Feature {
   name: string;
   flag: string;
   url: string;
-  enableInPlayground: boolean;
+  enableInPlayground?: boolean;
 }
 
 // unflag a feature when it reaches stage 3.
@@ -55,7 +55,6 @@ export const FEATURES = ([
     name: 'Skip bugfix for field initializers in decorator',
     flag: 'decorators.no-bugfix.1',
     url: '',
-    enableInPlayground: false,
   },
   {
     name: 'Temporal',
@@ -71,7 +70,7 @@ export const FEATURES = ([
     enableInPlayground: true,
   },
   {
-    name: 'Promise#allKeyed',
+    name: 'Promise.allKeyed',
     flag: 'promise.allkeyed',
     url: 'https://github.com/tc39/proposal-await-dictionary',
     enableInPlayground: true,
@@ -111,9 +110,18 @@ export class ExecutionContextStack extends Array<ExecutionContext> {
   }
 }
 
+/** https://tc39.es/ecma262/#sec-host-promise-rejection-tracker */
+export type HostPromiseRejectionTracker = (promise: PromiseObject, operation: 'reject' | 'handle') => void;
 export interface HostHooks {
-  HostInitializeShadowRealm?(realmRec: Realm, innerContext: ExecutionContext, O: ShadowRealmObject): PlainEvaluator | PlainCompletion<void>;
+  /** https://tc39.es/ecma262/#sec-hostensurecancompilestrings */
   HostEnsureCanCompileStrings?(calleeRealm: Realm, parameterStrings: readonly string[], bodyString: string, direct: boolean): PlainEvaluator | PlainCompletion<void>;
+  /** https://tc39.es/proposal-shadowrealm/#sec-hostinitializeshadowrealm */
+  HostInitializeShadowRealm?(realmRec: Realm, innerContext: ExecutionContext, O: ShadowRealmObject): PlainEvaluator | PlainCompletion<void>;
+  /** https://tc39.es/ecma262/#sec-#sec-HostLoadImportedModule */
+  HostLoadImportedModule?(referrer: CyclicModuleRecord | ScriptRecord | Realm, moduleRequest: ModuleRequestRecord, hostDefined: ModuleRecordHostDefined | undefined, payload: HostLoadImportedModulePayloadOpaque): void;
+  /** https://tc39.es/ecma262/#sec-host-promise-rejection-tracker */
+  HostPromiseRejectionTrackers?: Set<HostPromiseRejectionTracker>;
+  /** https://tc39.es/proposal-temporal/#sec-hostsystemutcepochnanoseconds */
   HostSystemUTCEpochNanoseconds?(global: ObjectValue): EpochNanoseconds;
 }
 
@@ -129,11 +137,13 @@ export interface AgentHostDefined {
   cleanupFinalizationRegistry?(FinalizationRegistry: FinalizationRegistryObject): PlainCompletion<void>;
   features?: readonly string[];
   supportedImportAttributes?: readonly string[];
-  loadImportedModule?(referrer: AbstractModuleRecord | ScriptRecord | Realm, specifier: string, attributes: Map<string, string>, hostDefined: ModuleRecordHostDefined | undefined, finish: (res: PlainCompletion<AbstractModuleRecord>) => void): void;
   onDebugger?(reason?: DebuggerPauseReason): void;
   onRealmCreated?(realm: ManagedRealm): void;
   onScriptParsed?(script: ScriptRecord | SourceTextModuleRecord | DynamicParsedCodeRecord, scriptId: string): void;
   onNodeEvaluation?(node: ParseNode, realm: Realm): void;
+
+  /** Promise rejection is standardized, but uncaught exception is not. */
+  uncaughtExceptionTrackers?: Set<(error: Value) => void>;
 
   errorStackAttachNativeStack?: boolean;
 }
@@ -217,13 +227,8 @@ export function* HostEnsureCanCompileStrings(calleeRealm: Realm, parameterString
 }
 
 export function HostPromiseRejectionTracker(promise: PromiseObject, operation: 'reject' | 'handle') {
-  if (surroundingAgent.debugger_isPreviewing) {
-    return;
-  }
-  const realm = surroundingAgent.currentRealmRecord;
-  if (realm && realm.HostDefined.promiseRejectionTracker) {
-    X(realm.HostDefined.promiseRejectionTracker(promise, operation));
-  }
+  if (surroundingAgent.debugger_isPreviewing) return;
+  surroundingAgent.hostDefinedOptions.hostHooks?.HostPromiseRejectionTrackers?.forEach((tracker) => tracker(promise, operation));
 }
 
 export function HostHasSourceTextAvailable(func: FunctionObject) {
@@ -241,36 +246,21 @@ export function HostGetSupportedImportAttributes(): readonly string[] {
 }
 
 // #sec-HostLoadImportedModule
-export function HostLoadImportedModule(referrer: CyclicModuleRecord | ScriptRecord | Realm, moduleRequest: ModuleRequestRecord, hostDefined: ModuleRecordHostDefined | undefined, payload: GraphLoadingState | PromiseCapabilityRecord) {
-  if (surroundingAgent.hostDefinedOptions.loadImportedModule) {
-    const executionContext = surroundingAgent.runningExecutionContext;
-    let result: PlainCompletion<AbstractModuleRecord> | undefined;
-    let sync = true;
-    const attributes = new Map(moduleRequest.Attributes.map(({ Key, Value }) => [Key.stringValue(), Value.stringValue()]));
-    surroundingAgent.hostDefinedOptions.loadImportedModule(referrer, moduleRequest.Specifier.stringValue(), attributes, hostDefined, (res) => {
-      result = res;
-      if (!sync) {
-        // If this callback has been called asynchronously, restore the correct execution context and enqueue a job.
-        surroundingAgent.executionContextStack.push(executionContext);
-        surroundingAgent.queueJob('FinishLoadingImportedModule', function* finishLoadingJob(): PlainEvaluator {
-          result = EnsureCompletion(result);
-          Assert(!!result && (result.Type === 'normal' || result.Type === 'throw'));
-          FinishLoadingImportedModule(referrer, moduleRequest, result, payload);
-        });
-        surroundingAgent.executionContextStack.pop(executionContext);
-        runJobQueue();
-      }
-    });
-    sync = false;
-    if (result !== undefined) {
-      result = EnsureCompletion(result);
-      Assert(result.Type === 'normal' || result.Type === 'throw');
-      FinishLoadingImportedModule(referrer, moduleRequest, result, payload);
-    }
+export function HostLoadImportedModule(referrer: CyclicModuleRecord | ScriptRecord | Realm, moduleRequest: ModuleRequestRecord, hostDefined: ModuleRecordHostDefined | undefined, payload: HostLoadImportedModulePayloadOpaque) {
+  const HostHook = surroundingAgent.hostDefinedOptions.hostHooks?.HostLoadImportedModule;
+  if (HostHook) {
+    HostHook(referrer, moduleRequest, hostDefined, payload);
   } else {
-    FinishLoadingImportedModule(referrer, moduleRequest, Throw.Error('Host does not set a module loader'), payload);
+    FinishLoadingImportedModule(referrer, moduleRequest, payload, Throw.Error('Host does not set a module loader'));
   }
 }
+
+// The operation must treat payload as an opaque value to be passed through to FinishLoadingImportedModule.
+export type HostLoadImportedModulePayloadOpaque = {
+  /** @internal */
+  data: GraphLoadingState | PromiseCapabilityRecord;
+  HostLoadImportedModulePayloadOpaque?: never
+};
 
 /** https://tc39.es/ecma262/#sec-hostgetimportmetaproperties */
 export function HostGetImportMetaProperties(moduleRecord: AbstractModuleRecord) {

--- a/src/index.mts
+++ b/src/index.mts
@@ -24,7 +24,11 @@ export { skipDebugger } from './utils/evaluator.mts';
 export {
   CallSite, CallFrame, captureStack, getHostDefinedErrorDetails, getCurrentStack,
 } from './utils/stack.mts';
-export { ModuleCache, type ModuleCacheKey } from './utils/module.mts';
+export { ModuleCache, type ModuleCacheKey, type ModuleCacheLoader } from './utils/module.mts';
+export {
+  type ModuleLoader, type ModuleLoaderResultWithCacheKey, type ModuleLoaderResultWithoutCacheKey, composeModuleLoaders,
+} from './utils/module-loader.mts';
+export { createBuiltinModuleLoader, type BuiltinModuleSource, type BuiltinModuleLoaderOptions } from './utils/module-loaders/builtin-loader.mts';
 
 export { isBoundFunctionObject, type BoundFunctionObject } from './intrinsics/FunctionPrototype.mts';
 export { isMapObject, type MapObject } from './intrinsics/Map.mts';

--- a/src/modules.mts
+++ b/src/modules.mts
@@ -52,8 +52,8 @@ import {
 
 // https://tc39.es/ecma262/#loadedmodulerequest-record
 export interface LoadedModuleRequestRecord {
-  readonly Specifier: JSStringValue;
-  readonly Attributes: ImportAttributeRecord[];
+  readonly Specifier: string;
+  readonly Attributes: readonly ImportAttributeRecord[];
   readonly Module: AbstractModuleRecord
 }
 
@@ -780,6 +780,6 @@ export class SyntheticModuleRecord extends AbstractModuleRecord {
   * SetSyntheticExport(name: JSStringValue, value: Value): PlainEvaluator {
     const module = this;
     // 1. Return module.[[Environment]].SetMutableBinding(name, value, true).
-    return yield* (module.Environment as ModuleEnvironmentRecord).SetMutableBinding(name, value, Value.true);
+    return yield* module.Environment!.SetMutableBinding(name, value, Value.true);
   }
 }

--- a/src/runtime-semantics/ImportCall.mts
+++ b/src/runtime-semantics/ImportCall.mts
@@ -4,7 +4,7 @@ import {
   Q, X, IfAbruptRejectPromise,
 } from '../completion.mts';
 import {
-  AbstractModuleRecord, AllImportAttributesSupported, Call, CyclicModuleRecord, EnumerableOwnProperties, Get, JSStringValue, NullValue, ObjectValue, Realm, Value, type ModuleRequestRecord, type PromiseObject, type ScriptRecord,
+  AbstractModuleRecord, AllImportAttributesSupported, Call, CyclicModuleRecord, EnumerableOwnProperties, Get, JSStringValue, NullValue, ObjectValue, Realm, Value, type ImportAttributeRecord, type ModuleRequestRecord, type PromiseObject, type ScriptRecord,
 } from '../index.mts';
 import type { ParseNode } from '../parser/ParseNode.mts';
 import { __ts_cast__ } from '../utils/language.mts';
@@ -58,7 +58,7 @@ function* EvaluateImportCall(
   IfAbruptRejectPromise(specifierString, promiseCapability);
   __ts_cast__<JSStringValue>(specifierString);
   // 10. Let attributes nw a new empty List.
-  const attributes = [];
+  const attributes: ImportAttributeRecord[] = [];
   // 11. If options is not undefined, then
   if (options !== Value.undefined) {
     // a. If options is not an Object, then
@@ -109,7 +109,7 @@ function* EvaluateImportCall(
             return promiseCapability.Promise;
           }
           // b. Append the ImportAttribute Record { [[Key]]: key, [[Value]]: value } to attributes.
-          attributes.push({ Key: key, Value: value });
+          attributes.push({ Key: key.value, Value: value.value });
         }
       }
       // e. If AllImportAttributesSupported(attributes) is false, then
@@ -117,19 +117,19 @@ function* EvaluateImportCall(
       if (unsupportedAttributeKey) {
         // i. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
         X(Call(promiseCapability.Reject, Value.undefined, [
-          Throw.TypeError('Unsupported import attribute "$1"', unsupportedAttributeKey.stringValue()).Value,
+          Throw.TypeError('Unsupported import attribute "$1"', unsupportedAttributeKey).Value,
         ]));
         // ii. Return promiseCapability.[[Promise]].
         return promiseCapability.Promise;
       }
       // f. Sort attributes according to the lexicographic order of their [[Key]] field, treating the value of each such field as a sequence of UTF-16 code unit values.
-      attributes.sort((a, b) => (a.Key.value < b.Key.value ? -1 : 1));
+      attributes.sort((a, b) => (a.Key < b.Key ? -1 : 1));
     }
   }
   // 12. Let moduleRequest be a new ModuleRequest Record { [[Specifier]]: specifierString, [[Attributes]]: attributes }.
-  const moduleRequest: ModuleRequestRecord = { Specifier: specifierString, Attributes: attributes, Phase: phase };
+  const moduleRequest: ModuleRequestRecord = { Specifier: specifierString.value, Attributes: attributes, Phase: phase };
   // 10. Perform HostLoadImportedModule(referrer, specifierString, ~empty~, promiseCapability).
-  HostLoadImportedModule(referrer as CyclicModuleRecord | ScriptRecord | Realm, moduleRequest, undefined, promiseCapability);
+  HostLoadImportedModule(referrer as CyclicModuleRecord | ScriptRecord | Realm, moduleRequest, undefined, { data: promiseCapability });
   // 9. Return promiseCapability.[[Promise]].
   return promiseCapability.Promise;
 }

--- a/src/static-semantics/ModuleRequests.mts
+++ b/src/static-semantics/ModuleRequests.mts
@@ -1,28 +1,23 @@
 import type { ParseNode } from '../parser/ParseNode.mts';
-import type { JSStringValue } from '../value.mts';
 import { StringValue } from './all.mts';
 import { type LoadedModuleRequestRecord } from '#self';
 
 // https://tc39.es/ecma262/#modulerequest-record
 export interface ModuleRequestRecord {
-  readonly Specifier: JSStringValue;
-  readonly Attributes: ImportAttributeRecord[];
+  readonly Specifier: string;
+  readonly Attributes: readonly ImportAttributeRecord[];
   readonly Phase: 'defer' | 'evaluation';
 }
 
 // https://tc39.es/ecma262/#importattribute-record
 export interface ImportAttributeRecord {
-  readonly Key: JSStringValue;
-  readonly Value: JSStringValue;
-}
-
-function stringsEqual(left: JSStringValue, right: JSStringValue) {
-  return left === right || left.stringValue() === right.stringValue();
+  readonly Key: string;
+  readonly Value: string;
 }
 
 // https://tc39.es/ecma262/#sec-ModuleRequestsEqual
 export function ModuleRequestsEqual(left: ModuleRequestRecord | LoadedModuleRequestRecord, right: ModuleRequestRecord | LoadedModuleRequestRecord) {
-  if (!stringsEqual(left.Specifier, right.Specifier)) {
+  if (left.Specifier !== right.Specifier) {
     return false;
   }
   const leftAttrs = left.Attributes;
@@ -33,7 +28,7 @@ export function ModuleRequestsEqual(left: ModuleRequestRecord | LoadedModuleRequ
     return false;
   }
   for (const l of leftAttrs) {
-    if (!rightAttrs.some((r) => stringsEqual(l.Key, r.Key) && stringsEqual(l.Value, r.Value))) {
+    if (!rightAttrs.some((r) => l.Key === r.Key && l.Value === r.Value)) {
       return false;
     }
   }
@@ -45,11 +40,11 @@ function WithClauseToAttributes(node: ParseNode.WithClause): ImportAttributeReco
   const attributes: ImportAttributeRecord[] = [];
   for (const attribute of node.WithEntries) {
     attributes.push({
-      Key: StringValue(attribute.AttributeKey),
-      Value: StringValue(attribute.AttributeValue),
+      Key: StringValue(attribute.AttributeKey).value,
+      Value: StringValue(attribute.AttributeValue).value,
     });
   }
-  attributes.sort((a, b) => (a.Key.value < b.Key.value ? -1 : 1));
+  attributes.sort((a, b) => (a.Key < b.Key ? -1 : 1));
   return attributes;
 }
 
@@ -77,19 +72,19 @@ export function ModuleRequests(node: ParseNode): ModuleRequestRecord[] {
       if (node.FromClause) {
         const specifier = StringValue(node.FromClause);
         const attributes = node.WithClause ? WithClauseToAttributes(node.WithClause) : [];
-        return [{ Specifier: specifier, Attributes: attributes, Phase: node.Phase }];
+        return [{ Specifier: specifier.value, Attributes: attributes, Phase: node.Phase }];
       }
       if (node.ModuleSpecifier) {
         const specifier = StringValue(node.ModuleSpecifier);
         const attributes = node.WithClause ? WithClauseToAttributes(node.WithClause) : [];
-        return [{ Specifier: specifier, Attributes: attributes, Phase: node.Phase }];
+        return [{ Specifier: specifier.value, Attributes: attributes, Phase: node.Phase }];
       }
       throw new Error('Unreachable: all imports must have either an ImportClause or a ModuleSpecifier');
     case 'ExportDeclaration':
       if (node.FromClause) {
         const specifier = StringValue(node.FromClause);
         const attributes = node.WithClause ? WithClauseToAttributes(node.WithClause) : [];
-        return [{ Specifier: specifier, Attributes: attributes, Phase: 'evaluation' }];
+        return [{ Specifier: specifier.value, Attributes: attributes, Phase: 'evaluation' }];
       }
       return [];
     default:

--- a/src/utils/module-loader.mts
+++ b/src/utils/module-loader.mts
@@ -1,0 +1,70 @@
+import {
+  AbstractModuleRecord,
+  FinishLoadingImportedModule,
+  ManagedRealm,
+  NormalCompletion,
+  Realm,
+  runJobQueue,
+  surroundingAgent,
+  Throw,
+  ThrowCompletion,
+  type CyclicModuleRecord, type HostHooks, type ModuleCacheKey, type ModuleRecordHostDefined, type ModuleRequestRecord, type PlainCompletion, type ScriptRecord,
+} from '#self';
+
+/**
+ * If finish is called with `undefined`, it will pass the module request to the next loader in the chain.
+ */
+export type ModuleLoader = (
+  referrer: CyclicModuleRecord | ScriptRecord | Realm,
+  moduleRequest: ModuleRequestRecord,
+  hostDefined: ModuleRecordHostDefined | undefined,
+  finish: (result: AbstractModuleRecord | NormalCompletion<AbstractModuleRecord> | ThrowCompletion | undefined) => void,
+  suggestError: (error: string) => void,
+) => void;
+
+export interface ModuleLoaderResultWithCacheKey {
+  cacheKey: ModuleCacheKey;
+  completion: AbstractModuleRecord | NormalCompletion<AbstractModuleRecord> | ThrowCompletion;
+}
+
+export interface ModuleLoaderResultWithoutCacheKey {
+  cacheKey: ModuleCacheKey | undefined;
+  completion: ThrowCompletion;
+}
+
+export function composeModuleLoaders(loaders: readonly ModuleLoader[]): NonNullable<HostHooks['HostLoadImportedModule']> {
+  return (referrer, moduleRequest, hostDefined, payload) => {
+    const executionContext = surroundingAgent.runningExecutionContext;
+    const errors: string[] = [];
+    function fin(completion: PlainCompletion<AbstractModuleRecord>) {
+      let async = false;
+      if (surroundingAgent.runningExecutionContext !== executionContext) {
+        async = true;
+        surroundingAgent.executionContextStack.push(executionContext);
+      }
+      FinishLoadingImportedModule(referrer, moduleRequest, payload, completion);
+      if (async) surroundingAgent.executionContextStack.pop(executionContext);
+      runJobQueue();
+    }
+    function tryNextLoader(loader: ModuleLoader | undefined, restLoaders: readonly ModuleLoader[]): void {
+      if (!loader) {
+        const errorMessage = errors.map((error) => `\n    - ${error}`).join('');
+        fin((executionContext.Realm as ManagedRealm).scope(() => Throw.SyntaxError('No module loader can load this module request.$1', errorMessage)));
+        return;
+      }
+      loader(referrer, moduleRequest, hostDefined, (completion): void => {
+        if (!completion && !restLoaders.length) {
+          completion = Throw.Error('Cannot load module $1', moduleRequest.Specifier);
+        }
+        if (!completion) {
+          tryNextLoader(restLoaders[0], restLoaders.slice(1));
+          return;
+        }
+        fin(completion);
+      }, (error) => {
+        errors.push(error);
+      });
+    }
+    tryNextLoader(loaders[0], loaders.slice(1));
+  };
+}

--- a/src/utils/module-loaders/builtin-loader.mts
+++ b/src/utils/module-loaders/builtin-loader.mts
@@ -1,0 +1,86 @@
+import type { ModuleCacheKey, ModuleCacheKeyObject, ModuleCacheLoader } from '../module.mts';
+import {
+  AbstractModuleRecord,
+  Assert,
+  JSStringValue,
+  ManagedRealm, ModuleCache, NormalCompletion, OutOfRange, Realm,
+  ThrowCompletion,
+  ValueOfNormalCompletion,
+  type ModuleLoader,
+} from '#self';
+
+export type BuiltinModuleSource = string | ((realm: Realm) => AbstractModuleRecord) | Uint8Array;
+
+export interface BuiltinModuleLoaderOptions {
+  getModuleCache?: (realm: ManagedRealm) => ModuleCache;
+  /** preloaded builtin module */
+  builtinModules?: Map<ModuleCacheKeyObject, BuiltinModuleSource>;
+  /** dynamically loaded builtin module */
+  loadBuiltinModule?: (moduleRequest: ModuleCacheKeyObject, realm: Realm, callback: (result: BuiltinModuleSource | NormalCompletion<BuiltinModuleSource> | ThrowCompletion<JSStringValue>) => void) => void;
+  isBuiltinModule?: (specifier: string) => boolean;
+}
+
+export function createBuiltinModuleLoader(options: BuiltinModuleLoaderOptions = {}): ModuleLoader {
+  const {
+    getModuleCache = (realm) => realm.HostDefined.resolverCache,
+    builtinModules,
+    loadBuiltinModule,
+    // starts with ".", "/", "#", or "<scheme>:" are not built-in modules
+    isBuiltinModule = (specifier) => !/^(\.|\/|#|\w+:)/.test(specifier),
+  } = options;
+
+  const modules = new Map<ModuleCacheKey, BuiltinModuleSource>();
+  if (builtinModules) {
+    for (const [key, source] of builtinModules) {
+      modules.set(ModuleCache.toCacheKey(key), source);
+    }
+  }
+
+  return (referrer, moduleRequest, _hostDefined, finish, suggestError) => {
+    if (!isBuiltinModule(moduleRequest.Specifier)) {
+      finish(undefined);
+      return;
+    }
+    const realm = (referrer instanceof Realm ? referrer : referrer.Realm) as ManagedRealm;
+    realm.scope(() => {
+      const cache = getModuleCache(realm);
+      const requestKey = ModuleCache.toCacheKey(moduleRequest);
+      const load: ModuleCacheLoader = (callback) => {
+        if (modules.has(requestKey)) {
+          next(modules.get(requestKey)!);
+        } else if (loadBuiltinModule) {
+          loadBuiltinModule(moduleRequest, realm, (result) => {
+            if (result instanceof ThrowCompletion) {
+              callback(result);
+              return;
+            }
+            const value = ValueOfNormalCompletion(result);
+            Assert(typeof value === 'string' || value instanceof Uint8Array || value instanceof AbstractModuleRecord);
+            next(value);
+          });
+        } else {
+          suggestError(`Module "${moduleRequest.Specifier}" is not a builtin module`);
+          finish(undefined);
+        }
+      };
+
+      if (cache) {
+        cache.load(requestKey, load, finish);
+      } else {
+        load(finish);
+      }
+
+      function next(source: BuiltinModuleSource) {
+        if (typeof source === 'string') {
+          const moduleCompletion = realm.compileModule(source, { specifier: moduleRequest.Specifier });
+          finish(moduleCompletion);
+        } else if (source instanceof Uint8Array) {
+          finish(realm.createBytesModule(source));
+        } else if (typeof source === 'function') {
+          const moduleRecord = source(realm);
+          finish(NormalCompletion(moduleRecord));
+        } else throw OutOfRange.exhaustive(source);
+      }
+    });
+  };
+}

--- a/src/utils/module.mts
+++ b/src/utils/module.mts
@@ -1,25 +1,46 @@
-import { type AbstractModuleRecord, type PlainCompletion } from '#self';
-
-type ModuleType = 'js' | 'json' | 'text' | 'bytes' | string;
-type ModuleAttributes = Record<string, string>;
+import {
+  AbstractModuleRecord,
+  CyclicModuleRecord, Realm, ScriptRecord, type ModuleRequestRecord, type PlainCompletion,
+} from '#self';
 
 interface ModuleCacheEntry {
   result?: PlainCompletion<AbstractModuleRecord>;
   pending?: PromiseWithResolvers<PlainCompletion<AbstractModuleRecord>>;
 }
 
+export type ModuleCacheKeyObject = Pick<ModuleRequestRecord, 'Specifier' | 'Attributes'>;
+
 export type ModuleCacheKey = string & { __ModuleCacheKey: never };
 
+export type ModuleCacheLoader = (setCache: (value: PlainCompletion<AbstractModuleRecord>, cacheKey?: ModuleCacheKey) => void) => void;
+
 export class ModuleCache {
+  static fromReferer(referrer: CyclicModuleRecord | ScriptRecord | Realm) {
+    const realm = referrer instanceof Realm ? referrer : referrer.Realm;
+    const cache = realm.HostDefined?.resolverCache;
+    if (cache instanceof ModuleCache) {
+      return cache;
+    }
+    throw new Error('Module cache is not available in the referring realm');
+  }
+
   #cache = new Map<ModuleCacheKey, ModuleCacheEntry>();
 
-  toCacheKey(specifier: string, type: ModuleType, attributes: ModuleAttributes): ModuleCacheKey {
-    const sorted: ModuleAttributes = {};
-    for (const key of Object.keys(attributes).sort()) {
-      sorted[key] = attributes[key];
+  static toCacheKey(moduleRequest: ModuleCacheKeyObject): ModuleCacheKey {
+    const { Specifier, Attributes } = moduleRequest;
+    const sorted: Record<string, string> = {};
+    for (const attr of Attributes.toSorted((a, b) => (a.Key < b.Key ? -1 : 1))) {
+      sorted[attr.Key] = attr.Value;
     }
-    sorted.type = type;
-    return JSON.stringify([specifier, sorted]) as ModuleCacheKey;
+    return JSON.stringify([Specifier, sorted]) as ModuleCacheKey;
+  }
+
+  toCacheKey(moduleRequest: ModuleCacheKeyObject): ModuleCacheKey {
+    return this.toCacheKey(moduleRequest);
+  }
+
+  static {
+    ModuleCache.prototype.toCacheKey = ModuleCache.toCacheKey;
   }
 
   set(key: ModuleCacheKey, result: PlainCompletion<AbstractModuleRecord>): void {
@@ -36,13 +57,13 @@ export class ModuleCache {
     }
   }
 
-  load(key: ModuleCacheKey, loader: (setCache: (value: PlainCompletion<AbstractModuleRecord>) => void) => void, callback: (result: PlainCompletion<AbstractModuleRecord>) => void): void {
+  load(key: ModuleCacheKey, loader: ModuleCacheLoader, callback: (result: PlainCompletion<AbstractModuleRecord>) => void): void {
     if (!this.#cache.has(key)) {
       const promise = Promise.withResolvers<PlainCompletion<AbstractModuleRecord>>();
       this.#cache.set(key, { pending: promise });
-      loader((value) => {
+      loader((value, cacheKey) => {
         promise.resolve(value);
-        this.#cache.set(key, { result: value });
+        this.#cache.set(cacheKey || key, { result: value });
         callback(value);
       });
       return;

--- a/test/base.mts
+++ b/test/base.mts
@@ -1,9 +1,10 @@
 import fs from 'node:fs';
-import { loadImportedModule, loadImportedModuleSync } from '../lib-src/node/module.mts';
+import { fileSystemModuleLoader, fileSystemModuleLoaderSync } from '../lib-src/node/module.mts';
 import { supportColor, type SkipReason } from './tui.mts';
 import {
   Agent, ManagedRealm, type OrdinaryObject, OrdinaryObjectCreate, createTest262Intrinsics,
   ModuleCache,
+  composeModuleLoaders,
 } from '#self';
 
 export interface Attrs {
@@ -140,7 +141,9 @@ export function createAgent({ features = [], asyncModuleLoader = false }: Create
   const agent = new Agent({
     features,
     supportedImportAttributes: ['type'],
-    loadImportedModule: asyncModuleLoader ? loadImportedModule : loadImportedModuleSync,
+    hostHooks: {
+      HostLoadImportedModule: composeModuleLoaders([asyncModuleLoader ? fileSystemModuleLoader : fileSystemModuleLoaderSync]),
+    },
     onDebugger() {
       // attach an empty debugger to make sure our debugger infrastructure does not break the engine
       agent.resumeEvaluate({ noBreakpoint: true });

--- a/test/engine262/cli.test.mts
+++ b/test/engine262/cli.test.mts
@@ -1,0 +1,113 @@
+/* eslint-disable quotes */
+import { ChildProcess, spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from 'vitest';
+
+const bin = fileURLToPath(new URL('../../lib-src/node/bin.mts', import.meta.url));
+
+function waitUntilProcessExit(getChildProcess: () => ChildProcess) {
+  return new Promise<{ code: number | null, stdout: string, stderr: string }>((resolve, reject) => {
+    const cp = getChildProcess();
+    let stdout = '';
+    let stderr = '';
+    cp.stdout!.on('data', (data) => {
+      stdout += data.toString();
+    });
+    cp.stderr!.on('data', (data) => {
+      stderr += data.toString();
+    });
+    cp.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+    cp.on('exit', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+    cp.on('error', (err) => {
+      reject(err);
+    });
+  });
+}
+
+test('script', async () => {
+  const cp = await waitUntilProcessExit(() => spawn(process.execPath, [bin, '-e', 'print(1)']));
+  expect(cp.code).toBe(0);
+  expect(cp.stdout).toMatchInlineSnapshot(`"1\n"`);
+  expect(cp.stderr).toMatchInlineSnapshot(`""`);
+});
+
+test('module', async () => {
+  const cp = await waitUntilProcessExit(() => spawn(process.execPath, [bin, fileURLToPath(new URL('./fixture/module-success.mjs', import.meta.url))]));
+  expect(cp.code).toBe(0);
+  expect(cp.stdout).toMatchInlineSnapshot(`
+    "'hello'
+    "
+  `);
+  expect(cp.stderr).toMatchInlineSnapshot(`""`);
+});
+
+test('syntax error', async () => {
+  const cp = await waitUntilProcessExit(() => spawn(process.execPath, [bin, '-e', ' +']));
+  expect(cp.code).toBe(1);
+  expect(cp.stdout).toMatchInlineSnapshot(`""`);
+  expect(cp.stderr).toMatchInlineSnapshot(`
+    "SyntaxError: Unexpected token
+    <eval>:1:3
+     +
+      ^
+    "
+  `);
+});
+
+test('module graph error', async () => {
+  const cp = await waitUntilProcessExit(() => spawn(process.execPath, [bin, '--module', '--eval', 'import "./x.js";']));
+  expect(cp.code).toBe(1);
+  expect(cp.stdout).toMatchInlineSnapshot(`""`);
+  expect(cp.stderr).toMatchInlineSnapshot(`
+    "Error: Cannot load module ./x.js
+    "
+  `);
+});
+
+test('sync error', async () => {
+  const cp = await waitUntilProcessExit(() => spawn(process.execPath, [bin, '--eval', 'throw new Error']));
+  expect(cp.code).toBe(1);
+  expect(cp.stdout).toMatchInlineSnapshot(`""`);
+  expect(cp.stderr).toMatchInlineSnapshot(`
+    "Error
+        at <eval>:1:11
+    "
+  `);
+});
+
+test('async error', async () => {
+  const cp = await waitUntilProcessExit(() => spawn(process.execPath, [bin, '--module', '--eval', 'await new Promise(r => setTimeout(r, 500)).then(() => { throw new Error(); })']));
+  expect(cp.code).toBe(1);
+  expect(cp.stdout).toMatchInlineSnapshot(`""`);
+  expect(cp.stderr).toMatchInlineSnapshot(`
+    "Error
+        at <anonymous> (<eval>:1:67)
+    "
+  `);
+});
+
+test('unhandled promise rejection', async () => {
+  const cp = await waitUntilProcessExit(() => spawn(process.execPath, [bin, '--eval', 'Promise.reject(new Error)']));
+  expect(cp.code).toBe(1);
+  expect(cp.stdout).toMatchInlineSnapshot(`""`);
+  expect(cp.stderr).toMatchInlineSnapshot(`
+    "Unhandled promise rejection: Error
+        at <eval>:1:20
+    "
+  `);
+});
+
+test('uncaught error', async () => {
+  const cp = await waitUntilProcessExit(() => spawn(process.execPath, [bin, '--eval', 'setTimeout(() => { throw new Error; }, 500)']));
+  expect(cp.code).toBe(1);
+  expect(cp.stdout).toMatchInlineSnapshot(`""`);
+  expect(cp.stderr).toMatchInlineSnapshot(`
+    "Uncaught exception: Error
+        at <anonymous> (<eval>:1:30)
+    "
+  `);
+});

--- a/test/engine262/fixture/module-success.mjs
+++ b/test/engine262/fixture/module-success.mjs
@@ -1,0 +1,2 @@
+import { f } from './y.mjs'
+f();

--- a/test/engine262/fixture/y.mjs
+++ b/test/engine262/fixture/y.mjs
@@ -1,0 +1,3 @@
+export function f() {
+  console.log('hello');
+}

--- a/test/engine262/module.test.mts
+++ b/test/engine262/module.test.mts
@@ -1,6 +1,6 @@
 import { assert, expect, test } from 'vitest';
 import {
-  AbstractModuleRecord, Agent, Call, EnsureCompletion, JSStringValue, ManagedRealm, NewPromiseCapability, PromiseCapabilityRecord, setSurroundingAgent, skipDebugger, Value, type PromiseObject,
+  AbstractModuleRecord, Agent, Call, EnsureCompletion, FinishLoadingImportedModule, JSStringValue, ManagedRealm, NewPromiseCapability, PromiseCapabilityRecord, setSurroundingAgent, skipDebugger, Throw, Value, type PromiseObject,
 } from '#self';
 
 test('Import attributes', () => {
@@ -9,10 +9,12 @@ test('Import attributes', () => {
 
   const agent = new Agent({
     supportedImportAttributes: ['fruit', 'animal'],
-    loadImportedModule: (_referrer, _specifier, attrs, _hostDefined, finish) => {
-      calls += 1;
-      attributes = attrs;
-      finish(realm.compileModule(''));
+    hostHooks: {
+      HostLoadImportedModule(referrer, moduleRequest, _hostDefined, payload) {
+        calls += 1;
+        attributes = new Map(moduleRequest.Attributes.map((attr) => [attr.Key, attr.Value]));
+        FinishLoadingImportedModule(referrer, moduleRequest, payload, realm.compileModule(''));
+      },
     },
   });
   setSurroundingAgent(agent);
@@ -91,27 +93,30 @@ test('Custom module records', () => {
   }
 
   const agent = new Agent({
-    loadImportedModule(referrer, specifier, _attributes, _hostDefined, finish) {
-      if (specifier !== 'dep') {
-        throw new Error('Invalid specifier');
-      }
-      finish(new CustomModuleRecord({
-        Realm: (referrer as AbstractModuleRecord).Realm,
-        Environment: undefined,
-        Namespace: undefined,
-        HostDefined: {},
-      }));
+    hostHooks: {
+      HostLoadImportedModule(referrer, moduleRequest, _hostDefined, payload) {
+        if (moduleRequest.Specifier !== 'dep') {
+          FinishLoadingImportedModule(referrer, moduleRequest, payload, Throw.SyntaxError('Invalid specifier'));
+        } else {
+          FinishLoadingImportedModule(referrer, moduleRequest, payload, new CustomModuleRecord({
+            Realm: (referrer as AbstractModuleRecord).Realm,
+            Environment: undefined,
+            Namespace: undefined,
+            HostDefined: {},
+          }));
+        }
+      },
+      HostPromiseRejectionTrackers: new Set([
+        (promise, operation) => {
+          calls.push([promise, operation]);
+        }]),
     },
   });
   setSurroundingAgent(agent);
 
   const calls: unknown[] = [];
 
-  const realm = new ManagedRealm({
-    promiseRejectionTracker(promise, operation) {
-      calls.push([promise, operation]);
-    },
-  });
+  const realm = new ManagedRealm();
 
   realm.evaluateModule('import "dep"', 'entrypoint', () => {});
 


### PR DESCRIPTION
close #340 close #234

# Module loader changes:

See lib-src/node/example.mts for new API.

Changed signatures:
 - HostLoadImportedModule
 - FinishLoadingImportedModule
 - ModuleRequestRecord
 - LoadedModuleRequestRecord
 - ImportAttributeRecord
 - ModuleCache
 - `Agent.hostDefinedOptions.loadImportedModule` => `Agent.hostDefinedOptions.hostHooks.HostLoadImportedModule`

New utils for module loading

 - createBuiltinModuleLoader
 - composeModuleLoaders
 - createFileSystemModuleLoader (NodeJS only, defined in lib-src/node)
      - fileSystemModuleLoader
      - fileSystemModuleLoaderSync

# Other changes

- `Agent.queueJob` removed. Use `Agent.jobQueue.push(...)`
- Add `setTimeout` to bin’s global to test the event loop
- Add `Agent.hostDefinedOptions.uncaughtExceptionTrackers`
- `Realm.HostDefined.promiseRejectionTracker = f` => `Agent.hostDefinedOptions.hostHooks.HostPromiseRejectionTrackers.add(f)`