### PR TITLE
Add class private fields to garbage collection.

### DIFF
--- a/src/runtime-semantics/MethodDefinitionEvaluation.mts
+++ b/src/runtime-semantics/MethodDefinitionEvaluation.mts
@@ -17,6 +17,7 @@ import {
   MakeMethod,
   sourceTextMatchedBy,
   type FunctionObject,
+  type GCMarker,
 } from '#self';
 
 /** https://tc39.es/ecma262/#sec-privateelement-specification-type */
@@ -41,6 +42,13 @@ export const PrivateElementRecord = function PrivateElementRecord(value: Private
 } as {
   (value: PrivateElementRecord): PrivateElementRecord;
   [Symbol.hasInstance](instance: unknown): instance is PrivateElementRecord;
+};
+
+// NON-SPEC
+PrivateElementRecord.prototype.mark = function mark(m: GCMarker): void {
+  m(this.Value);
+  m(this.Get);
+  m(this.Set);
 };
 
 // -decorator

--- a/src/value.mts
+++ b/src/value.mts
@@ -851,6 +851,10 @@ export class ObjectValue extends Value implements ObjectInternalMethods<ObjectVa
         this[s].forEach(m);
       }
     });
+
+    this.PrivateElements.forEach((pr) => {
+      m(pr);
+    });
   }
 
   static {


### PR DESCRIPTION
I noticed my FinalizationRegistry wasn't firing, and it's simply because it was a private field of a class.

[Playground link](https://engine262.js.org/#code=MYGwhgzhAEBiBKB9AKgUwgF2gbwFDWgGIAnVAcwEtNiBPaAXmgDtUB3OCpsECgLzAwUA9k3jkqGWgAoAFqhAATAGrcArqgYA%2BaAAdinDLPnK1qAJRmA3PmgKhYyplTEprVGADWKkOoA00OUVvdTMcGwIMGSoAOhJxahpo0kcMZ1d3L1N%2FQJMfc2sCAF8CEtKy8orK3ELcXGARTGgAM2IGZjY4JDRMKStcFui7Bwk07EL%2FACImimJG5JHSBQm%2BgaH41JcxyYhUeqYFaHmnReXrfqFWqRBULAo2gAZLaDuAHmgAJieKAGpv0LwCGBWGAKFgAArEIQAWyoqCS6CEIAAbqhegVdPomIYJiAhEIdNAJtBvs9iYToPUoTprqkln0akA%3D%3D%3D&mode=module&features=)

```javascript
class FR_Test {
  #registry = new FinalizationRegistry(heldValue => print(heldValue));
  doRegister(weakValue, heldValue) {
    this.#registry.register(weakValue, heldValue);
  }                                   
}

const fr = new FR_Test();
fr.doRegister({}, "first registered");
fr.doRegister({}, "second registered");

for (let i = 0; i < 2; i++) {
  await Promise.resolve();
  print("loop " + i + " completed");
}
```

If I change `#registry` to `registry`, then we print "first registered" and "second registered".  Without that change, the registration callback doesn't happen.

I don't know where to put a test for this.  Suggestions welcome.